### PR TITLE
refactor: remove amazon smile

### DIFF
--- a/src/pages/donate.js
+++ b/src/pages/donate.js
@@ -42,7 +42,7 @@ function Donate() {
                   />
                 </div>
               </div>
-              <div className="story col-sm-4">
+              <div className="story col-sm-6">
                 <h3 className="text-center">Corporate Giving</h3>
                 <Image
                   src="/images/corporate-giving.jpeg"
@@ -62,7 +62,7 @@ function Donate() {
                   to make it easy for your employees and company to donate to our cause.
                 </p>
               </div>
-              <div className="story col-sm-4">
+              <div className="story col-sm-6">
                 <h3 className="text-center">Github Sponsors</h3>
                 <Image
                   src="/images/github-sponsors.jpeg"
@@ -77,23 +77,6 @@ function Donate() {
                   you would like to sponsor us, please visit our{' '}
                   <a href="https://github.com/sponsors/Vets-Who-Code">Github Sponsors page</a> to
                   learn more.
-                </p>
-              </div>
-              <div className="story col-sm-4">
-                <h3 className="text-center">Amazon Smile</h3>
-                <Image
-                  src="/images/amazon-smile.jpeg"
-                  alt="Amazon Smile"
-                  blurDataURL="/images/amazon-smile.jpeg"
-                  width={1000}
-                  height={500}
-                  placeholder="blur"
-                  // layout="fill"
-                />
-                <p>
-                  Looking to give while shopping? We have a{' '}
-                  <a href="https://smile.amazon.com/ch/86-2122804">Smile</a> account to make it easy
-                  for you to give while shopping to your hearts content.
                 </p>
               </div>
             </div>


### PR DESCRIPTION
Remove Amazon smile as an option from the Donate page.

## Description
Removed Amazon smile div and re-sized remaining two divs to be 50/50. 

## Related Issue
https://github.com/orgs/Vets-Who-Code/projects/46?pane=issue&itemId=28649331

## Motivation and Context
Amazon Smile ended on 2/20/23 and this change is to reflect that it is no longer an option. 

## How Has This Been Tested?
- Verified removal of Amazon Smile section.
- Verified existing links on Donation page still work. 
- Tested responsiveness of remaining 2 options.
- Ran test suite to verify all tests still pass. 

## Screenshots (if appropriate):
![image](https://github.com/Vets-Who-Code/vets-who-code-app/assets/15794495/d49c8861-d53b-4cef-add2-b8915719ea87)
![image](https://github.com/Vets-Who-Code/vets-who-code-app/assets/15794495/4bb957a4-8257-4336-b9eb-b5ff7459d15e)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
