### PR TITLE
Make accordion buttons fullWidth

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1974,6 +1974,7 @@ uneditable-input:focus {
 }
 .panel-heading {
   padding: 0;
+  width: 100%;
 }
 
 .faq_list .panel-title {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I added the required CSS on the "panel-heading" class to make the accordion buttons expand to full width

## Related Issue
Here is the issue - **Buttons not full width in accordion panels** https://github.com/Vets-Who-Code/vets-who-code-app/issues/313