### PR TITLE
Fix Nav Bar shifting down #128

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -35,7 +35,7 @@ function Nav() {
       role="navigation"
       style={{ opacity: opacity }}
     >
-      <div className="container">
+      <div className="container-fluid">
         <div className="navbar-header">
           <div
             className="navbar-brand"

--- a/src/components/Nav/nav.css
+++ b/src/components/Nav/nav.css
@@ -56,9 +56,34 @@
   vertical-align: middle;
   font-size: 0.5em;
 }
+@media only screen and (max-width: 363px) {
+  .navbar-brand {
+    max-width: 200px;
+  }
+}
 
 /*  */
-.donate:hover{
-  transition: .3s linear;
-  background-color: #C5203E;
+.donate:hover {
+  transition: 0.3s linear;
+  background-color: #c5203e;
+}
+
+@media (max-width: 1140px) {
+  .navbar-right {
+    float: right !important;
+    margin-right: -15px;
+    display: none;
+  }
+  .main-navigation .navbar-toggle {
+    display: block;
+    position: absolute;
+    float: right;
+    padding: 9px 10px;
+    margin-top: 8px;
+    margin-right: 15px;
+    margin-bottom: 8px;
+    background-color: transparent;
+    background-image: none;
+    border: 1px solid transparent;
+  }
 }

--- a/tests/components/__snapshots__/Layout.test.js.snap
+++ b/tests/components/__snapshots__/Layout.test.js.snap
@@ -16,7 +16,7 @@ exports[`<Layout /> should render correctly 1`] = `
       style="opacity: 0.9;"
     >
       <div
-        class="container"
+        class="container-fluid"
       >
         <div
           class="navbar-header"

--- a/tests/components/__snapshots__/Nav.test.js.snap
+++ b/tests/components/__snapshots__/Nav.test.js.snap
@@ -9,7 +9,7 @@ exports[`<Nav /> should render correctly 1`] = `
   style="opacity: 0.9;"
 >
   <div
-    class="container"
+    class="container-fluid"
   >
     <div
       class="navbar-header"


### PR DESCRIPTION

## Description
- Changed Navbar container classname to `<div className="container-fluid">` to push the VWC brand to far left of navbar
- Added `@media-only screen and (max-width: 363px)` to nav.css and added max-width of `.navbar-brand{max-width: 200px;}` so that the hambirger wouldn't overflow to the next line.
- Override bootstrap for the navbar main navigation using media query `@media (max-width: 1140px) {...}`
- Changed breakpoint for burger menu from 768px to 1140px to prevent wide menu from shifting down.

## Related Issue
#128 

## Motivation and Context
Changes the breakpoint when burger menu shows up from 768px to 1140px to fix navbar shifting down.

## How Has This Been Tested?
Tested on dev server. 

## Screenshots (if appropriate):
[Link to gif of changes](https://i.ibb.co/ZJ2ytCg/navbarshifting.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
