### PR TITLE
fix(font): removed quotations from sans-serif which fixed footer font

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2377,7 +2377,7 @@ div.zabuto_calendar tr.calendar-dow td {
   background-color: var(--surface-6);
 }
 .footer-widgets h3 {
-  font-family: 'Gotham', 'Sans-Serif';
+  font-family: 'Gotham', sans-serif;
   font-size: 1.3125rem; /*21px*/
   font-weight: 800;
   letter-spacing: 1px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed ' ' from sans-serif within main.css font-family section. This updated the font to show as expected.

## Related Issue
#384 

## Motivation and Context
Site font was transitioned to Gotham. Jerome noticed the footer still had some alibis.

## How Has This Been Tested?
Visually saw the change.

## Screenshots (if appropriate):
![Screen Shot 2022-05-19 at 8 28 17 PM](https://user-images.githubusercontent.com/60114461/169425749-c02a5e57-f45d-443e-ac3d-4d6187f139e7.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
