### PR TITLE
 Add YouTube link to Social and Text widgets

### DIFF
--- a/src/components/socials/social-01.tsx
+++ b/src/components/socials/social-01.tsx
@@ -23,6 +23,13 @@ const Social01 = ({ className }: { className?: string }) => (
         >
             <i className="fab fa-linkedin" />
         </SocialLink>
+        <SocialLink
+            href="https://www.youtube.com/@vetswhocode"
+            label="youtube"
+            className="tw-px-2.5"
+        >
+            <i className="fab fa-youtube" />
+        </SocialLink>
     </Social>
 );
 

--- a/src/components/widgets/text-widget.tsx
+++ b/src/components/widgets/text-widget.tsx
@@ -41,6 +41,9 @@ const TextWidget = ({ className, mode }: TProps) => {
                 <SocialLink href="https://www.linkedin.com/company/vets-who-code" label="linkedin">
                     <i className="fab fa-linkedin" />
                 </SocialLink>
+                <SocialLink href="https://www.youtube.com/@vetswhocode" label="youtube">
+                    <i className="fab fa-youtube" />
+                </SocialLink>
             </Social>
         </div>
     );


### PR DESCRIPTION
This pull request includes changes to add a YouTube social link to two components in the codebase. The most important changes are as follows:

Enhancements to social links:

* [`src/components/socials/social-01.tsx`](diffhunk://#diff-315482d1901b9fb0da16f827ddb580415a462a68a2d1e9ab3b4bd99e23bd59baR26-R32): Added a YouTube social link with the label "youtube" and the class "tw-px-2.5".
* [`src/components/widgets/text-widget.tsx`](diffhunk://#diff-3c657162d8684b6ca181afa80dd4df2d05e76f7b6add3523ce5f35266e1c585aR44-R46): Added a YouTube social link with the label "youtube".