### PR TITLE
fixed link in footer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,7 @@
     },
     "typescript.tsdk": "./node_modules/typescript/lib",
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "files.associations": {
         "*.scss": "postcss"

--- a/src/components/widgets/two-col-list-widget.tsx
+++ b/src/components/widgets/two-col-list-widget.tsx
@@ -30,7 +30,7 @@ const TwoColumnListWidget = ({ className, mode }: TProps) => {
                     <Anchor path="/curriculum/subjects">Modules</Anchor>
                 </li>
                 <li className="tw-w-1/2 tw-pr-5 tw-mb-[11px]">
-                    <Anchor path="/about-us-01">About us</Anchor>
+                    <Anchor path="/about-us">About us</Anchor>
                 </li>
                 <li className="tw-w-1/2 tw-pr-5 tw-mb-[11px]">
                     <Anchor path="/contact-us">Contact us</Anchor>


### PR DESCRIPTION
### Summary

This PR addresses the issue of the broken 'About Us' link found in the website's footer. The link was not correctly redirecting to the 'About Us' page due to an incorrect URL path.

### Changes

- Updated the href attribute in the footer's 'About Us' link to point to the correct URL.
- Verified that the updated link navigates to the 'About Us' page as expected.

### How to Test

1. Navigate to the website's homepage.
2. Scroll down to the footer section.
3. Click on the 'About Us' link.
4. Ensure that it successfully redirects to the 'About Us' page without any errors.
