### PR TITLE
updated playwright.yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,59 @@
 name: Playwright Tests
+
 on:
-    push:
-        branches: [main, master]
-    pull_request:
-        branches: [main, master]
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
 jobs:
-    test:
-        timeout-minutes: 60
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-            - name: Install dependencies
-              run: yarn
-            - name: Install Playwright Browsers
-              run: yarn playwright install --with-deps
-            - name: Run Playwright tests
-              run: yarn playwright test
-            - uses: actions/upload-artifact@v3
-              if: always()
-              with:
-                  name: playwright-report
-                  path: playwright-report/
-                  retention-days: 30
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # This path is platform dependent; use **/node_modules for Windows
+          path: |
+            node_modules
+            **/node_modules
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          
+      - name: Install dependencies
+        run: yarn
+        
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: yarn playwright test
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30


### PR DESCRIPTION
This pull request includes improvements to the GitHub Actions workflow for Playwright tests. The changes primarily focus on adding caching for node modules and Playwright browsers to speed up the test runs. 

Here is a summary of the key changes:

* [`.github/workflows/playwright.yml`](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R2-R53): Added caching for node modules using `actions/cache@v2`. This caches the `node_modules` directory based on the hash of the `yarn.lock` file, which will speed up the installation of dependencies in future runs if the `yarn.lock` file hasn't changed.
* [`.github/workflows/playwright.yml`](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3R2-R53): Added caching for Playwright browsers. This caches the `~/.cache/ms-playwright` directory, which contains the browser binaries used by Playwright. This will speed up the installation of Playwright browsers in future runs.