### PR TITLE
 change url to apply

### DIFF
--- a/src/data/homepages/index.json
+++ b/src/data/homepages/index.json
@@ -167,8 +167,8 @@
             "buttons": [
                 {
                     "id": 1,
-                    "path": "/apply-to-be-a-student",
-                    "content": "Join Us"
+                    "path": "/apply",
+                    "content": "Apply"
                 }
             ],
             "items": [

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -131,7 +131,7 @@ export default [
             {
                 id: 25,
                 label: "Apply to be a Student",
-                path: "/apply-to-be-a-student",
+                path: "/apply",
             },
             /*           {
                 id: 26,

--- a/src/pages/apply.tsx
+++ b/src/pages/apply.tsx
@@ -31,10 +31,10 @@ const ApplyPage: PageProps = ({ data }) => {
     const content = normalizedData<PageContent>(data.page?.content, "section");
     return (
         <>
-            <SEO title="Apply to be a Student" />
+            <SEO title="Apply" />
             <Breadcrumb
                 pages={[{ path: "/", label: "Home" }]}
-                currentPage="Apply to be a Student"
+                currentPage="Apply"
                 showTitle={false}
             />
             <Wrapper>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at af89f9d</samp>

### Summary
🖱️📋🍽️

<!--
1.  🖱️ - This emoji represents the change in the homepage link, which is a clickable element that leads to the apply page. The mouse cursor emoji suggests the action of clicking on a link and the idea of navigation or redirection.
2. 📋 - This emoji represents the change in the page file name, the SEO title, and the breadcrumb current page for the apply page. The clipboard emoji suggests the idea of filling out an application or a form, which is the main purpose of the page. It also implies the concept of simplicity and clarity, as the page name and title are now shorter and more direct.
3. 🍽️ - This emoji represents the change in the menu item for the apply page. The plate emoji suggests the idea of a menu or a list of options, as well as the notion of serving or offering something to the visitors. It also conveys the concept of consistency and alignment, as the menu item now matches the homepage link and the page name and title.
-->
The URL, title, and navigation label of the apply page were simplified from "apply-to-be-a-student" and "Apply to be a Student" to "apply" and "Apply". This change was made to improve the user experience and consistency of the website.

> _`/apply` is clear_
> _Simpler path and title now_
> _Autumn of changes_

### Walkthrough
*  Simplify the URL and title of the apply page from "apply-to-be-a-student" and "Apply to be a Student" to "apply" and "Apply" ([link](https://github.com/Vets-Who-Code/vets-who-code-app/pull/504/files?diff=unified&w=0#diff-4e2e270fa5735804889bde55c23721dc839113a9eeee178b0c09c1a03787dd0aL170-R171), [link](https://github.com/Vets-Who-Code/vets-who-code-app/pull/504/files?diff=unified&w=0#diff-c9fbaec999bea407d6e7a186dbd006baf323984bf53f5a0a047c290be52303d0L134-R134), [link](https://github.com/Vets-Who-Code/vets-who-code-app/pull/504/files?diff=unified&w=0#diff-8c404182d74ae3928b76db1f43b4f56b2663baa5fd3c6c4a3aa7c6e7f5aaa5a8L34-R37))
* Update the link text and the breadcrumb label for the apply page to match the new title ([link](https://github.com/Vets-Who-Code/vets-who-code-app/pull/504/files?diff=unified&w=0#diff-4e2e270fa5735804889bde55c23721dc839113a9eeee178b0c09c1a03787dd0aL170-R171), [link](https://github.com/Vets-Who-Code/vets-who-code-app/pull/504/files?diff=unified&w=0#diff-8c404182d74ae3928b76db1f43b4f56b2663baa5fd3c6c4a3aa7c6e7f5aaa5a8L34-R37))

