### PR TITLE
 fixed SEO images

### DIFF
--- a/src/components/logo/index.tsx
+++ b/src/components/logo/index.tsx
@@ -12,7 +12,7 @@ const Logo = ({ variant, className }: TProps) => {
             <a className={clsx("tw-inline-block", className)}>
                 {variant === "dark" && (
                     <img
-                        src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto/f_auto/f_auto/v1627489505/VWC_Logo_Horizontal_gsxn3h.png"
+                        src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto/v1627489505/VWC_Logo_Horizontal_gsxn3h.png"
                         alt="Logo"
                         width={158}
                         height={26}
@@ -20,7 +20,7 @@ const Logo = ({ variant, className }: TProps) => {
                 )}
                 {variant === "light" && (
                     <img
-                        src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto/f_auto/f_auto/v1627489505/VWC_Logo_Horizontal_gsxn3h.png"
+                        src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto/v1627489505/VWC_Logo_Horizontal_gsxn3h.png"
                         alt="Logo"
                         width={158}
                         height={26}


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at fa8ec0a</samp>

### Summary
:recycle::art::wrench:

<!--
1.  :recycle: This emoji conveys the idea of simplifying or reducing something to its essential parts, which is what the change does by removing unnecessary parameters from the `src` attributes.
2.  :art: This emoji conveys the idea of improving the appearance or style of something, which is what the change does by making the code cleaner and more consistent.
3.  :wrench: This emoji conveys the idea of fixing or adjusting something, which is what the change does by ensuring that the `src` attributes work correctly and match the intended logo images.
-->
Simplified logo image sources in `src/components/logo/index.tsx` to improve code readability and maintainability.

> _A coder who wanted to show_
> _The logo on their website so_
> _They simplified the `src`_
> _And removed the debris_
> _Now the `img` elements glow_

### Walkthrough
*  Simplified the `src` attributes of the `img` elements for the dark and light variants of the logo by removing the redundant `f_auto` parameters ([link](https://github.com/Vets-Who-Code/vets-who-code-app/pull/524/files?diff=unified&w=0#diff-7155f2b59cede823e1f7aad3c3ab350e6bacff959083c48d892be410f4ae87d2L15-R15), [link](https://github.com/Vets-Who-Code/vets-who-code-app/pull/524/files?diff=unified&w=0#diff-7155f2b59cede823e1f7aad3c3ab350e6bacff959083c48d892be410f4ae87d2L23-R23)). This improves the readability and maintainability of the code in `src/components/logo/index.tsx`.

