### PR TITLE
added styling to .btn-subscribe:hover fixing the undesired hover state set by global styles

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -322,6 +322,7 @@ h1.bold_404 {
   background-color: #091F40;
   color: #FFFFFF;
   margin-top: 8px;
+  font-weight: 700;
 }
 .btn-subscribe:hover {
   background-color: #C5203E;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -323,6 +323,11 @@ h1.bold_404 {
   color: #FFFFFF;
   margin-top: 8px;
 }
+.btn-subscribe:hover {
+  background-color: #C5203E;
+  border: 1px solid #091F40;
+  color: #FFFFFF;
+}
 .btn.btn-block {
   width: 100%;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -164,7 +164,7 @@ class IndexPage extends Component {
                               type="submit"
                               className="btn btn-subscribe"
                             >
-                              subscribe
+                              Subscribe
                             </button>
                           </div>
                         </div>

--- a/tests/pages/__snapshots__/index.test.js.snap
+++ b/tests/pages/__snapshots__/index.test.js.snap
@@ -469,7 +469,7 @@ exports[`<IndexPage /> should render correctly 1`] = `
                           id="subscribe-button"
                           type="submit"
                         >
-                          subscribe
+                          Subscribe
                         </button>
                       </div>
                     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Used the hover pseudo class on .btn-subscribe to override the global hover state set by the bootstrap .btn:hover css class. The styles added were chosen in an effort to match other existing buttons located on the home page. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #62  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The change is required to improve the user experience, and maintain consistent styling throughout the site.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ensured all tests passed. And manually checked several buttons for unexpected behaviors ensuring my changes did not affect buttons elsewhere.

## Screenshots (if appropriate):
The image below shows the subscribe button and apply button with the hover states toggled. I used the apply button styling as a template for the subscribe style.
<img width="500" alt="screen shot 2019-01-22 at 1 17 12 am" src="https://user-images.githubusercontent.com/24724409/51516323-10ea0800-1de5-11e9-8803-34888d4407b2.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.