### PR TITLE
 AddUnderlineToSiteMapLinks, added styel to main.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ public/
 
 # jest coverage report
 coverage
+
+# env
+.env

--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -115,3 +115,4 @@
   padding-bottom: inherit;
   padding-top: inherit;
 }
+

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2196,6 +2196,7 @@ div.zabuto_calendar tr.calendar-dow td {
 }
 .footer-widgets .widgets-content .widgets-list li a:hover {
   color: #C5203E;
+  text-decoration: underline;
 }
 .footer-widgets .widgets-content .widgets-list li:first-child {
   margin-top: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Added underline to hover of site map links.

## Description
added online text decoration in main.css.

## Related Issue
Accessibility

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
WCAG states that links need two indicators on hover for the user on links. We had only one.

## How Has This Been Tested?
I tested by hovering over site map link to see the underline.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
