### PR TITLE
Add application question for prior bootcamps or programs

### DIFF
--- a/src/components/forms/apply-form.tsx
+++ b/src/components/forms/apply-form.tsx
@@ -47,7 +47,6 @@ const ApplyForm = () => {
     const watchHasAttendedPreviousCourses = watch("hasAttendedPreviousCourse", false);
     const watchWillAttendAnotherCourse = watch("willAttendAnotherCourse", false);
 
-
     const onSubmit: SubmitHandler<IFormValues> = async (data) => {
         try {
             await axios.post("/api/apply", data);
@@ -249,7 +248,7 @@ const ApplyForm = () => {
                         </label>
                         <TextArea
                             id="previousCourses"
-                            placeholder="Fundamentals of Spouse Stealing"
+                            placeholder="Javascript 101"
                             bg="light"
                             feedbackText={errors?.previousCourses?.message}
                             state={hasKey(errors, "previousCourses") ? "error" : "success"}
@@ -280,7 +279,7 @@ const ApplyForm = () => {
                         </label>
                         <TextArea
                             id="otherCourses"
-                            placeholder="Fundamentals of Spouse Stealing"
+                            placeholder="Civvies Who Code"
                             bg="light"
                             feedbackText={errors?.otherCourses?.message}
                             state={hasKey(errors, "otherCourses") ? "error" : "success"}

--- a/src/components/forms/apply-form.tsx
+++ b/src/components/forms/apply-form.tsx
@@ -3,10 +3,13 @@ import { useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import axios from "axios";
 import Input from "@ui/form-elements/input";
+import Checkbox from "@ui/form-elements/checkbox";
+import TextArea from "@ui/form-elements/textarea";
 import Button from "@ui/button";
 import { hasKey } from "@utils/methods";
 import Feedback from "@ui/form-elements/feedback";
 import { linkedinRegex, githubRegex } from "@utils/formValidations";
+import { motion } from "framer-motion";
 
 interface IFormValues {
     firstName: string;
@@ -19,6 +22,8 @@ interface IFormValues {
     branchOfService: string;
     yearJoined: string;
     yearSeparated: string;
+    hasAttendedPreviousCourse: boolean;
+    previousCourses: string;
     linkedInAccountName: string;
     githubAccountName: string;
     preworkLink: string;
@@ -34,7 +39,10 @@ const ApplyForm = () => {
         handleSubmit,
         formState: { errors },
         reset,
+        watch,
     } = useForm<IFormValues>();
+
+    const watchHasAttendedPreviousCourses = watch("hasAttendedPreviousCourse", false);
 
     const onSubmit: SubmitHandler<IFormValues> = async (data) => {
         try {
@@ -219,7 +227,36 @@ const ApplyForm = () => {
                         })}
                     />
                 </div>
-                <div className="tw-mb-7.5">
+                <Checkbox
+                    label="Have you previously attended any coding bootcamps or tech education programs?"
+                    id="hasAttendedPreviousCourse"
+                    {...register("hasAttendedPreviousCourse")}
+                />
+                <br />
+                {watchHasAttendedPreviousCourses && (
+                    <motion.div
+                        layout
+                        className="tw-mb-7.5"
+                        initial={{ opacity: 0, scale: 0.4 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                    >
+                        <label htmlFor="previousCourses" className="tw-text-heading tw-text-md">
+                            Previous Courses *
+                        </label>
+                        <TextArea
+                            id="previousCourses"
+                            placeholder="Fundamentals of Spouse Stealing"
+                            bg="light"
+                            feedbackText={errors?.previousCourses?.message}
+                            state={hasKey(errors, "previousCourses") ? "error" : "success"}
+                            showState={!!hasKey(errors, "previousCourses")}
+                            {...register("previousCourses", {
+                                required: "List previous coursework or uncheck the box",
+                            })}
+                        />
+                    </motion.div>
+                )}
+                <motion.div layout className="tw-mb-7.5">
                     <label htmlFor="linkedInAccountName" className="tw-text-heading tw-text-md">
                         LinkedIn Account Name *
                     </label>
@@ -239,8 +276,8 @@ const ApplyForm = () => {
                             },
                         })}
                     />
-                </div>
-                <div className="tw-mb-7.5">
+                </motion.div>
+                <motion.div layout className="tw-mb-7.5">
                     <label htmlFor="githubAccountName" className="tw-text-heading tw-text-md">
                         GitHub Account Name *
                     </label>
@@ -260,8 +297,8 @@ const ApplyForm = () => {
                             },
                         })}
                     />
-                </div>
-                <div className="tw-mb-7.5">
+                </motion.div>
+                <motion.div layout className="tw-mb-7.5">
                     <label htmlFor="preworkLink" className="tw-text-heading tw-text-md">
                         Prework Link *
                     </label>
@@ -276,8 +313,8 @@ const ApplyForm = () => {
                             required: "Prework Link is required",
                         })}
                     />
-                </div>
-                <div className="tw-mb-7.5">
+                </motion.div>
+                <motion.div layout className="tw-mb-7.5">
                     <label htmlFor="preworkRepo" className="tw-text-heading tw-text-md">
                         Prework Repository *
                     </label>
@@ -292,17 +329,19 @@ const ApplyForm = () => {
                             required: "Prework Repository is required",
                         })}
                     />
