### PR TITLE
Changed toggle position in mobile menu

### DIFF
--- a/src/components/Toggle/toggle.css
+++ b/src/components/Toggle/toggle.css
@@ -12,7 +12,7 @@
   .toggle-container {
     z-index: 1;
     position: absolute;
-    right: 4.2rem;
+    right: 1rem;
     top: -0.88rem;
   }
 }


### PR DESCRIPTION
## Description
Changed toggle position in mobile menu from 4.2rem to 1rem

## Related Issue
#231 

## Motivation and Context
Dark mode toggle position was off

## How Has This Been Tested?
Visually

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
