### PR TITLE
PROD-21: Moved donate link to the end of the nav

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -41,7 +41,7 @@ function Nav() {
             className="navbar-brand"
             style={{ padding: '5px 15px 5px' }}
             itemScope=""
-            itemType="https://schema.org/Organization" 
+            itemType="https://schema.org/Organization"
           >
             <span className="sr-only">#VetsWhoCode</span>
             <Link to="/" id="navbar-brand">
@@ -102,11 +102,6 @@ function Nav() {
                 <span>Apply</span>
               </Link>
             </li>
-            <li role="menuitem" className="donate">
-              <Link to="/donate">
-                <span>Donate</span>
-              </Link>
-            </li>
             <li role="menuitem" className="nav">
               <Link to="/contact">
                 <span>Contact</span>
@@ -115,6 +110,11 @@ function Nav() {
             <li role="menuitem" className="nav">
               <Link to="/blog">
                 <span>Blog</span>
+              </Link>
+            </li>
+            <li role="menuitem" className="donate">
+              <Link to="/donate">
+                <span>Donate</span>
               </Link>
             </li>
           </ul>

--- a/tests/components/__snapshots__/Layout.test.js.snap
+++ b/tests/components/__snapshots__/Layout.test.js.snap
@@ -152,18 +152,6 @@ exports[`<Layout /> should render correctly 1`] = `
               </a>
             </li>
             <li
-              class="donate"
-              role="menuitem"
-            >
-              <a
-                href="/donate"
-              >
-                <span>
-                  Donate
-                </span>
-              </a>
-            </li>
-            <li
               class="nav"
               role="menuitem"
             >
@@ -184,6 +172,18 @@ exports[`<Layout /> should render correctly 1`] = `
               >
                 <span>
                   Blog
+                </span>
+              </a>
+            </li>
+            <li
+              class="donate"
+              role="menuitem"
+            >
+              <a
+                href="/donate"
+              >
+                <span>
+                  Donate
                 </span>
               </a>
             </li>

--- a/tests/components/__snapshots__/Nav.test.js.snap
+++ b/tests/components/__snapshots__/Nav.test.js.snap
@@ -145,18 +145,6 @@ exports[`<Nav /> should render correctly 1`] = `
           </a>
         </li>
         <li
-          class="donate"
-          role="menuitem"
-        >
-          <a
-            href="/donate"
-          >
-            <span>
-              Donate
-            </span>
-          </a>
-        </li>
-        <li
           class="nav"
           role="menuitem"
         >
@@ -177,6 +165,18 @@ exports[`<Nav /> should render correctly 1`] = `
           >
             <span>
               Blog
+            </span>
+          </a>
+        </li>
+        <li
+          class="donate"
+          role="menuitem"
+        >
+          <a
+            href="/donate"
+          >
+            <span>
+              Donate
             </span>
           </a>
         </li>


### PR DESCRIPTION
## Description
Moved the donated link to the end of the nav

## Related Issue
PROD-21: Place donate page at the end of Nav

## Motivation and Context

## How Has This Been Tested?
Ran `yarn test --updateSnapshot` to ensure change was detected by jest

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
