### PR TITLE
Update hero-area image source

### DIFF
--- a/src/data/homepages/index.json
+++ b/src/data/homepages/index.json
@@ -45,7 +45,7 @@
             "images": [
                 {
                     "id":1,
-                    "src": "https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto/v1710539370/vetswhocode-navyblue-banner.jpg"
+                    "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1746070172/2_zc19qj.png"
                 }
             ],
             "video": {


### PR DESCRIPTION
This pull request includes a small update to the `src/data/homepages/index.json` file, replacing the source URL of an image with a new one.

* [`src/data/homepages/index.json`](diffhunk://#diff-4e2e270fa5735804889bde55c23721dc839113a9eeee178b0c09c1a03787dd0aL48-R48): Updated the `src` field of the image with `id: 1` to use a new Cloudinary URL for the image.