### PR TITLE
Fix heading a11y issue

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -169,3 +169,13 @@
     width: 95%;
   }
 }
+
+.next-cohort {
+  font-size: 1.3125rem;
+}
+
+#cause-title {
+  font-size: 1.5rem;
+  font-family: Open Sans;
+  font-weight: 800;
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -118,7 +118,7 @@ function IndexPage() {
         <div className="container">
           <div className="row">
             <div className="col-sm-6 event_content">
-              <h4>Next Cohort</h4>
+              <h3 className="next-cohort">Next Cohort</h3>
               <div className="event_excerpt">
                 <p>Countdown until our next #VetsWhoCode Cohort gets started:</p>
               </div>
@@ -159,7 +159,8 @@ function IndexPage() {
           </div>
           <div className="row">
             <div className="col-sm-12 cause_content text-center" style={{ marginBottom: 40 }}>
-              <h4 className="cause_title">Thank You For Working With #VetsWhoCode!</h4>
+              {/* eslint-disable-next-line max-len */}
+              <h3 id="cause-title">Thank You For Working With #VetsWhoCode!</h3>
               <hr />
               <h3 className="subtitle">
                 We Are Grateful To Have These Companies Partner With Us On Our Journey To Train


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR addresses the Lighthouse accessibility issue of the heading elements not being in a sequentially-descending order on the homepage. Offending elements have been changed from `h4` to `h3` and styled as they were originally before the change. A class was created for the Next Cohort heading. An id was created for the Thank you for working with #VetsWhoCode heading in order to override a class.
## Related Issue
This addresses issue #215 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This addresses accessibility standards. The fix brings the Lighthouse accessibility score to 100.
## How Has This Been Tested?
This was tested via Lighthouse.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
