### PR TITLE
 feat: add Theory of Change page and enhance About Us with a link to it

### DIFF
--- a/src/data/innerpages/about-us.json
+++ b/src/data/innerpages/about-us.json
@@ -206,18 +206,34 @@
             ]
           }
         ]
-      },
-      {
+      },      {
         "section": "cta-area",
         "section_title": {
-          "title": "Your investment today creates tomorrow's software engineers. Every dollar you contribute to #VetsWhoCode doesn't just fund training—it transforms lives, families, and communities. Veterans who complete our program see an average salary increase of 400%, turning military precision into six-figure careers. When you donate, you're not giving charity; you're fueling a proven system that has already generated over twenty million dollars in collective earnings for those who served our country. Our graduates become mentors and donors themselves, creating a self-sustaining cycle of success that multiplies your impact far beyond your initial contribution.<br></br> By 2030, with your help, we'll equip 10,000 veterans with cutting-edge tech skills, generate one billion dollars in lifetime earnings, and prove that nonprofits can scale like startups while maintaining their soul. Unlike traditional programs with high overhead, we're remote-first and tech-enabled—meaning more of your donation goes directly to veteran success. Our AI-augmented learning platform adapts to each veteran's unique background and learning style, maximizing educational outcomes while minimizing costs. Join our mission to transform military experience into tech excellence, close the digital talent gap, and help those who defended our freedom build America's innovation future. Your donation isn't just appreciated—it's leveraged, maximized, and transformed into sustainable careers that honor service through opportunity.",
-          "subtitle": "How can <strong>YOU</strong> join our mission?"
+          "title": "",
+          "subtitle": "Support Vets Who Code"
         },
-        "buttons": [
+        "items": [
           {
             "id": 1,
-            "path": "/donate",
-            "content": "Donate"
+            "headings": [
+              {
+                "id": 1,
+                "content": "Transform Lives Through Technology"
+              }
+            ],
+            "texts": [
+              {
+                "id": 1,
+                "content": "Your contribution directly empowers veterans to build new careers in tech. With your support, we can provide free, high-quality software engineering education that turns military experience into valuable technical skills."
+              },              {
+                "id": 2,
+                "content": "Vets Who Code graduates see an average 400% salary increase, creating lasting financial stability for veterans and their families. By 2030, we aim to equip 10,000 veterans with cutting-edge tech skills and generate $1 billion in lifetime earnings."
+              },
+              {
+                "id": 3,
+                "content": "Whether you donate, volunteer as a mentor, or help spread our mission, you're not just saying 'thank you for your service' — you're investing in veterans' futures and strengthening America's tech workforce."
+              }
+            ]
           }
         ]
       }

--- a/src/data/innerpages/theory-of-change.json
+++ b/src/data/innerpages/theory-of-change.json
@@ -1,0 +1,270 @@
+{
+  "name": "theory-of-change",
+  "content": [
+    {
+      "section": "hero-area",
+      "items": [
+        {
+          "id": 1,
+          "images": [
+            {
+              "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1746590043/9_ahefah.png"
+            }
+          ],
+          "headings": [
+            {
+              "id": 1,
+              "content": "Our Theory <br>of Change"
+            },
+            {
+              "id": 2,
+              "content": "Blueprint for Impact"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "How we transform military experience into software engineering excellence."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "section": "theory-of-change-area",
+      "section_title": {
+        "title": "Vets Who Code — Theory of Change",
+        "subtitle": "A Structured Path from Service to Software"
+      },
+      "items": [
+        {
+          "id": 1,
+          "headings": [
+            {
+              "id": 1,
+              "content": "Core Belief"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "We believe that military experience instills a unique blend of grit, discipline, and adaptive thinking that—when paired with cutting-edge technical training and real-world software development opportunities—produces exceptional software engineers. Our mission is to channel that potential through a proven, product-focused learning ecosystem designed for impact."
+            }
+          ]
+        },
+        {
+          "id": 2,
+          "headings": [
+            {
+              "id": 1,
+              "content": "Inputs"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "We start by identifying highly motivated U.S. military veterans and military spouses ready to transition into tech. Our key inputs include:"
+            },
+            {
+              "id": 2,
+              "content": "A curated selection of veteran learners with high aptitude and drive"
+            },
+            {
+              "id": 3,
+              "content": "The Vets Who Code learning platform, housing our open-source curriculum, projects, and blog"
+            },
+            {
+              "id": 4,
+              "content": "A network of experienced mentors, industry veterans, and alumni coaches"
+            },
+            {
+              "id": 5,
+              "content": "Community infrastructure for remote collaboration and code reviews"
+            },
+            {
+              "id": 6,
+              "content": "Access to development tools, GitHub repositories, and cloud environments"
+            }
+          ]
+        },
+        {
+          "id": 3,
+          "headings": [
+            {
+              "id": 1,
+              "content": "Activities"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "We immerse our learners in a 100% remote-first, product-driven experience that mirrors real software engineering workflows. Our core activities include:"
+            },
+            {
+              "id": 2,
+              "content": "Platform-Based Learning: Learners progress through a rigorous 12-module open-source curriculum hosted on our custom platform, covering everything from core web fundamentals to backend APIs and DevOps."
+            },
+            {
+              "id": 3,
+              "content": "Mentorship & Pair Programming: Each veteran is paired with mentors from our alumni and industry network who guide them through weekly check-ins, code reviews, and career strategy."
+            },
+            {
+              "id": 4,
+              "content": "Open Source Collaboration: Learners contribute to internal and external open-source projects, learning how to write scalable, readable code that integrates into production environments."
+            },
+            {
+              "id": 5,
+              "content": "Product Development: Veterans work on real nonprofit apps, tools, and features—like the PTSD Toolkit and AEGIS—designed to be used by real users. This gives them portfolio-ready projects with real-world scope and impact."
+            },
+            {
+              "id": 6,
+              "content": "Career Development: Weekly resume reviews, GitHub audits, behavioral interview training, and asynchronous job prep help troops present themselves as polished professionals."
+            }
+          ]
+        },
+        {
+          "id": 4,
+          "headings": [
+            {
+              "id": 1,
+              "content": "Outputs"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "By the end of the program, graduates leave with:"
+            },
+            {
+              "id": 2,
+              "content": "A strong GitHub profile reflecting open-source and production-level contributions"
+            },
+            {
+              "id": 3,
+              "content": "Completed software products deployed or used by actual users"
+            },
+            {
+              "id": 4,
+              "content": "Job-ready skills in tools like TypeScript, React, Next.js, Python, FastAPI, Git, and CI/CD workflows"
+            },
+            {
+              "id": 5,
+              "content": "Direct mentorship and professional guidance from engineers already in the field"
+            },
+            {
+              "id": 6,
+              "content": "The confidence and social proof to break into the tech industry"
+            }
+          ]
+        },
+        {
+          "id": 5,
+          "headings": [
+            {
+              "id": 1,
+              "content": "Short- to Medium-Term Outcomes"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "Within 6–12 months, we see:"
+            },
+            {
+              "id": 2,
+              "content": "Veterans hired into six-figure tech roles in software engineering, DevOps, or data roles"
+            },
+            {
+              "id": 3,
+              "content": "Alumni re-engagement as mentors, speakers, and open-source contributors"
+            },
+            {
+              "id": 4,
+              "content": "Economic mobility, especially among underrepresented and minority veterans"
+            },
+            {
+              "id": 5,
+              "content": "Product impact as the tools and apps they've built are used in the real world"
+            },
+            {
+              "id": 6,
+              "content": "Portfolio visibility, helping them stand out in competitive hiring pipelines"
+            }
+          ]
+        },
+        {
+          "id": 6,
+          "headings": [
+            {
+              "id": 1,
+              "content": "Long-Term Impact"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "Over time, our model creates:"
+            },
+            {
+              "id": 2,
+              "content": "A visible, high-performing ecosystem of veteran technologists whose skills are rooted in service and real-world engineering"
+            },
+            {
+              "id": 3,
+              "content": "Generational wealth creation and stability for veteran families"
+            },
+            {
+              "id": 4,
+              "content": "A transformed narrative in tech: veterans aren't just potential hires—they're builders, maintainers, and innovators"
+            },
+            {
+              "id": 5,
+              "content": "A proven, replicable nonprofit model that blends product-based learning with mentorship and community leadership"
+            },
+            {
+              "id": 6,
+              "content": "A more diverse and mission-driven U.S. tech workforce that reflects the values of service, resilience, and contribution"
+            }
+          ]
+        },
+        {
+          "id": 7,
+          "headings": [
+            {
+              "id": 1,
+              "content": "Vision"
+            }
+          ],
+          "texts": [
+            {
+              "id": 1,
+              "content": "We envision a future where every veteran who wants a career in tech has access to the platform, mentorship, and tools they need to succeed. Our platform is not just a curriculum—it's a launchpad. By continuing to build open-source tools that matter, develop products people use, and uplift our own through mentoring and advocacy, Vets Who Code will remain a blueprint for what's possible when service meets software."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "section": "cta-area",
+      "section_title": {
+        "title": "",
+        "subtitle": ""
+      },
+      "items": [
+        {
+          "id": 1,
+          "texts": [
+            {
+              "id": 1,
+              "content": "Your contribution fuels a proven system that has already generated over twenty million dollars in collective earnings for those who served our country. Our graduates become mentors and donors themselves, creating a self-sustaining cycle of success that multiplies your impact far beyond your initial contribution."
+            },
+            {
+              "id": 2,
+              "content": "Unlike traditional programs with high overhead, we're remote-first and tech-enabled—meaning more of your donation goes directly to veteran success. Our AI-augmented learning platform adapts to each veteran's unique background and learning style, maximizing educational outcomes while minimizing costs."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -4,6 +4,7 @@ import Layout from "@layout/layout-01";
 import HeroArea from "@containers/hero/layout-07";
 import TimelineArea from "@containers/timeline";
 import CtaArea from "@containers/cta/layout-01";
+import Link from "next/link";
 import { normalizedData } from "@utils/methods";
 import { getPageData } from "../lib/page";
 
@@ -14,6 +15,21 @@ interface PageContent extends Record<string, unknown> {
     content?: string;
     metadata?: Record<string, unknown>;
     customFields?: Record<string, unknown>;
+    section_title?: {
+        title?: string;
+        subtitle?: string;
+    };
+    items?: Array<{
+        id: number | string;
+        headings?: Array<{ id: number | string; content: string }>;
+        texts?: Array<{ id: number | string; content: string }>;
+        images?: Array<{ src: string }>;
+    }>;
+    buttons?: Array<{
+        id: number | string;
+        content: string;
+        path: string;
+    }>;
 }
 
 type TProps = {
@@ -24,7 +40,6 @@ type TProps = {
     };
 };
 
-// Create a new type that includes both the component and Layout property
 type PageWithLayout = {
     (props: TProps): JSX.Element;
     Layout: typeof Layout;
@@ -35,10 +50,22 @@ const AboutUs: PageWithLayout = ({ data }) => {
 
     return (
         <>
-            <SEO title="About Us" />
+            <SEO title="About Us | Vets Who Code" />
             <h1 className="tw-sr-only">About Us</h1>
             <HeroArea data={content?.["hero-area"]} />
             <TimelineArea data={content?.["timeline-area"]} />
+
+            {/* Theory of Change Link */}
+            <div className="tw-container tw-my-10 tw-text-center">
+                <p className="tw-mb-4 tw-text-lg">Want to understand our methodology in depth?</p>
+                <Link
+                    href="/theory-of-change"
+                    className="tw-inline-block tw-rounded-md tw-bg-primary tw-px-6 tw-py-3 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-secondary"
+                >
+                    View Our Theory of Change
+                </Link>
+            </div>
+
             <CtaArea data={content?.["cta-area"]} space="bottom" />
         </>
     );

--- a/src/pages/theory-of-change.tsx
+++ b/src/pages/theory-of-change.tsx
@@ -1,0 +1,145 @@
+import type { GetStaticProps } from "next";
+import SEO from "@components/seo/page-seo";
+import Layout from "@layout/layout-01";
+import HeroArea from "@containers/hero/layout-07";
+import CtaArea from "@containers/cta/layout-01";
+import { normalizedData } from "@utils/methods";
+import { getPageData } from "../lib/page";
+
+// Base content interface
+interface PageContent extends Record<string, unknown> {
+    section: string;
+    title?: string;
+    content?: string;
+    metadata?: Record<string, unknown>;
+    customFields?: Record<string, unknown>;
+    section_title?: {
+        title?: string;
+        subtitle?: string;
+    };
+    items?: Array<{
+        id: number | string;
+        headings?: Array<{ id: number | string; content: string }>;
+        texts?: Array<{ id: number | string; content: string }>;
+        images?: Array<{ src: string }>;
+    }>;
+    buttons?: Array<{
+        id: number | string;
+        content: string;
+        path: string;
+    }>;
+}
+
+type TProps = {
+    data: {
+        page: {
+            content: PageContent[];
+        };
+    };
+};
+
+type PageWithLayout = {
+    (props: TProps): JSX.Element;
+    Layout: typeof Layout;
+};
+
+const TheoryOfChange: PageWithLayout = ({ data }) => {
+    const content = normalizedData<PageContent>(data.page?.content, "section");
+    const theoryOfChangeData = content?.["theory-of-change-area"];
+
+    return (
+        <>
+            <SEO title="Theory of Change | Vets Who Code" />
+            <h1 className="tw-sr-only">Theory of Change</h1>
+            <HeroArea data={content?.["hero-area"]} />
+
+            {theoryOfChangeData && (
+                <div className="tw-py-15 md:tw-py-20 lg:tw-py-28">
+                    <div className="tw-container">
+                        {theoryOfChangeData.section_title?.title && (
+                            <h2 className="tw-mb-4 tw-text-center tw-text-3xl tw-font-bold md:tw-text-4xl lg:tw-text-5xl">
+                                {theoryOfChangeData.section_title.title}
+                            </h2>
+                        )}
+                        {theoryOfChangeData.section_title?.subtitle && (
+                            <p className="tw-mb-10 tw-text-center tw-text-lg md:tw-mb-16">
+                                {theoryOfChangeData.section_title.subtitle}
+                            </p>
+                        )}
+                        {theoryOfChangeData.items?.map((item, itemIndex) => (
+                            <div key={item.id} className="tw-mb-16 last:tw-mb-0">
+                                {item.headings?.map((heading) => (
+                                    <h3
+                                        key={heading.id}
+                                        className="tw-mb-5 tw-text-2xl tw-font-semibold"
+                                    >
+                                        {heading.content}
+                                    </h3>
+                                ))}
+                                <div className="tw-text-base tw-text-gray-700">
+                                    {item.texts?.map((text, index) => {
+                                        if (item.texts && item.texts.length > 1 && index === 0) {
+                                            return (
+                                                <p key={text.id} className="tw-mb-4">
+                                                    {text.content}
+                                                </p>
+                                            );
+                                        }
+
+                                        if (item.texts && item.texts.length > 1 && index > 0) {
+                                            // For list items after the intro paragraph
+                                            return (
+                                                <div
+                                                    key={text.id}
+                                                    className="tw-mb-3 tw-flex last:tw-mb-0"
+                                                >
+                                                    <div className="tw-mr-2">•</div>
+                                                    <div>{text.content}</div>
+                                                </div>
+                                            );
+                                        }
+
+                                        // For sections with only a single paragraph
+                                        return (
+                                            <p key={text.id} className="tw-mb-4">
+                                                {text.content}
+                                            </p>
+                                        );
+                                    })}
+                                </div>
+
+                                {theoryOfChangeData.items &&
+                                    itemIndex < theoryOfChangeData.items.length - 1 && (
+                                        <hr className="tw-my-10 tw-border-gray-200" />
+                                    )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <CtaArea data={content?.["cta-area"]} space="bottom" />
+        </>
+    );
+};
+
+TheoryOfChange.Layout = Layout;
+
+export const getStaticProps: GetStaticProps = () => {
+    const page = getPageData("inner", "theory-of-change");
+
+    return {
+        props: {
+            data: {
+                page,
+            },
+            layout: {
+                headerShadow: true,
+                headerFluid: false,
+                footerMode: "light",
+            },
+        },
+    };
+};
+
+export default TheoryOfChange;


### PR DESCRIPTION
This pull request introduces significant updates to the "About Us" page and adds a new "Theory of Change" page to the project. The changes enhance content structure, improve user engagement, and extend functionality. Below is a breakdown of the most important updates grouped by theme:

### Content Updates
* Refactored the "About Us" page's call-to-action (CTA) content to simplify and focus messaging, replacing a lengthy description with concise and impactful text.
* Added a new JSON data file (`theory-of-change.json`) to define the content structure for the "Theory of Change" page, including sections for core beliefs, inputs, activities, outputs, outcomes, and long-term impact.

### Functional Enhancements
* Introduced a new `TheoryOfChange` page (`theory-of-change.tsx`) that dynamically renders content based on the new JSON data file, including support for headings, text, and lists.
* Added a link on the "About Us" page to navigate to the "Theory of Change" page, improving discoverability of the new content.

### Code Structure and Typing Improvements
* Updated the `PageContent` interface in `about-us.tsx` to support new content fields like `section_title`, `items`, and `buttons`, ensuring consistent data handling across pages.
* Added the `Link` component from `next/link` to the "About Us" page to enable navigation to the new page.

These changes collectively improve the user experience by providing clearer messaging, adding valuable new content, and enhancing navigation between related pages.