### PR TITLE
set min-width of nav bar to 821px #400

### DIFF
--- a/src/assets/css/nav.css
+++ b/src/assets/css/nav.css
@@ -102,7 +102,7 @@
   color: var(--element-4);
 }
 
-@media (min-width: 768px) and (max-width: 1400px) {
+@media (min-width: 821px) and (max-width: 1400px) {
   .container-fluid {
     display: flex;
     flex-flow: column nowrap;
@@ -134,7 +134,7 @@
   }
 }
 
-@media (min-width: 768px) {
+@media (min-width: 821px) {
   .navbar-right {
       float: right!important;
       margin-right: -15px;


### PR DESCRIPTION
## Description
Set min width of Nav Bar to 821px so that once a window goes to 820px it switches to mobile version.

## Related Issue
issue #400 

## Motivation and Context
Nav bar changes to mobile version originally at 768px. The issue with this is that the nav bar is no longer inline with the each other. At 820px the Code of Conduct NAV bar option becomes two lines instead of one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
