### PR TITLE
Change page header size to 25vh

### DIFF
--- a/src/components/PageHeader/PageHeader.js
+++ b/src/components/PageHeader/PageHeader.js
@@ -22,7 +22,7 @@ const PageHeader = ({ title, link }) => {
           style={{
             backgroundImage: `url(${data.file.childImageSharp.fixed.src})`,
             backgroundPositionY: 'bottom',
-            height: '45vh',
+            height: '25vh',
           }}
         >
           <div className="overlay-01" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Scale down the header height to 2vh instead of 45vh.

## Related Issue
[https://github.com/Vets-Who-Code/vets-who-code-app/issues/194](https://github.com/Vets-Who-Code/vets-who-code-app/issues/194)

## Motivation and Context
Resizing the page header keeps from pushing top-level page data too far down the screen.

## How Has This Been Tested?
Re-compiled with the change and observed each page.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
