### PR TITLE
Replaced start-here paths with about-us

### DIFF
--- a/src/data/homepages/index.json
+++ b/src/data/homepages/index.json
@@ -30,7 +30,7 @@
             "buttons": [
                 {
                     "id":1,
-                    "path": "/start-here",
+                    "path": "/about-us",
                     "content":"Learn More",
                     "color": "light"
                 },

--- a/src/data/innerpages/join-our-community.json
+++ b/src/data/innerpages/join-our-community.json
@@ -10,7 +10,7 @@
             "buttons": [
                 {
                     "id": 1,
-                    "path": "/start-here",
+                    "path": "/about-us",
                     "content": "Get started for free"
                 }
             ]


### PR DESCRIPTION
## Description
The VWC production app's "Learn More" button sends users to `start-here`. A path that is no longer valid. I went ahead and replaced it with `about-us` to match the footers "Start Here" link.

## Related Issue
https://github.com/Vets-Who-Code/vets-who-code-app/issues/516

## Motivation and Context
Important for the learn more to work since we want potential donors, mentors, veterans to be redirected appropriately to stay engaged. Returning a 404 could be the difference in getting that person into the community.

## How Has This Been Tested?
* On the VWC landing page, I clicked on "Learn More."
* Validated that I was redirected to `about-us`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
