### PR TITLE
Move donate button to footer. Fixed donate button heading alignment

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -14,20 +14,18 @@ import {
 function Footer() {
   return (
     <div>
-      {window.location.pathname !== '/donate' && (
-        <section id="call-to-action-small" className="call-to-action-small">
-          <div className="container">
-            <div className="row">
-              <div className="col-sm-12 text-center">
-                <h3>Help Us Teach More Veterans How To Code &nbsp;</h3>
-                <Link to="/donate" className="btn btn-charity-default">
-                  DONATE
-                </Link>
-              </div>
+      <section id="call-to-action-small" className="call-to-action-small">
+        <div className="container">
+          <div className="row">
+            <div className="col-sm-12 text-center">
+              <h3>Help Us Teach More Veterans How To Code &nbsp;</h3>
+              <Link to="/donate" className="btn btn-charity-default">
+                DONATE
+              </Link>
             </div>
           </div>
-        </section>
-      )}
+        </div>
+      </section>
       <section className="footer-widgets pad-extra">
         <div className="container">
           <div className="row">

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -14,6 +14,20 @@ import {
 function Footer() {
   return (
     <div>
+      {window.location.pathname !== '/donate' && (
+        <section id="call-to-action-small" className="call-to-action-small">
+          <div className="container">
+            <div className="row">
+              <div className="col-sm-12 text-center">
+                <h3>Help Us Teach More Veterans How To Code &nbsp;</h3>
+                <Link to="/donate" className="btn btn-charity-default">
+                  DONATE
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
       <section className="footer-widgets pad-extra">
         <div className="container">
           <div className="row">

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -60,8 +60,8 @@ function About() {
             </div>
             <div className="col-md-12">
               <div className="success-story">
+                <h2>Who We Are</h2>
                 <p className="story">
-                  <h2>Who We Are</h2>
                   Launched in 2014, Vets Who Code is a non-profit dedicated to filling the nations
                   technical skills gap with America’s best. We achieve this by using technology to
                   connect and train veterans remotely in web development in order to close the
@@ -81,8 +81,8 @@ function About() {
                   our veterans and military spouses.
                 </p>
 
+                <h2>What We Do</h2>
                 <p className="story">
-                  <h2>What We Do</h2>
                   At Vets Who Code, we take a small cohort of veterans and spouses twice a year and
                   over the course of sixteen weeks train them in programming with a deep focus on
                   Javascript, the language of the web. We do this all remotely using the best tools
@@ -91,11 +91,9 @@ function About() {
                   better programmers.
                 </p>
 
+                <h2>How We Do This</h2>
                 <p className="story">
-                  <h2>How We Do This</h2>
-                  How we accomplish this mission is through a process of <i>
-                    Crawl, Walk, Run
-                  </i>{' '}
+                  How we accomplish this mission is through a process of <i>Crawl, Walk, Run</i>{' '}
                   where as we teach them programming we build upon each lesson in deeper dives so
                   that they become better programmers through each iteration. All this while being
                   lead by instructors who are also veterans, and programmers, and alumni of the
@@ -104,8 +102,8 @@ function About() {
                   on the path of becoming a paid programmer.
                 </p>
 
+                <h2>WE NEED YOUR HELP</h2>
                 <p className="story-last">
-                  <h2>WE NEED YOUR HELP</h2>
                   As our country is going through this unprecedented time with COVID-19, people are
                   wanting to learn the skills of today and tomorrow to future-proof themselves so
                   that they can provide for thier families. Furthermore due to the nature of
@@ -118,20 +116,6 @@ function About() {
                   becoming programmers.
                 </p>
               </div>
-            </div>
-          </div>
-        </div>
-      </section>
-      <section id="call-to-action-small" className="call-to-action-small">
-        <div className="container">
-          <div className="row">
-            <div className="col-sm-12 text-center">
-              <h3>
-                Help Us Teach More Veterans How To Code &nbsp;
-                <a className="btn btn-charity-default" href="/donate">
-                  DONATE
-                </a>
-              </h3>
             </div>
           </div>
         </div>

--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -32,20 +32,6 @@ export default function Apply() {
           </div>
         </div>
       </section>
-      <section id="call-to-action-small" className="call-to-action-small">
-        <div className="container">
-          <div className="row">
-            <div className="col-sm-12 text-center">
-              <h3>
-                Help Us Teach More Veterans How To Code &nbsp;
-                <a className="btn btn-charity-default" href="/donate">
-                  DONATE
-                </a>
-              </h3>
-            </div>
-          </div>
-        </div>
-      </section>
     </Layout>
   )
 }

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -24,21 +24,6 @@ function Contact() {
           </div>
         </div>
       </section>
-
-      <section id="call-to-action-small" className="call-to-action-small">
-        <div className="container">
-          <div className="row">
-            <div className="col-sm-12 text-center">
-              <h3>
-                Help Us Teach More Veterans How To Code &nbsp;
-                <a className="btn btn-charity-default" href="/donate">
-                  DONATE
-                </a>
-              </h3>
-            </div>
-          </div>
-        </div>
-      </section>
     </Layout>
   )
 }

--- a/src/pages/donate.js
+++ b/src/pages/donate.js
@@ -77,20 +77,6 @@ function Donate() {
           </div>
         </div>
       </section>
-      <section id="call-to-action-small" className="call-to-action-small">
-        <div className="container">
-          <div className="row">
-            <div className="col-sm-12 text-center">
-              <h3>
-                Help Us Teach More Veterans How To Code &nbsp;
-                <a className="btn btn-charity-default" href="/donate">
-                  DONATE
-                </a>
-              </h3>
-            </div>
-          </div>
-        </div>
-      </section>
     </Layout>
   )
 }

--- a/src/pages/mentor.js
+++ b/src/pages/mentor.js
@@ -197,20 +197,6 @@ function Mentor() {
           </div>
         </section>
       </div>
-      <section id="call-to-action-small" className="call-to-action-small">
-        <div className="container">
-          <div className="row">
-            <div className="col-sm-12 text-center">
-              <h3>
-                Help Us Teach More Veterans How To Code &nbsp;
-                <a className="btn btn-charity-default" href="/donate">
-                  DONATE
-                </a>
-              </h3>
-            </div>
-          </div>
-        </div>
-      </section>
     </Layout>
   )
 }

--- a/src/pages/syllabus.js
+++ b/src/pages/syllabus.js
@@ -79,21 +79,6 @@ export default class Mentor extends Component {
             </div>
           </div>
         </section>
-        < section id = "call-to-action-small" className = "call-to-action-small" >
-          <div className = "container" >
-            <div className="row">
-              <div className = "col-sm-12 text-center" >
-                <h3>
-                  Help Us Teach More Veterans How To Code &nbsp; 
-                  <a className = "btn btn-charity-default" href = "/donate">
-                    DONATE
-                  </a>
-                </h3>
-              </div>
-            </div>
-          </div>
-          {' '}
-        </section>
       </Layout>
     )
   }

--- a/src/pages/testimonials.js
+++ b/src/pages/testimonials.js
@@ -130,20 +130,6 @@ function Testimonial() {
           </div>
         </div>
       </section>
-      <section id="call-to-action-small" className="call-to-action-small">
-        <div className="container">
-          <div className="row">
-            <div className="col-sm-12 text-center">
-              <h3>
-                Help Us Teach More Veterans How To Code &nbsp;
-                <a className="btn btn-charity-default" href="/donate">
-                  DONATE
-                </a>
-              </h3>
-            </div>
-          </div>
-        </div>
-      </section>
     </Layout>
   )
 }

--- a/tests/components/__snapshots__/Footer.test.js.snap
+++ b/tests/components/__snapshots__/Footer.test.js.snap
@@ -3,6 +3,32 @@
 exports[`<Footer /> should render correctly 1`] = `
 <div>
   <section
+    class="call-to-action-small"
+    id="call-to-action-small"
+  >
+    <div
+      class="container"
+    >
+      <div
+        class="row"
+      >
+        <div
+          class="col-sm-12 text-center"
+        >
+          <h3>
+            Help Us Teach More Veterans How To Code  
+          </h3>
+          <a
+            class="btn btn-charity-default"
+            href="/donate"
+          >
+            DONATE
+          </a>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
     class="footer-widgets pad-extra"
   >
     <div

--- a/tests/components/__snapshots__/Layout.test.js.snap
+++ b/tests/components/__snapshots__/Layout.test.js.snap
@@ -191,6 +191,32 @@ exports[`<Layout /> should render correctly 1`] = `
     </nav>
     <div>
       <section
+        class="call-to-action-small"
+        id="call-to-action-small"
+      >
+        <div
+          class="container"
+        >
+          <div
+            class="row"
+          >
+            <div
+              class="col-sm-12 text-center"
+            >
+              <h3>
+                Help Us Teach More Veterans How To Code  
+              </h3>
+              <a
+                class="btn btn-charity-default"
+                href="/donate"
+              >
+                DONATE
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section
         class="footer-widgets pad-extra"
       >
         <div


### PR DESCRIPTION
# Fixed "Help Us Teach More Veterans How To Code" donation button alignment on mobile

## Description

- Moved "Help Us Teach More Veterans How To Code" snippet found in all pages except for the home page to the footer component.
- Add ternary to query what location footer was at. If it was on the donate page `window.location.pathname !== "/donate"` it would not display "Help Us Teach More Veterans How To Code" and button. It displays on all other pages.
- Changed the donation button link in the footer from `<a href="/donate">` to `<Link to="/donate">` because Gatsby `<Link>` was designed to handle internal links.
- Found an error on About page where `<h2>` was a child of `<p>`. I moved the `<h2>` tag above the `<p>` tag. 
- Updated testing snapshot. All tests passed. 

## Related Issue

Related to #150 

## Motivation and Context

- Removes repeated code. Went from 84 lines to 14 lines

## How Has This Been Tested?

In Chrome, I checked the responsiveness in all pages. 
Using Jest 

## Screenshots (if appropriate):
![screenshot of fixed alignment](https://i.ibb.co/pxMcGVk/fixed.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
