### PR TITLE
feat: update header navigation and sticky donate button

### DIFF
--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -106,11 +106,6 @@ const navigation: NavigationItem[] = [
         label: "Contact",
         path: "/contact-us",
     },
-    {
-        id: 7,
-        label: "Donate",
-        path: "/donate",
-    },
 ];
 
 export default navigation;

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -32,14 +32,19 @@ const Header = ({ shadow, fluid }: TProps) => {
     return (
         <>
             <header className="header tw-relative">
-                <div className="header-top tw-bg-gray-200 tw-py-2.5">
+                <div
+                    className={clsx(
+                        "header-top tw-bg-gray-200 tw-py-2.5 tw-z-[60] tw-w-full tw-transition-all",
+                        sticky && "tw-fixed tw-top-0 tw-left-0 tw-shadow-md"
+                    )}
+                >
                     <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-justify-center">
                         <p className="tw-mb-3.8 tw-flex-100 tw-text-center md:tw-mb-0 md:tw-mr-7.5 md:tw-flex-1 md:tw-text-left">
-                            Platform Launch + Vets Who Code Demo Day
+                            New Cohort Starts:
                         </p>
                         <div className="tw-flex tw-items-center sm:tw-mr-[45px] md:tw-mr-5 lg:tw-mr-[45px]">
                             <i className="far fa-clock tw-mr-[5px] tw-text-lg tw-text-secondary" />
-                            <CountdownTimer targetDate="2025/11/11" />
+                            <CountdownTimer targetDate="2026/04/07" />
                         </div>
                         <Button size="sm" path="/donate" className="tw-shadow-lg tw-shadow-primary/25">
                             Donate
@@ -50,10 +55,10 @@ const Header = ({ shadow, fluid }: TProps) => {
                     <div
                         ref={measuredRef}
                         className={clsx(
-                            "header-inner tw-left-0 tw-top-0 tw-z-50 tw-h-auto tw-w-full tw-py-[25px] tw-transition-all xl:tw-py-0",
-                            !sticky && "tw-absolute tw-bg-white",
+                            "header-inner tw-left-0 tw-z-50 tw-h-auto tw-w-full tw-py-[25px] tw-transition-all xl:tw-py-0",
+                            !sticky && "tw-absolute tw-top-0 tw-bg-white",
                             sticky &&
-                                "tw-fixed tw-animate-headerSlideDown tw-backdrop-blur-lg tw-bg-white/90 tw-border-b tw-border-gray-200/50 tw-shadow-lg tw-shadow-black/5",
+                                "tw-fixed tw-top-[52px] tw-animate-headerSlideDown tw-backdrop-blur-lg tw-bg-white/90 tw-border-b tw-border-gray-200/50 tw-shadow-lg tw-shadow-black/5",
                             shadow && "tw-shadow-sm tw-shadow-black/5"
                         )}
                     >


### PR DESCRIPTION
- Remove Donate tab from main navigation menu
- Make header top bar sticky with donate button always visible
- Update countdown message to 'New Cohort Starts:'
- Set countdown timer to April 7, 2026
This pull request updates the site header and navigation menu. The most notable changes are the removal of the "Donate" link from the main navigation and improvements to the header's sticky behavior and announcement bar. The "Donate" button remains accessible in the header, and the announcement bar content and countdown have been updated.

Navigation menu update:

* Removed the "Donate" item from the main navigation array in `menu.ts`. (`src/data/menu.ts`)

Header and announcement bar improvements:

* Enhanced the sticky header behavior by adjusting class names and positioning, ensuring smoother transitions and correct stacking order. (`src/layouts/headers/header.tsx`) [[1]](diffhunk://#diff-401ed5a5190ad062af3f1fe2918d8224799dc545971905a71ca5fad4ded0bb87L35-R47) [[2]](diffhunk://#diff-401ed5a5190ad062af3f1fe2918d8224799dc545971905a71ca5fad4ded0bb87L53-R61)
* Updated the announcement bar text to "New Cohort Starts:" and set a new countdown target date. (`src/layouts/headers/header.tsx`)
* The "Donate" button remains visible in the header, even though it was removed from the navigation menu. (`src/layouts/headers/header.tsx`)