### PR TITLE
Add new mentorship program details and audio brief for veterans

### DIFF
--- a/src/data/blogs/updated-mentor-program.md
+++ b/src/data/blogs/updated-mentor-program.md
@@ -1,0 +1,116 @@
+---
+title: "Empowering Veterans in 2025: The Vets Who Code Mentorship Program"
+postedAt: "2025-05-05T00:00:00.000Z"
+author: "Jerome Hardaway"
+description: "Why Vets Who Code’s new mentorship model is changing the game for veteran developers by focusing on tactical guidance from recently transitioned engineers."
+image:
+    {
+        src: "https://res.cloudinary.com/vetswhocode/image/upload/v1746411634/vwc-mentorship-program_ywhqsa.jpg",
+    }
+category: "Mentorship"
+tags:
+    - veterans
+    - mentorship
+    - software engineering
+    - Vets Who Code
+    - developer careers
+is_featured: true
+---
+
+<div style="background-color: #091f40; color: white; padding: 1.5rem; border-radius: 1rem; max-width: 600px; margin: 2rem auto;">
+  <h2 style="font-size: 1.25rem; font-weight: 600; display: flex; align-items: center; margin-bottom: 0.5rem; color: white;">
+    🎙️ <span style="margin-left: 0.5rem;">Vets Who Code Mentorship Audio Brief</span>
+  </h2>
+  <p style="font-size: 0.875rem; color: #cbd5e1; margin-bottom: 1rem;">
+    Learn how our Mentorship Program helps veterans and military spouses break into tech with real support, tactical guidance, and a system built for outcomes.
+  </p>
+  <audio controls style="width: 100%; border-radius: 0.5rem;">
+    <source src="https://res.cloudinary.com/vetswhocode/video/upload/v1746493982/empowering-veterans-in-2025-the-vets-who-code-mentorship-program_ihomfk.m4a" type="audio/mp4" />
+    Your browser does not support the audio element.
+  </audio>
+  <p style="margin-top: 1rem; font-size: 0.875rem;">
+    <a href="https://res.cloudinary.com/vetswhocode/video/upload/v1746493982/empowering-veterans-in-2025-the-vets-who-code-mentorship-program_ihomfk.m4a" target="_blank" rel="noopener noreferrer" style="text-decoration: underline; color: #cbd5e1;">
+      Or open in new tab
+    </a>
+  </p>
+</div>
+
+<p><strong>Time to read: 8 minutes</strong></p>  
+<p><strong>Key Takeaways:</strong></p>
+
+<ul>
+  <li>Why most veteran coding programs are broken—and how we fix it</li>
+  <li>The principle behind our mentorship model and how it supports real growth</li>
+  <li>How to join as a mentor or mentee and what to expect from the program</li>
+</ul>
+
+In 2025, most veteran coding programs still follow the same failed playbook: Pack a classroom with transitioning service members, rush through outdated curriculum, and chase VET TEC dollars while ignoring real outcomes. The result? Veterans left holding certificates but lacking the practical skills employers demand.
+
+As Executive Director of Vets Who Code, I've seen what it takes to help people transition successfully into tech; I've trained over 300 veterans and military spouses and watched many grow into senior engineers, engineering managers, and even mentors themselves. Their success came from something most boot camps don't provide: personalized guidance from developers who remember exactly what it's like to be a few steps behind where they are now. Their practical skills are often outdated, and those promises collapse under real-world pressure without a degree or alumni network to fall back on.
+
+That's why we've evolved our mentorship practice into a fully developed Mentorship Program, built around a simple principle: The best mentor isn't the most experienced developer—it's the one who recently overcame the exact challenges you're facing now.
+
+Unlike traditional programs that pair junior developers with senior engineers who've forgotten what it's like to learn, we match veterans with mentors no more than two years ahead in their journey. It's a high-accountability, outcomes-oriented system designed to pair veterans and military spouses with experienced developers who are close enough in skill level to provide tactical guidance—because that's how people grow. We're talking weekly check-ins, pair programming, and personalized guidance that helps our mentees learn and level up.
+
+### Mentorship That Moves the Needle
+
+This program was born from necessity. Too many boot camps preach practical skills yet fail to teach industry practices. We focus on what matters—things like GitHub fluency, collaborative problem-solving, and building career capital that employers respect.
+
+Whether you're a veteran who wants to accelerate your transition into tech or a developer looking to give back, our program is built to foster mutual growth. It's not just about teaching others—it's about learning how to lead, communicate clearly, and solve problems in real-time.
+
+Here's what you can expect:
+
+- Structured pair programming sessions focused on growth, not perfection.
+- Weekly check-ins that drive accountability and progress.
+- Real mentorship—conversations beyond syntax and into systems thinking, career strategy, and business context.
+- Matching is based on proximity of experience, not arbitrary titles.
+
+### Our Track Record
+
+- 10 Years of experience supporting veterans in tech.
+- 300+ Veterans trained and mentored.
+- 10+ Subjects taught, from frontend engineering to APIs and deployment.
+- 90% Satisfaction Rate—and we aim higher every year.
+
+We've done the work, refined the process, and are now scaling it because every veteran deserves a pathway into tech that doesn't rely on luck, outdated curriculum, or hollow promises.
+
+### How to Join the Vets Who Code Mentorship Program
+
+**Step 1: Determine Your Role**  
+Are you seeking guidance as a mentee or looking to share your expertise as a mentor? If you're a veteran who would qualify as a VWC troop, you're eligible to apply as a mentee. Mentors must have no more than two years of experience above the mentee's level. This is about relatability and relevance.
+
+**Step 2: Complete the Interest Form**  
+Fill out the mentorship interest form. Whether you're applying as a mentor or mentee, this step is required. Mentees must include a GitHub profile—your code tells a story, and we want to read it.
+
+**Step 3: Profile Review**  
+We assess mentee GitHub portfolios to gauge experience. This isn't about judgment—it's about accurate pairing.
+
+**Step 4: Interview**  
+Every applicant will undergo a short interview with our team. We're here to align expectations, understand your goals, and ensure that you're ready to invest in the process.
+
+**Step 5: Confirm Eligibility**  
+Mentees must be veterans eligible for our program and not currently in a full-time developer role. Paid apprenticeships may qualify. Mentors must be within two years of their matched mentee's experience level.
+
+**Step 6: Self-Assess**  
+You'll complete a brief skill self-assessment during the interview or form process. This helps us build effective mentor/mentee pairs.
+
+**Step 7: Matching**  
+After evaluation, we pair you with a partner based on skill proximity, goals, and learning style. Final approval happens here.
+
+**Step 8: Begin**  
+Once matched, your mentorship begins. Expect structure, community, and progress tracking—we're here to build developers, not just match resumes.
+
+### Why This Matters
+
+The tech industry doesn't need another feel-good veteran initiative. It needs a proven system that turns military precision into engineering excellence. Our mentors aren't just experienced—they're recently experienced. They remember the stumbling blocks because they just cleared them themselves. That's the difference between theoretical guidance and practical acceleration.
+
+This program is about access, accountability, and acceleration. It's where veterans and military spouses find guides who speak their language, understand their challenges, and know exactly how to help them level up—because they just did it themselves.
+
+If you're ready to make tech more inclusive, practical, and purpose-driven—join us.  
+👉 [Apply to the Vets Who Code Mentorship Program](https://vetswhocode.io/mentor)
+
+---
+
+### Support Vets Who Code
+
+If this story resonates with you, consider supporting Vets Who Code to help more veterans transition into successful tech careers. Your donations can make a significant impact. You can also sponsor us on GitHub to get technical updates and support our mission. Together, we can make a difference.


### PR DESCRIPTION
This pull request adds a new blog post to the `src/data/blogs` directory, introducing the updated Vets Who Code Mentorship Program. The blog highlights the program's focus on tactical guidance and practical skills for veterans transitioning into tech careers. Below are the key changes:

### New Blog Post Addition:
* A new markdown file, `updated-mentor-program.md`, has been created with details about the Vets Who Code Mentorship Program, including its goals, structure, and application process. The blog emphasizes mentorship by recently transitioned engineers, weekly check-ins, pair programming, and practical career guidance.

### Content Highlights:
* Key takeaways and benefits of the mentorship program are outlined, such as GitHub fluency, collaborative problem-solving, and career strategy development.
* The blog includes a detailed step-by-step guide for joining the program, covering roles, application, and matching processes.
* An embedded audio brief and call-to-action links are added to enhance engagement and provide additional resources.

This update aims to promote the program and provide veterans with a clear pathway into tech careers.