### PR TITLE
 adding public charity EIN

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -32,8 +32,8 @@ function Footer() {
               <div className="widgets-content footer-widget-wrap">
                 <h3 className="widgets-title">About #VetsWhoCode</h3>
                 <p>
-                  FRAGO, doing business as #VetsWhoCode, is an exempt organization as described in
-                  Section 501(c)(3) of the Internal Revenue Code. Our EIN is 47-3555231.
+                  Vets Who Code Inc. is an exempt organization as described in
+                  Section 501(c)(3) of the Internal Revenue Code. Our EIN is 86-2122804.
                 </p>
                 <div className="footer-social">
                   <a href="http://bit.ly/vetswhocode-facebook-link" aria-label="Facebook">

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -32,8 +32,8 @@ function Footer() {
               <div className="widgets-content footer-widget-wrap">
                 <h3 className="widgets-title">About #VetsWhoCode</h3>
                 <p>
-                  Vets Who Code Inc. is an exempt organization as described in
-                  Section 501(c)(3) of the Internal Revenue Code. Our EIN is 86-2122804.
+                  Vets Who Code Inc. is an exempt organization as described in Section 501(c)(3) of
+                  the Internal Revenue Code. Our EIN is 86-2122804.
                 </p>
                 <div className="footer-social">
                   <a href="http://bit.ly/vetswhocode-facebook-link" aria-label="Facebook">

--- a/tests/components/__snapshots__/Footer.test.js.snap
+++ b/tests/components/__snapshots__/Footer.test.js.snap
@@ -49,7 +49,7 @@ exports[`<Footer /> should render correctly 1`] = `
               About #VetsWhoCode
             </h3>
             <p>
-              FRAGO, doing business as #VetsWhoCode, is an exempt organization as described in Section 501(c)(3) of the Internal Revenue Code. Our EIN is 47-3555231.
+              Vets Who Code Inc. is an exempt organization as described in Section 501(c)(3) of the Internal Revenue Code. Our EIN is 86-2122804.
             </p>
             <div
               class="footer-social"

--- a/tests/components/__snapshots__/Layout.test.js.snap
+++ b/tests/components/__snapshots__/Layout.test.js.snap
@@ -301,7 +301,7 @@ exports[`<Layout /> should render correctly 1`] = `
                 About #VetsWhoCode
               </h3>
               <p>
-                FRAGO, doing business as #VetsWhoCode, is an exempt organization as described in Section 501(c)(3) of the Internal Revenue Code. Our EIN is 47-3555231.
+                Vets Who Code Inc. is an exempt organization as described in Section 501(c)(3) of the Internal Revenue Code. Our EIN is 86-2122804.
               </p>
               <div
                 class="footer-social"


### PR DESCRIPTION
IRS finally consolidated all of our paperwork, changed the name from FRAGO to Vets Who Code, changed our charity status from a private foundation to a public charity and we have a new EIN, so changing the footer to reflect that.