### PR TITLE
Move handlers so dropdowns close on click

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -161,7 +161,6 @@ function Nav() {
             <li
               className={`dropdown nav ${isOurStoryDropDownOpen ? 'open' : ''}`}
               role="menuitem"
-              onClick={() => toggleMenuItem(NAV.TOGGLE_OUR_STORY_DROPDOWN)}
               style={{ marginRight: 10 }}
             >
               <a
@@ -171,6 +170,7 @@ function Nav() {
                 className="nav"
                 href="#"
                 role="button"
+                onClick={() => toggleMenuItem(NAV.TOGGLE_OUR_STORY_DROPDOWN)}
               >
                 Our Story
                 <AiFillCaretDown className="dropdown-caret" />
@@ -196,7 +196,6 @@ function Nav() {
             <li
               className={`dropdown nav ${isMediaDropdownOpen ? 'open' : ''}`}
               role="menuitem"
-              onClick={() => toggleMenuItem(NAV.TOGGLE_MEDIA_DROPDOWN)}
               style={{ marginRight: 10 }}
             >
               <a
@@ -206,6 +205,7 @@ function Nav() {
                 className="nav"
                 href="#"
                 role="button"
+                onClick={() => toggleMenuItem(NAV.TOGGLE_MEDIA_DROPDOWN)}
               >
                 Media
                 <AiFillCaretDown className="dropdown-caret" />
@@ -226,7 +226,6 @@ function Nav() {
             <li
               className={`dropdown nav ${isApplyDropdownOpen ? 'open' : ''}`}
               role="menuitem"
-              onClick={() => toggleMenuItem(NAV.TOGGLE_APPLY_DROPDOWN)}
               style={{ marginRight: 10 }}
             >
               <a
@@ -236,6 +235,7 @@ function Nav() {
                 className="nav"
                 href="#"
                 role="button"
+                onClick={() => toggleMenuItem(NAV.TOGGLE_APPLY_DROPDOWN)}
               >
                 Apply
                 <AiFillCaretDown className="dropdown-caret" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Nav dropdowns remained open on click of child elements.
## Description
<!--- Describe your changes in detail -->
Moved handler to `a` element instead of `li`.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
