### PR TITLE
Clean Up Sponsor section #117

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -104,7 +104,7 @@ function Nav() {
                 <span>Apply</span>
               </Link>
             </li>
-            <li role="menuitem">
+            <li role="menuitem" className="donate">
               <Link to="/donate">
                 <span>Donate</span>
               </Link>

--- a/src/components/Nav/nav.css
+++ b/src/components/Nav/nav.css
@@ -56,3 +56,9 @@
   vertical-align: middle;
   font-size: 0.5em;
 }
+
+/*  */
+.donate:hover{
+  transition: .3s linear;
+  background-color: red;
+}

--- a/src/components/SponsorSlider/SponsorSlider.js
+++ b/src/components/SponsorSlider/SponsorSlider.js
@@ -28,42 +28,68 @@ function SponsorSlider() {
     window.addEventListener('resize', updateWindowDimensions)
 
     return () => window.removeEventListener('resize', updateWindowDimensions)
-  })
+  }, [])
 
   const isMobile = Boolean(viewport < 800)
 
   return (
     <Carousel
       {...baseSettlings}
-      slidesToShow={isMobile ? 4 : 8}
+      slidesToShow={isMobile ? 4 : 6}
       transitionMode={isMobile ? 'scroll' : 'fade'}
     >
-      <a href="https://www.google.com/" target="_blank" rel="noopener noreferrer">
-        <FluidImage fileName="google.png" alt="google" style={alignmentStyles} />
-      </a>
-      <a href="https://github.com/" target="_blank" rel="noopener noreferrer">
-        <FluidImage fileName="github.png" alt="Github" style={alignmentStyles} />
-      </a>
-      <a href="https://repl.it" target="_blank" rel="noopener noreferrer">
-        <FluidImage fileName="repl.it.png" alt="Repl.it" style={alignmentStyles} />
-      </a>
-      <a href="https://slack.com/" target="_blank" rel="noopener noreferrer">
-        <FluidImage fileName="slack.png" alt="Slack" style={alignmentStyles} />
-      </a>
-      <a href="https://www.digitalocean.com/" target="_blank" rel="noopener noreferrer">
-        <FluidImage fileName="DO.png" alt="Digital Ocean" style={alignmentStyles} />
-      </a>
-      <a href="https://frontendmasters.com/" target="_blank" rel="noopener noreferrer">
-        <FluidImage fileName="fem.png" alt="Front End Masters" style={alignmentStyles} />
-      </a>
       <a
-        href="https://corporate.comcast.com/company/nbcuniversal"
+        href="https://www.google.com/"
+        aria-label="Link to Google"
+        title="Google"
         target="_blank"
         rel="noopener noreferrer"
       >
-        <FluidImage fileName="comcast.png" alt="Comcast" style={alignmentStyles} />
+        <FluidImage fileName="google.png" alt="google" style={alignmentStyles} />
       </a>
-      <a href="https://www.contentful.com/" rel="noopener noreferrer" target="_blank">
+      <a
+        href="https://github.com/"
+        aria-label="Link to Github"
+        title="GitHub"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FluidImage fileName="github.png" alt="Github" style={alignmentStyles} />
+      </a>
+      <a
+        href="https://repl.it"
+        aria-label="Link to Replit "
+        title="Repl.it"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FluidImage fileName="repl.it.png" alt="Repl.it" style={alignmentStyles} />
+      </a>
+      <a
+        href="https://slack.com/"
+        aria-label="Link to Slack"
+        title="Slack"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FluidImage fileName="slack.png" alt="Slack" style={alignmentStyles} />
+      </a>
+      <a
+        href="https://frontendmasters.com/"
+        aria-label="Link to Front End Masters"
+        title="Front End Masters"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FluidImage fileName="fem.png" alt="Front End Masters" style={alignmentStyles} />
+      </a>
+      <a
+        href="https://www.contentful.com/"
+        aria-label="Link to Contentful"
+        title="Contentful"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
         <FluidImage fileName="contentful.png" alt="Powered by Contentful" style={alignmentStyles} />
       </a>
     </Carousel>

--- a/tests/components/__snapshots__/Layout.test.js.snap
+++ b/tests/components/__snapshots__/Layout.test.js.snap
@@ -135,6 +135,7 @@ exports[`<Layout /> should render correctly 1`] = `
               </a>
             </li>
             <li
+              class="donate"
               role="menuitem"
             >
               <a

--- a/tests/components/__snapshots__/Nav.test.js.snap
+++ b/tests/components/__snapshots__/Nav.test.js.snap
@@ -128,6 +128,7 @@ exports[`<Nav /> should render correctly 1`] = `
           </a>
         </li>
         <li
+          class="donate"
           role="menuitem"
         >
           <a

--- a/tests/components/__snapshots__/SponsorSlider.test.js.snap
+++ b/tests/components/__snapshots__/SponsorSlider.test.js.snap
@@ -19,10 +19,12 @@ exports[`<SponsorSlider /> should render correctly 1`] = `
       >
         <a
           aria-hidden="false"
+          aria-label="Link to Google"
           href="https://www.google.com/"
           rel="noopener noreferrer"
           tabindex="0"
           target="_blank"
+          title="Google"
         >
           static-query
         </a>
@@ -33,10 +35,12 @@ exports[`<SponsorSlider /> should render correctly 1`] = `
       >
         <a
           aria-hidden="false"
+          aria-label="Link to Github"
           href="https://github.com/"
           rel="noopener noreferrer"
           tabindex="0"
           target="_blank"
+          title="GitHub"
         >
           static-query
         </a>
@@ -47,10 +51,12 @@ exports[`<SponsorSlider /> should render correctly 1`] = `
       >
         <a
           aria-hidden="false"
+          aria-label="Link to Replit "
           href="https://repl.it"
           rel="noopener noreferrer"
           tabindex="0"
           target="_blank"
+          title="Repl.it"
         >
           static-query
         </a>
@@ -61,10 +67,12 @@ exports[`<SponsorSlider /> should render correctly 1`] = `
       >
         <a
           aria-hidden="false"
+          aria-label="Link to Slack"
           href="https://slack.com/"
           rel="noopener noreferrer"
           tabindex="0"
           target="_blank"
+          title="Slack"
         >
           static-query
         </a>
@@ -75,24 +83,12 @@ exports[`<SponsorSlider /> should render correctly 1`] = `
       >
         <a
           aria-hidden="false"
-          href="https://www.digitalocean.com/"
-          rel="noopener noreferrer"
-          tabindex="0"
-          target="_blank"
-        >
-          static-query
-        </a>
-      </li>
-      <li
-        class="slider-slide slide-visible"
-        style="box-sizing: border-box; display: block; height: auto; left: 0px; list-style-type: none; margin: auto 0px auto 0px; opacity: 1; position: absolute; top: 0px; vertical-align: top; visibility: inherit; width: 0px;"
-      >
-        <a
-          aria-hidden="false"
+          aria-label="Link to Front End Masters"
           href="https://frontendmasters.com/"
           rel="noopener noreferrer"
           tabindex="0"
           target="_blank"
+          title="Front End Masters"
         >
           static-query
         </a>
@@ -103,24 +99,12 @@ exports[`<SponsorSlider /> should render correctly 1`] = `
       >
         <a
           aria-hidden="false"
-          href="https://corporate.comcast.com/company/nbcuniversal"
-          rel="noopener noreferrer"
-          tabindex="0"
-          target="_blank"
-        >
-          static-query
-        </a>
-      </li>
-      <li
-        class="slider-slide slide-visible"
-        style="box-sizing: border-box; display: block; height: auto; left: 0px; list-style-type: none; margin: auto 0px auto 0px; opacity: 1; position: absolute; top: 0px; vertical-align: top; visibility: inherit; width: 0px;"
-      >
-        <a
-          aria-hidden="false"
+          aria-label="Link to Contentful"
           href="https://www.contentful.com/"
           rel="noopener noreferrer"
           tabindex="0"
           target="_blank"
+          title="Contentful"
         >
           static-query
         </a>

--- a/tests/pages/__snapshots__/404.test.js.snap
+++ b/tests/pages/__snapshots__/404.test.js.snap
@@ -135,6 +135,7 @@ exports[`<NotFoundPage /> should render correctly 1`] = `
               </a>
             </li>
             <li
+              class="donate"
               role="menuitem"
             >
               <a

--- a/tests/pages/__snapshots__/about.test.js.snap
+++ b/tests/pages/__snapshots__/about.test.js.snap
@@ -135,6 +135,7 @@ exports[`<About /> should render correctly 1`] = `
               </a>
             </li>
             <li
+              class="donate"
               role="menuitem"
             >
               <a

--- a/tests/pages/__snapshots__/apply.test.js.snap
+++ b/tests/pages/__snapshots__/apply.test.js.snap
@@ -136,6 +136,7 @@ exports[`<Apply /> should render correctly 1`] = `
                 </a>
               </li>
               <li
+                class="donate"
                 role="menuitem"
               >
                 <a

--- a/tests/pages/__snapshots__/contact.test.js.snap
+++ b/tests/pages/__snapshots__/contact.test.js.snap
@@ -135,6 +135,7 @@ exports[`<Contact /> should render correctly 1`] = `
               </a>
             </li>
             <li
+              class="donate"
               role="menuitem"
             >
               <a

--- a/tests/pages/__snapshots__/donate.test.js.snap
+++ b/tests/pages/__snapshots__/donate.test.js.snap
@@ -135,6 +135,7 @@ exports[`<Donate /> should render correctly 1`] = `
               </a>
             </li>
             <li
+              class="donate"
               role="menuitem"
             >
               <a

--- a/tests/pages/__snapshots__/index.test.js.snap
+++ b/tests/pages/__snapshots__/index.test.js.snap
@@ -329,10 +329,12 @@ exports[`<IndexPage /> should render correctly 1`] = `
               >
                 <a
                   aria-hidden="false"
+                  aria-label="Link to Google"
                   href="https://www.google.com/"
                   rel="noopener noreferrer"
                   tabindex="0"
                   target="_blank"
+                  title="Google"
                 >
                   static-query
                 </a>
@@ -343,10 +345,12 @@ exports[`<IndexPage /> should render correctly 1`] = `
               >
                 <a
                   aria-hidden="false"
+                  aria-label="Link to Github"
                   href="https://github.com/"
                   rel="noopener noreferrer"
                   tabindex="0"
                   target="_blank"
+                  title="GitHub"
                 >
                   static-query
                 </a>
@@ -357,10 +361,12 @@ exports[`<IndexPage /> should render correctly 1`] = `
               >
                 <a
                   aria-hidden="false"
+                  aria-label="Link to Replit "
                   href="https://repl.it"
                   rel="noopener noreferrer"
                   tabindex="0"
                   target="_blank"
+                  title="Repl.it"
                 >
                   static-query
                 </a>
@@ -371,10 +377,12 @@ exports[`<IndexPage /> should render correctly 1`] = `
               >
                 <a
                   aria-hidden="false"
+                  aria-label="Link to Slack"
                   href="https://slack.com/"
                   rel="noopener noreferrer"
                   tabindex="0"
                   target="_blank"
+                  title="Slack"
                 >
                   static-query
                 </a>
@@ -385,24 +393,12 @@ exports[`<IndexPage /> should render correctly 1`] = `
               >
                 <a
                   aria-hidden="false"
-                  href="https://www.digitalocean.com/"
-                  rel="noopener noreferrer"
-                  tabindex="0"
-                  target="_blank"
-                >
-                  static-query
-                </a>
-              </li>
-              <li
-                class="slider-slide slide-visible"
-                style="box-sizing: border-box; display: block; height: auto; left: 0px; list-style-type: none; margin: auto 0px auto 0px; opacity: 1; position: absolute; top: 0px; vertical-align: top; visibility: inherit; width: 0px;"
-              >
-                <a
-                  aria-hidden="false"
+                  aria-label="Link to Front End Masters"
                   href="https://frontendmasters.com/"
                   rel="noopener noreferrer"
                   tabindex="0"
                   target="_blank"
+                  title="Front End Masters"
                 >
                   static-query
                 </a>
@@ -413,24 +409,12 @@ exports[`<IndexPage /> should render correctly 1`] = `
               >
                 <a
                   aria-hidden="false"
-                  href="https://corporate.comcast.com/company/nbcuniversal"
-                  rel="noopener noreferrer"
-                  tabindex="0"
-                  target="_blank"
-                >
-                  static-query
-                </a>
-              </li>
-              <li
-                class="slider-slide slide-visible"
-                style="box-sizing: border-box; display: block; height: auto; left: 0px; list-style-type: none; margin: auto 0px auto 0px; opacity: 1; position: absolute; top: 0px; vertical-align: top; visibility: inherit; width: 0px;"
-              >
-                <a
-                  aria-hidden="false"
+                  aria-label="Link to Contentful"
                   href="https://www.contentful.com/"
                   rel="noopener noreferrer"
                   tabindex="0"
                   target="_blank"
+                  title="Contentful"
                 >
                   static-query
                 </a>

--- a/tests/pages/__snapshots__/index.test.js.snap
+++ b/tests/pages/__snapshots__/index.test.js.snap
@@ -135,6 +135,7 @@ exports[`<IndexPage /> should render correctly 1`] = `
               </a>
             </li>
             <li
+              class="donate"
               role="menuitem"
             >
               <a

--- a/tests/pages/__snapshots__/mentor.test.js.snap
+++ b/tests/pages/__snapshots__/mentor.test.js.snap
@@ -136,6 +136,7 @@ exports[`<Mentor /> should render correctly 1`] = `
                 </a>
               </li>
               <li
+                class="donate"
                 role="menuitem"
               >
                 <a

--- a/tests/pages/__snapshots__/syllabus.test.js.snap
+++ b/tests/pages/__snapshots__/syllabus.test.js.snap
@@ -135,6 +135,7 @@ exports[`<Syllabus /> should render correctly 1`] = `
               </a>
             </li>
             <li
+              class="donate"
               role="menuitem"
             >
               <a


### PR DESCRIPTION
#117 
## Description

Removed Digital Ocean and NBC from the SponsorSlider.js
Realigned sponsors.
Added title and aria-label attributes to remaining sponsors.

## Related Issue

[Clean Up Sponsor section #117](https://github.com/Vets-Who-Code/vets-who-code-app/issues/117)

## Motivation and Context

Companies no longer sponsors of Vets Who Code

## How Has This Been Tested?

Tested using jest test suite

## Screenshots (if appropriate):

Desktop:
![partners screenshot](https://i.ibb.co/TqvCbFN/sponsors.png)

Mobile:
![partners mobile view](https://i.ibb.co/0XtVKS3/viewport.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
