### PR TITLE
 add url to site conifg

### DIFF
--- a/src/data/site-config.ts
+++ b/src/data/site-config.ts
@@ -3,5 +3,5 @@ export default {
     titleTemplate: "%s | Vets Who Code",
     description:
         "Vets Who Code is a non-profit organization that provides free technical training to veterans and their spouses.",
-    url: "https://yourwebsite.com", // Add the URL property here
+    url: "https://vetswhocode.io", // Add the URL property here
 };


### PR DESCRIPTION
This pull request includes a small but important change to the `src/data/site-config.ts` file. The change updates the `url` property to reflect the correct website URL for Vets Who Code.

* [`src/data/site-config.ts`](diffhunk://#diff-a189ae4d1657207fdc4f87e5f7711375f6b9964def6f8e1a8e4b1cb8265d334aL6-R6): Updated the `url` property from `"https://yourwebsite.com"` to `"https://vetswhocode.io"`.