### PR TITLE
 add vets who code platform launch date

### DIFF
--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -35,11 +35,11 @@ const Header = ({ shadow, fluid }: TProps) => {
                 <div className="header-top tw-bg-gray-200 tw-py-2.5">
                     <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-justify-center">
                         <p className="tw-mb-3.8 tw-flex-100 tw-text-center md:tw-mb-0 md:tw-mr-7.5 md:tw-flex-1 md:tw-text-left">
-                            Our Next Cohort
+                            Platform Launch + Vets Who Code Demo Day
                         </p>
                         <div className="tw-flex tw-items-center sm:tw-mr-[45px] md:tw-mr-5 lg:tw-mr-[45px]">
                             <i className="far fa-clock tw-mr-[5px] tw-text-lg tw-text-secondary" />
-                            <CountdownTimer targetDate="2025/03/03" />
+                            <CountdownTimer targetDate="2025/11/11" />
                         </div>
                         <Button size="xs" path="/donate">
                             Donate


### PR DESCRIPTION
This pull request updates the header component to reflect new event details and adjust the countdown timer accordingly.

Content updates in the header:

* Updated the header text from "Our Next Cohort" to "Platform Launch + Vets Who Code Demo Day" to reflect the new event. (`src/layouts/headers/header.tsx`, [src/layouts/headers/header.tsxL38-R42](diffhunk://#diff-401ed5a5190ad062af3f1fe2918d8224799dc545971905a71ca5fad4ded0bb87L38-R42))
* Changed the `CountdownTimer` target date from "2025/03/03" to "2025/11/11" to align with the updated event schedule. (`src/layouts/headers/header.tsx`, [src/layouts/headers/header.tsxL38-R42](diffhunk://#diff-401ed5a5190ad062af3f1fe2918d8224799dc545971905a71ca5fad4ded0bb87L38-R42))