### PR TITLE
Add EIN to the website footer #542

### DIFF
--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -50,7 +50,7 @@ const Footer01 = ({ mode }: TProps) => {
                         All Rights Reserved
                     </a>
                 </p>
-                <p className="copyright tw-text-center tw-text-md tw-text-gray-400 tw-mt-5" style={{ marginTop: '-5px' }} >
+                <p className="copyright tw-text-center tw-text-md tw-text-gray-400 mt-n5">
                     Vets Who Code is a registered 501(c)(3) nonprofit under EIN 86-2122804. Donations are tax-deductible to the fullest extent allowable under the law.
                 </p>
             </div>

--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -50,6 +50,9 @@ const Footer01 = ({ mode }: TProps) => {
                         All Rights Reserved
                     </a>
                 </p>
+                <p className="copyright tw-text-center tw-text-md tw-text-gray-400 tw-mt-5" style={{ marginTop: '-5px' }} >
+                    Vets Who Code is a registered 501(c)(3) nonprofit under EIN 86-2122804. Donations are tax-deductible to the fullest extent allowable under the law.
+                </p>
             </div>
         </footer>
     );


### PR DESCRIPTION
Problem:
The website currently does not show the nonprofit EIN on the website

Solution:
At the footer, place the following statement about the copyright info, perhaps centered to the website or near the Candid image. It just needs to look good at all sizes!

Vets Who Code is a registered 501(c)(3) nonprofit under EIN 86-2122804. Donations are tax-deductible to the fullest extent allowable under the law.

I placed the statement by borrowing a className and modifying the margin-top of the <p> tag:  
![Screen Shot 2024-02-22 at 8 17 18 PM](https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/38644102-f7d5-4e1d-970a-c83d05a285d5)

This is how it looks on the website:
<img width="918" alt="Screen Shot 2024-02-22 at 8 17 58 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/22f49cbd-8f67-4aca-9395-05f95d514d68">
