### PR TITLE
Update image sources in course-area section

### DIFF
--- a/src/data/homepages/index.json
+++ b/src/data/homepages/index.json
@@ -60,7 +60,7 @@
                     "id": 1,
                     "images": [
                         {
-                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto/v1678667460/website-images/vetswhocode-remote.jpg"
+                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1746105264/9_xwkdus.png"
                         }
                     ],
                     "title": "Remote-First Learning",
@@ -72,7 +72,7 @@
                     "id": 2,
                     "images": [
                         {
-                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto/v1678667458/website-images/vetswhocode-self-paced.jpg"
+                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1746105263/5_beplkr.png"
                         }
                     ],
                     "title": "Develop Cutting-Edge Skills",
@@ -84,7 +84,7 @@
                     "id": 3,
                     "images": [
                         {
-                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto/v1678667458/website-images/vetswhocode-learn-with-peers.jpg"
+                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1746105262/1_tvrmfb.png"
                         }
                     ],
                     "title": "A Lifelong Community of Support",


### PR DESCRIPTION
This pull request updates image URLs in the `src/data/homepages/index.json` file to use new Cloudinary paths. These changes ensure that the homepage visuals are updated with the latest assets.

Image URL updates:

* Updated the image URL for the "Remote-First Learning" section to a new Cloudinary path.
* Updated the image URL for the "Develop Cutting-Edge Skills" section to a new Cloudinary path.
* Updated the image URL for the "A Lifelong Community of Support" section to a new Cloudinary path.