### PR TITLE
Changed github footer url

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -61,7 +61,7 @@ function Footer() {
                       <FaLinkedinIn />
                     </i>
                   </a>
-                  <a href="http://bit.ly/vwc-github" aria-label="Github">
+                  <a href="https://bit.ly/2HSojjv" aria-label="Github">
                     <i className="fa">
                       <FaGithub />
                     </i>

--- a/tests/components/__snapshots__/Footer.test.js.snap
+++ b/tests/components/__snapshots__/Footer.test.js.snap
@@ -166,7 +166,7 @@ exports[`<Footer /> should render correctly 1`] = `
               </a>
               <a
                 aria-label="Github"
-                href="http://bit.ly/vwc-github"
+                href="https://bit.ly/2HSojjv"
               >
                 <i
                   class="fa"

--- a/tests/components/__snapshots__/Layout.test.js.snap
+++ b/tests/components/__snapshots__/Layout.test.js.snap
@@ -374,7 +374,7 @@ exports[`<Layout /> should render correctly 1`] = `
                   </a>
                   <a
                     aria-label="Github"
-                    href="http://bit.ly/vwc-github"
+                    href="https://bit.ly/2HSojjv"
                   >
                     <i
                       class="fa"


### PR DESCRIPTION
## Description
Changed the github footer url to link to https://github.com/sponsors/Vets-Who-Code in the Footer component. 

## Related Issue
Closes #246 

## Motivation and Context
Per Jerome

## How Has This Been Tested?
Visited link
Updated footer snapshot in jest

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
