### PR TITLE
 fix: update Candid seal image and link to transparency seal

### DIFF
--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -33,11 +33,17 @@ const Footer01 = ({ mode }: TProps) => {
                         className="tw-col-span-12 tw-mb-7.5 md:tw-col-span-5 lg:tw-col-span-3"
                     />
                     <div className="sm:tw-col-span-2 xl:tw-col-span-1 maxSm:tw-col-span-3">
-                        <img
-                            src="https://res.cloudinary.com/vetswhocode/image/upload/v1705549609/candid-seal-platinum-2024_wexkdk.png"
-                            alt="Candid Seal Platinum Award"
-                            width={150}
-                        />
+                        <a
+                            href="https://app.candid.org/profile/9981881/vets-who-code-86-2122804"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            <img
+                                src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/9981881/svg"
+                                alt="Candid/Guidestar Transparency Seal"
+                                title="Candid/Guidestar Transparency Seal"
+                            />{" "}
+                        </a>
                     </div>
                 </div>
                 <p className="copyright tw-mt-5 tw-text-center tw-text-md tw-text-gray-400">

--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -36,7 +36,7 @@ const Footer01 = ({ mode }: TProps) => {
                         <a
                             href="https://app.candid.org/profile/9981881/vets-who-code-86-2122804"
                             target="_blank"
-                            rel="noreferrer"
+                            rel="noopener noreferrer"
                         >
                             <img
                                 src="https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/9981881/svg"


### PR DESCRIPTION
This pull request updates the footer component in the `src/layouts/footers/footer-01.tsx` file to replace the displayed image and link with updated information. 

### Changes to `Footer01` component:

* Updated the link to point to the Candid profile page for "Vets Who Code" (`https://app.candid.org/profile/9981881/vets-who-code-86-2122804`) and added `target="_blank"` and `rel="noreferrer"` attributes to ensure the link opens in a new tab securely.
* Replaced the image source with a new URL (`https://widgets.guidestar.org/prod/v1/pdp/transparency-seal/9981881/svg`) and updated the `alt` text to "Candid/Guidestar Transparency Seal" while adding a `title` attribute for better accessibility and context.