### PR TITLE
Fix dark mode icon alignment across devices; fixes #213

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -601,11 +601,17 @@ h1.bold_404 {
   font-weight: bold;
   letter-spacing: 2px;
   margin-bottom: -1px;
-  padding: 20px 15px 20px 15px;
+  padding: 20px 12px 20px 12px;
   position: relative;
   text-transform: uppercase;
   -webkit-transition: all 0.4s ease;
   transition: all 0.4s ease;
+}
+
+@media only screen and (min-width: 1500px) {
+  .main-navigation .navbar-nav li a {
+    padding: 20px 15px 20px 15px;
+  }
 }
 @media only screen and (max-width: 767px) {
   .main-navigation .navbar-nav li a {

--- a/src/components/Nav/nav.css
+++ b/src/components/Nav/nav.css
@@ -36,9 +36,8 @@
 }
 
 .navbar-brand a {
-  min-width: 200px;
   display: grid;
-  grid-template-columns: 50px 180px;
+  grid-template-columns: 50px 1fr;
   grid-template-rows: 50px;
 }
 

--- a/src/components/Toggle/toggle.css
+++ b/src/components/Toggle/toggle.css
@@ -4,11 +4,6 @@
   text-align: right;
 }
 @media only screen and (min-width: 768px) and (max-width: 1023px) {
-  .toggle-container {
-    position: absolute;
-    right: -45.5rem;
-    top: 2rem;
-  }
   .switch {
     color: var(--element-3);
   }
@@ -17,8 +12,8 @@
   .toggle-container {
     z-index: 1;
     position: absolute;
-    right: 1rem;
-    top: -1rem;
+    right: 4.2rem;
+    top: -0.88rem;
   }
 }
 .btn-toggle {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR fixes the misalignment of the dark/light mode icon switcher in the navigation bar. It currently drops on a new line whenever the device's width is between 768 and 1024px. The reason is that it's absolutely positioned within these sizes. The fix is to remove the position absolute, and to make it cleaner, I've fine tuned the positioning for the smaller devices as well (i.e. between 320 and 767px).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This fixes #213.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Having the icon a new line for those widths, right underneath the main navigation makes it look out of place.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Different browsers and browser widths.

## Screenshots (if appropriate):
https://i.imgur.com/7C9U8NB.mp4

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