-                </div>
+                </motion.div>
 
-                <Button
-                    type="submit"
-                    fullwidth
-                    className="tw-mx-auto tw-w-full sm:tw-w-[200px] tw-mt-7.5"
-                >
-                    Apply
-                </Button>
-                {message && <Feedback state="success">{message}</Feedback>}
-                {showEmojiRain && <EmojiRain />}
+                <motion.div layout>
+                    <Button
+                        type="submit"
+                        fullwidth
+                        className="tw-mx-auto tw-w-full sm:tw-w-[200px] tw-mt-7.5"
+                    >
+                        Apply
+                    </Button>
+                    {message && <Feedback state="success">{message}</Feedback>}
+                    {showEmojiRain && <EmojiRain />}
+                </motion.div>
             </form>
         </div>
     );

--- a/src/components/forms/apply-form.tsx
+++ b/src/components/forms/apply-form.tsx
@@ -24,6 +24,8 @@ interface IFormValues {
     yearSeparated: string;
     hasAttendedPreviousCourse: boolean;
     previousCourses: string;
+    willAttendAnotherCourse: boolean;
+    otherCourses: string;
     linkedInAccountName: string;
     githubAccountName: string;
     preworkLink: string;
@@ -43,6 +45,8 @@ const ApplyForm = () => {
     } = useForm<IFormValues>();
 
     const watchHasAttendedPreviousCourses = watch("hasAttendedPreviousCourse", false);
+    const watchWillAttendAnotherCourse = watch("willAttendAnotherCourse", false);
+
 
     const onSubmit: SubmitHandler<IFormValues> = async (data) => {
         try {
@@ -241,7 +245,7 @@ const ApplyForm = () => {
                         animate={{ opacity: 1, scale: 1 }}
                     >
                         <label htmlFor="previousCourses" className="tw-text-heading tw-text-md">
-                            Previous Courses *
+                            List previous courses *
                         </label>
                         <TextArea
                             id="previousCourses"
@@ -252,6 +256,37 @@ const ApplyForm = () => {
                             showState={!!hasKey(errors, "previousCourses")}
                             {...register("previousCourses", {
                                 required: "List previous coursework or uncheck the box",
+                            })}
+                        />
+                    </motion.div>
+                )}
+                <motion.div layout>
+                    <Checkbox
+                        label="Will you be attending any other courses or programs concurrently with Vets Who Code?"
+                        id="willAttendAnotherCourse"
+                        {...register("willAttendAnotherCourse")}
+                    />
+                    <br />
+                </motion.div>
+                {watchWillAttendAnotherCourse && (
+                    <motion.div
+                        layout
+                        className="tw-mb-7.5"
+                        initial={{ opacity: 0, scale: 0.4 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                    >
+                        <label htmlFor="otherCourses" className="tw-text-heading tw-text-md">
+                            List concurrent courses/programs *
+                        </label>
+                        <TextArea
+                            id="otherCourses"
+                            placeholder="Fundamentals of Spouse Stealing"
+                            bg="light"
+                            feedbackText={errors?.otherCourses?.message}
+                            state={hasKey(errors, "otherCourses") ? "error" : "success"}
+                            showState={!!hasKey(errors, "otherCourses")}
+                            {...register("otherCourses", {
+                                required: "List concurrent coursework or uncheck the box",
                             })}
                         />
                     </motion.div>

--- a/src/pages/api/apply.ts
+++ b/src/pages/api/apply.ts
@@ -14,6 +14,8 @@ interface ParsedBody {
     branchOfService?: string;
     yearJoined?: string;
     yearSeparated?: string;
+    hasAttendedPreviousCourse?: boolean;
+    previousCourses?: string;
     linkedInAccountName?: string;
     githubAccountName?: string;
     preworkLink?: string;
@@ -34,6 +36,7 @@ export default async function handler(req: Request, res: Response) {
             "branchOfService",
             "yearJoined",
             "yearSeparated",
+            "hasAttendedPreviousCourse",
             "linkedInAccountName",
             "githubAccountName",
             "preworkLink",
@@ -48,7 +51,7 @@ export default async function handler(req: Request, res: Response) {
         }
 
         // Construct the text message to be sent
-        const text = [
+        const items = [
             `First Name: \`${parsedBody.firstName ?? ""}\``,
             `Last Name: \`${parsedBody.lastName ?? ""}\``,
             `Email: \`${parsedBody.email ?? ""}\``,
@@ -59,11 +62,20 @@ export default async function handler(req: Request, res: Response) {
             `Branch of Service: \`${parsedBody.branchOfService ?? ""}\``,
             `Year Joined: \`${parsedBody.yearJoined ?? ""}\``,
             `Year Separated: \`${parsedBody.yearSeparated ?? ""}\``,
+            `Has attended previous bootcamp/programs: \`${
+                parsedBody.hasAttendedPreviousCourse ? "Yes" : "No"
+            }\``,
             `LinkedIn Account Name: \`${parsedBody.linkedInAccountName ?? ""}\``,
             `GitHub Account Name: \`${parsedBody.githubAccountName ?? ""}\``,
             `Prework Link: \`${parsedBody.preworkLink ?? ""}\``,
             `Prework Repository: \`${parsedBody.preworkRepo ?? ""}\``,
-        ].join("\n");
+        ];
+
+        if (parsedBody.hasAttendedPreviousCourse && parsedBody.previousCourses !== "") {
+            items.splice(11, 0, `\`\`\`${parsedBody.previousCourses}\`\`\``);
+        }
+
+        const text = items.join("\n");
 
         // Send the payload to the configured Slack webhook URL
         await axios.post(

--- a/src/pages/api/apply.ts
+++ b/src/pages/api/apply.ts
@@ -16,6 +16,8 @@ interface ParsedBody {
     yearSeparated?: string;
     hasAttendedPreviousCourse?: boolean;
     previousCourses?: string;
+    willAttendAnotherCourse?: boolean;
+    otherCourses?: string;
     linkedInAccountName?: string;
     githubAccountName?: string;
     preworkLink?: string;
@@ -37,6 +39,7 @@ export default async function handler(req: Request, res: Response) {
             "yearJoined",
             "yearSeparated",
             "hasAttendedPreviousCourse",
+            "willAttendAnotherCourse",
             "linkedInAccountName",
             "githubAccountName",
             "preworkLink",
@@ -65,11 +68,18 @@ export default async function handler(req: Request, res: Response) {
             `Has attended previous bootcamp/programs: \`${
                 parsedBody.hasAttendedPreviousCourse ? "Yes" : "No"
             }\``,
+            `Will do other courses/programs concurrently: \`${
+                parsedBody.willAttendAnotherCourse ? "Yes" : "No"
+            }\``,
             `LinkedIn Account Name: \`${parsedBody.linkedInAccountName ?? ""}\``,
             `GitHub Account Name: \`${parsedBody.githubAccountName ?? ""}\``,
             `Prework Link: \`${parsedBody.preworkLink ?? ""}\``,
             `Prework Repository: \`${parsedBody.preworkRepo ?? ""}\``,
         ];
+
+        if (parsedBody.willAttendAnotherCourse && parsedBody.otherCourses !== "") {
+            items.splice(12, 0, `\`\`\`${parsedBody.otherCourses}\`\`\``);
+        }
 
         if (parsedBody.hasAttendedPreviousCourse && parsedBody.previousCourses !== "") {
             items.splice(11, 0, `\`\`\`${parsedBody.previousCourses}\`\`\``);


### PR DESCRIPTION
This pull request adds a field to the student application form to indicated if the applicant has completed any prior bootcamps or programs.

### Implementation
- Adds a checkbox for the applicant to indicate if any prior programs have been completed
- If checked, a text area will show where programs may be listed. If the checkbox is checked, entering text into the text box is required. The text area will animate into view as the check box is checked.
- All fields below the text area will animate up or down as the check box is checked or unchecked.
- Relevant fields added to `/api/apply` endpoint and the corresponding slack channel output

### Affected files
- /src/components/forms/apply-form.tsx
- /src/pages/api/apply.ts

Resolves #595 