### PR TITLE
#554 Header looks different on inner pages; needs to be same

### DIFF
--- a/src/containers/course-details/index.tsx
+++ b/src/containers/course-details/index.tsx
@@ -21,7 +21,7 @@ const CourseDetails = ({
 }: TProps) => {
 
     return (
-        <> 
+        <>
         <section className="course-details">
             <div className="tw-container tw-grid lg:tw-grid-cols-3 tw-gap-12">
                 <div className="lg:tw-col-[1/3]">
@@ -57,7 +57,6 @@ const CourseDetails = ({
                 </div>
             </div>
         </section>
-
 </>
     );
 };

--- a/src/containers/course-details/index.tsx
+++ b/src/containers/course-details/index.tsx
@@ -19,7 +19,9 @@ type TProps = {
 const CourseDetails = ({
     data: { course, curriculum, instructor },
 }: TProps) => {
+
     return (
+        <> 
         <section className="course-details">
             <div className="tw-container tw-grid lg:tw-grid-cols-3 tw-gap-12">
                 <div className="lg:tw-col-[1/3]">
@@ -55,6 +57,8 @@ const CourseDetails = ({
                 </div>
             </div>
         </section>
+
+</>
     );
 };
 

--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -50,7 +50,7 @@ const Footer01 = ({ mode }: TProps) => {
                         All Rights Reserved
                     </a>
                 </p>
-                <p className="copyright tw-text-center tw-text-md tw-text-gray-400 tw-mt-5" style={{ marginTop: '-5px' }} >
+                <p className="copyright tw-text-center tw-text-md tw-text-gray-400 mt-n5">
                     Vets Who Code is a registered 501(c)(3) nonprofit under EIN 86-2122804. Donations are tax-deductible to the fullest extent allowable under the law.
                 </p>
             </div>

--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -50,6 +50,9 @@ const Footer01 = ({ mode }: TProps) => {
                         All Rights Reserved
                     </a>
                 </p>
+                <p className="copyright tw-text-center tw-text-md tw-text-gray-400 tw-mt-5" style={{ marginTop: '-5px' }} >
+                    Vets Who Code is a registered 501(c)(3) nonprofit under EIN 86-2122804. Donations are tax-deductible to the fullest extent allowable under the law.
+                </p>
             </div>
         </footer>
     );

--- a/src/pages/curriculum/[slug].tsx
+++ b/src/pages/curriculum/[slug].tsx
@@ -1,6 +1,6 @@
 import type { GetStaticPaths, NextPage } from "next";
 import SEO from "@components/seo/page-seo";
-import Layout01 from "@layout/layout-02";
+import Layout01 from "@layout/layout-01";
 import Breadcrumb from "@components/breadcrumb";
 import CourseDetails from "@containers/course-details";
 import { ICourse, IInstructor, ICurriculum } from "@utils/types";


### PR DESCRIPTION
Problem:  
When you click on the pages available from the Modules page: https://vetswhocode.io/curriculum/subjectsthe header looks different from what's on all the other pages. (See homepage for the right example)
The header needs to remain the same across all pages of this webapp.

Solution:

On src/pages/curriculum/[slug].tsx, I saw an inconsistency on line number 3: import Layout01 from "@layout/layout-02";
I changed it to import Layout01 from "@layout/layout-01";

Now, we can see the same header across all pages on Modules.

Before:
<img width="965" alt="Screen Shot 2024-03-11 at 9 00 28 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/e958331e-9cfd-40c8-9d45-e5718cc3f030">

After:
<img width="1440" alt="Screen Shot 2024-03-11 at 8 57 56 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/71cbaac1-d560-42c1-97d9-a51c1002cf2f">
<img width="1434" alt="Screen Shot 2024-03-11 at 8 58 13 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/c21c702b-304f-4d44-a963-274e7b72a52c">
<img width="1434" alt="Screen Shot 2024-03-11 at 8 58 26 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/e210f6cd-ae13-4bba-9ba1-7727f3a45bfb">
<img width="1440" alt="Screen Shot 2024-03-11 at 8 58 48 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/0a584612-bd6c-4cfa-acfb-1d168fabad42">
<img width="1439" alt="Screen Shot 2024-03-11 at 8 59 00 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/113d738d-2a15-44d1-a661-f52b63ccd00b">
<img width="1438" alt="Screen Shot 2024-03-11 at 8 59 10 PM" src="https://github.com/Vets-Who-Code/vets-who-code-app/assets/49660565/04376912-046e-424d-8454-6d569ab28c1c">



