### PR TITLE
Add a check for length in the footer form to help lessen the amount of spam received

### DIFF
--- a/src/pages/api/api-helpers/index.js
+++ b/src/pages/api/api-helpers/index.js
@@ -17,3 +17,8 @@ export const checkLength = message => {
   }
   return false
 }
+
+export const contactErrors = {
+  missingOrRequired: 'Missing or incorrect required property',
+  tooShort: 'Message is too short for submission',
+}

--- a/src/pages/api/api-helpers/index.js
+++ b/src/pages/api/api-helpers/index.js
@@ -9,3 +9,11 @@ export function checkParams(eventBody, params) {
 
   return hasError
 }
+
+export const checkLength = message => {
+  const length = message.trim().split(' ').length
+  if (length === 1) {
+    return true
+  }
+  return false
+}

--- a/src/pages/api/contact.js
+++ b/src/pages/api/contact.js
@@ -1,15 +1,22 @@
 import axios from 'axios'
-import { checkParams } from './api-helpers'
+import { checkParams, checkLength, validateEmail } from './api-helpers'
 
 export default async function handler(req, res) {
   const parsedBody = JSON.parse(req.body)
   const { name, email, phone, message } = parsedBody
   const requiredParams = ['email', 'message']
   const hasErrors = checkParams(parsedBody, requiredParams)
+  const isPossiblySpam = checkLength(message)
 
   if (hasErrors) {
     return res.status(422).json({
       error: 'Missing or incorrect required property',
+    })
+  }
+
+  if (isPossiblySpam) {
+    return res.status(400).json({
+      error: 'Message is too short for submission',
     })
   }
 

--- a/src/pages/api/contact.js
+++ b/src/pages/api/contact.js
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { checkParams, checkLength, validateEmail } from './api-helpers'
+import { checkParams, checkLength, contactErrors } from './api-helpers'
 
 export default async function handler(req, res) {
   const parsedBody = JSON.parse(req.body)
@@ -10,13 +10,13 @@ export default async function handler(req, res) {
 
   if (hasErrors) {
     return res.status(422).json({
-      error: 'Missing or incorrect required property',
+      error: contactErrors.missingOrRequired,
     })
   }
 
   if (isPossiblySpam) {
     return res.status(400).json({
-      error: 'Message is too short for submission',
+      error: contactErrors.tooShort,
     })
   }
 

--- a/tests/api/contact.test.js
+++ b/tests/api/contact.test.js
@@ -69,4 +69,23 @@ describe('contact handler', () => {
     expect(res._getStatusCode()).toBe(500)
     expect(res._getData()).toBe('{"message":"Failed post to #contact channel"}')
   })
+
+  test('should throw a 400 error when the length of the message is too short', async () => {
+    const body = {
+      name: 'Jody',
+      email: 'fake@email.com',
+      phone_number: '111-111-1111',
+      message: 'nope',
+    }
+    const { req, res } = createMocks({
+      method: 'POST',
+      statusCode: 200,
+      body: JSON.stringify(body),
+    })
+
+    await contactApiHandler(req, res)
+
+    expect(res._getStatusCode()).toBe(400)
+    expect(res._getData()).toBe('{"error":"Message is too short for submission"}')
+  })
 })


### PR DESCRIPTION
Add a check for length in the footer form to help lessen the amount of spam received

## Description
Add a checkLength function to the api. The function checks for length of 1. If true, returns a 400

## Motivation and Context
Tired of all the spam. Hoping this will lessen it

## How Has This Been Tested?
Wrote a unit test with a message with the length of 1
 
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
