### PR TITLE
fix og

### DIFF
--- a/src/components/seo/deafult-seo.tsx
+++ b/src/components/seo/deafult-seo.tsx
@@ -16,14 +16,14 @@ const DefaultSEO = () => {
                 images: [
                     {
                         url: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
-                        width: 800,
-                        height: 600,
+                        width: 1200,
+                        height: 630,
                         alt: "Og Image Alt",
                     },
                     {
                         url: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
-                        width: 900,
-                        height: 800,
+                        width: 1230,
+                        height: 630,
                         alt: "Og Image Alt Second",
                     },
                 ],

--- a/src/components/seo/deafult-seo.tsx
+++ b/src/components/seo/deafult-seo.tsx
@@ -15,13 +15,13 @@ const DefaultSEO = () => {
                 site_name: siteConfig.name,
                 images: [
                     {
-                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1746152938/vwc-logo_fs7bon.png",
+                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
                         width: 800,
                         height: 600,
                         alt: "Og Image Alt",
                     },
                     {
-                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1746152938/vwc-logo_fs7bon.png",
+                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
                         width: 900,
                         height: 800,
                         alt: "Og Image Alt Second",
@@ -53,7 +53,7 @@ const DefaultSEO = () => {
             additionalLinkTags={[
                 {
                     rel: "apple-touch-icon",
-                    href: "https://res.cloudinary.com/vetswhocode/image/upload/v1746152938/vwc-logo_fs7bon.png",
+                    href: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
                 },
                 {
                     rel: "manifest",

--- a/src/components/seo/deafult-seo.tsx
+++ b/src/components/seo/deafult-seo.tsx
@@ -15,13 +15,13 @@ const DefaultSEO = () => {
                 site_name: siteConfig.name,
                 images: [
                     {
-                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1656268751/favicon_dpiacy.png",
+                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1746152938/vwc-logo_fs7bon.png",
                         width: 800,
                         height: 600,
                         alt: "Og Image Alt",
                     },
                     {
-                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1656268751/favicon_dpiacy.png",
+                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1746152938/vwc-logo_fs7bon.png",
                         width: 900,
                         height: 800,
                         alt: "Og Image Alt Second",
@@ -53,7 +53,7 @@ const DefaultSEO = () => {
             additionalLinkTags={[
                 {
                     rel: "apple-touch-icon",
-                    href: "https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto/v1656268751/favicon_dpiacy.png",
+                    href: "https://res.cloudinary.com/vetswhocode/image/upload/v1746152938/vwc-logo_fs7bon.png",
                 },
                 {
                     rel: "manifest",

--- a/src/components/seo/page-seo.tsx
+++ b/src/components/seo/page-seo.tsx
@@ -39,14 +39,14 @@ const PageSeo = ({
         images: [
             {
                 url: image as string,
-                width: 800,
-                height: 600,
+                width: 1230,
+                height: 630,
                 alt: title,
             },
             {
                 url: image as string,
-                width: 900,
-                height: 800,
+                width: 1230,
+                height: 630,
                 alt: title,
             },
         ],

--- a/src/pages/events/[slug].tsx
+++ b/src/pages/events/[slug].tsx
@@ -27,13 +27,13 @@ const SingleEvent: PageProps = ({ data: { event } }) => {
                     type: "article",
                     images: [
                         {
-                            url: `https://vetswhocode.io-react.pages.dev${event.thumbnail.src}`,
+                            url: `https://vetswhocode.io${event.thumbnail.src}`,
                             width: 800,
                             height: 600,
                             alt: event.title,
                         },
                         {
-                            url: `https://vetswhocode.io-react.pages.dev${event.thumbnail.src}`,
+                            url: `https://vetswhocode.io${event.thumbnail.src}`,
                             width: 900,
                             height: 800,
                             alt: event.title,

--- a/src/pages/subjects/[slug].tsx
+++ b/src/pages/subjects/[slug].tsx
@@ -30,13 +30,13 @@ const SingleCourse: PageProps = ({ data: { course, instructor, relatedCourses } 
                     type: "website",
                     images: [
                         {
-                            url: `https://maxcoach-react.pages.dev${course.thumbnail.src}`,
+                            url: `https://vetswhocode.io${course.thumbnail.src}`,
                             width: 800,
                             height: 600,
                             alt: course.title,
                         },
                         {
-                            url: `https://maxcoach-react.pages.dev${course.thumbnail.src}`,
+                            url: `https://vetswhocode.io${course.thumbnail.src}`,
                             width: 900,
                             height: 800,
                             alt: course.title,

--- a/src/pages/zoom-meetings/[slug].tsx
+++ b/src/pages/zoom-meetings/[slug].tsx
@@ -26,13 +26,13 @@ const ZoomMeetingDetails: PageProps = ({ data: { zoomMeeting } }) => {
                     type: "website",
                     images: [
                         {
-                            url: `https://vetswhocode.io-react.pages.dev${zoomMeeting.thumbnail.src}`,
+                            url: `https://vetswhocode.io${zoomMeeting.thumbnail.src}`,
                             width: 800,
                             height: 600,
                             alt: zoomMeeting.title,
                         },
                         {
-                            url: `https://vetswhocode.io-react.pages.dev${zoomMeeting.thumbnail.src}`,
+                            url: `https://vetswhocode.io${zoomMeeting.thumbnail.src}`,
                             width: 900,
                             height: 800,
                             alt: zoomMeeting.title,

--- a/src/pages/zoom-meetings/[slug].tsx
+++ b/src/pages/zoom-meetings/[slug].tsx
@@ -27,14 +27,14 @@ const ZoomMeetingDetails: PageProps = ({ data: { zoomMeeting } }) => {
                     images: [
                         {
                             url: `https://vetswhocode.io${zoomMeeting.thumbnail.src}`,
-                            width: 800,
-                            height: 600,
+                            width: 1230,
+                            height: 630,
                             alt: zoomMeeting.title,
                         },
                         {
                             url: `https://vetswhocode.io${zoomMeeting.thumbnail.src}`,
-                            width: 900,
-                            height: 800,
+                            width: 1230,
+                            height: 630,
                             alt: zoomMeeting.title,
                         },
                     ],


### PR DESCRIPTION
This pull request updates various URLs in the codebase to use the correct domain and assets for images and icons. The changes primarily focus on improving consistency and ensuring that the correct branding assets are used across the application.

### Updates to branding assets:

* [`src/components/seo/deafult-seo.tsx`](diffhunk://#diff-aa4f54df8958a583e79cf202b875017a423b3dbd4198be6f73db17d1173be275L18-R24): Updated the Open Graph image URLs and the `apple-touch-icon` link to use the new `vwc-logo_fs7bon.png` asset hosted on Cloudinary. [[1]](diffhunk://#diff-aa4f54df8958a583e79cf202b875017a423b3dbd4198be6f73db17d1173be275L18-R24) [[2]](diffhunk://#diff-aa4f54df8958a583e79cf202b875017a423b3dbd4198be6f73db17d1173be275L56-R56)

### Updates to domain references:

* `src/pages/events/[slug].tsx`: Replaced the `vetswhocode.io-react.pages.dev` domain with `vetswhocode.io` for event thumbnail URLs in Open Graph metadata. ([src/pages/events/[slug].tsxL30-R36](diffhunk://#diff-e8ee9c8359983c355bd43be6339feced5ac8fc1f1ef0cda0f7f3026f0efcfd6cL30-R36))
* `src/pages/subjects/[slug].tsx`: Replaced the `maxcoach-react.pages.dev` domain with `vetswhocode.io` for course thumbnail URLs in Open Graph metadata. ([src/pages/subjects/[slug].tsxL33-R39](diffhunk://#diff-cc9f25dda8520528d0f679754957abceffc1fbc1fcf07e6e6c08edad95613c02L33-R39))
* `src/pages/zoom-meetings/[slug].tsx`: Replaced the `vetswhocode.io-react.pages.dev` domain with `vetswhocode.io` for Zoom meeting thumbnail URLs in Open Graph metadata. ([src/pages/zoom-meetings/[slug].tsxL29-R35](diffhunk://#diff-9397bb21cc1214e727fe66cb4432d087ad20312faeec26ff170e1e2f5a640e2aL29-R35))