### PR TITLE
Updated Nav Donate Link

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -304,9 +304,7 @@ function Nav() {
             </li>
             <li role="menuitem" className="donate" onClick={resetNavigation}>
               <Link href="/donate">
-                <a>
-                  <span>Donate</span>
-                </a>
+                <a>Donate</a>
               </Link>
             </li>
           </ul>

--- a/tests/components/__snapshots__/Layout.test.js.snap
+++ b/tests/components/__snapshots__/Layout.test.js.snap
@@ -340,9 +340,7 @@ exports[`<Layout /> should render correctly 1`] = `
               <a
                 href="/donate"
               >
-                <span>
-                  Donate
-                </span>
+                Donate
               </a>
             </li>
           </ul>

--- a/tests/components/__snapshots__/Nav.test.js.snap
+++ b/tests/components/__snapshots__/Nav.test.js.snap
@@ -333,9 +333,7 @@ exports[`<Nav /> should render correctly 1`] = `
           <a
             href="/donate"
           >
-            <span>
-              Donate
-            </span>
+            Donate
           </a>
         </li>
       </ul>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deleted out the span included within the Nav Donate link.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #338  
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change enhances the lighthouse accessibility score by removing a span that did not meet the 4:1 color ratio compliance.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Executed the lighthouse report on localhost. Accessibility score is at 100. I did go back and double check the website and it too has the same score and does not flag the span anymore. Not sure if you'd still wish to merge this PR.

This update does affect the underline on hover transition for the Donate link.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
