### PR TITLE
Added Apply page prework button and added margins to pages

### DIFF
--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -30,6 +30,17 @@ export default function Apply() {
                     which will allow us to gauge your initial skill levels and help us assign an
                     appropriate mentor), and fill out the following application form.
                   </p>
+                  <div className="container-fluid">
+                    <a
+                      className="btn btn-charity-default col-xs-6"
+                      href="https://github.com/Vets-Who-Code/prework"
+                      role="button"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Required Prework
+                    </a>
+                  </div>
                   <ApplyForm />
                 </div>
               </div>

--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -34,15 +34,17 @@ export default function Apply() {
                     </p>
                   </div>
                   <div className="container-fluid">
-                    <a
-                      className="btn btn-charity-default col-xs-6"
-                      href="https://github.com/Vets-Who-Code/prework"
-                      role="button"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      Required Prework
-                    </a>
+                    <div className="text-center">
+                      <a
+                        className="btn btn-charity-default"
+                        href="https://github.com/Vets-Who-Code/prework"
+                        role="button"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Required Prework
+                      </a>
+                    </div>
                   </div>
                   <ApplyForm />
                 </div>

--- a/src/pages/apply.js
+++ b/src/pages/apply.js
@@ -17,19 +17,22 @@ export default function Apply() {
             <div className="row">
               <div className="col-xs-12">
                 <div className="contactus-brief">
-                  <p className="section-description">
-                    Thank you for choosing to apply to Vets Who Code. Your first step in this
-                    journey will be to visit our&nbsp;
-                    <a href="https://github.com/Vets-Who-Code/prework">prework repository</a>
-                    &nbsp;on <a href="http://github.com">github.com</a>. We ask that, prior to
-                    applying to our program, you complete a small series of tutorial assignments
-                    that will introduce you to the basics of HTML5, CSS3 and JavaScript. The prework
-                    reading assignment will also guide you through setting up your development
-                    environment to work with the Vets Who Code program. After finishing the reading,
-                    we ask that you complete the capstone project&nbsp;(a short one-page website
-                    which will allow us to gauge your initial skill levels and help us assign an
-                    appropriate mentor), and fill out the following application form.
-                  </p>
+                  <div className="container-fluid">
+                    <p className="section-description">
+                      Thank you for choosing to apply to Vets Who Code. Your first step in this
+                      journey will be to visit our&nbsp;
+                      <a href="https://github.com/Vets-Who-Code/prework">prework repository</a>
+                      &nbsp;on <a href="http://github.com">github.com</a>. We ask that, prior to
+                      applying to our program, you complete a small series of tutorial assignments
+                      that will introduce you to the basics of HTML5, CSS3 and JavaScript. The
+                      prework reading assignment will also guide you through setting up your
+                      development environment to work with the Vets Who Code program. After
+                      finishing the reading, we ask that you complete the capstone project&nbsp;(a
+                      short one-page website which will allow us to gauge your initial skill levels
+                      and help us assign an appropriate mentor), and fill out the following
+                      application form.
+                    </p>
+                  </div>
                   <div className="container-fluid">
                     <a
                       className="btn btn-charity-default col-xs-6"

--- a/src/pages/mentor.js
+++ b/src/pages/mentor.js
@@ -170,20 +170,21 @@ function Mentor() {
                       ))}
                     </Accordion>
                     <h1 className="small-top-pad">Time Commitment</h1>
-                    <p>
+                    <p className="text-justify">
                       After being formally assigned a mentee, we ask mentors to set up an initial
                       chat with their mentee to discuss their needs and to get to know one another.
                       After this initial meeting, we ask that our mentors check in with their mentee
                       at least once a week to inquire about their progress and if the mentees have
                       any issues.
                     </p>
-                    #VetsWhoCode is a virtual organization where Slack is the primary vehicle for
-                    communication and activity. We ask mentors to be available on Slack to students
-                    and to use Slack as a way to check in with mentees on a weekly basis. Mentors
-                    and mentees may also use email or video chat to communicate with one another.
-                    Please work with your mentee to establish the best frequency and method of
-                    communication for you both.
-                    <p />
+                    <p className="text-justify">
+                      #VetsWhoCode is a virtual organization where Slack is the primary vehicle for
+                      communication and activity. We ask mentors to be available on Slack to
+                      students and to use Slack as a way to check in with mentees on a weekly basis.
+                      Mentors and mentees may also use email or video chat to communicate with one
+                      another. Please work with your mentee to establish the best frequency and
+                      method of communication for you both.
+                    </p>
                   </div>
                 </div>
               </div>

--- a/src/pages/syllabus.js
+++ b/src/pages/syllabus.js
@@ -45,14 +45,14 @@ export default class Mentor extends Component {
                 <h1 className="story-title">Syllabus</h1>
                 <p>
                   <i>
-                    Our curriculum is designed to teach our veterans skills needed for today&apos;s tech
-                    market.
+                    Our curriculum is designed to teach our veterans skills needed for today&apos;s
+                    tech market.
                   </i>
                 </p>
               </div>
               <div className="row">
                 <div className="col-md-12">
-                  <div className="faq-short-brief">
+                  <div className="faq-short-brief container-fluid">
                     <p>
                       Our curriculum is designed using the Agile Methodology with four-day sprints
                       dedicated to the subject. We do it in this manner based on the practice of how


### PR DESCRIPTION
## Description
- Added a button to Apply page so that users could navigate to the prework page on Github more easily
- Added a small gutter to the paragraphs on the Apply, Syllabus, and Mentor pages to improve readability.

## Related Issue
Closes #241 & #242 

## Motivation and Context
- A button on the Apply page that directs visitors to the pre-work. It would be more clear at a glance that you can easily navigate to that documentation, especially helpful for people who skim the text.
- Keep the page consistent and improve readability on the site.

## How Has This Been Tested?
Tested through Chrome's Device Toolbar

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
