### PR TITLE
feat: implement VetsWhoCode brand style guide colors

### DIFF
--- a/COLOR_MIGRATION_GUIDE.md
+++ b/COLOR_MIGRATION_GUIDE.md
@@ -1,0 +1,180 @@
+# Color Migration Guide
+
+## Overview
+This guide maps old (deprecated) colors to new brand-approved colors based on the VetsWhoCode Brand Style Guide.
+
+---
+
+## Color Mappings
+
+### Primary Colors
+
+| Old Color | New Color | Usage |
+|-----------|-----------|-------|
+| `primary` (was red) | `primary` or `red` | Primary CTAs, accents |
+| `secondary` (was blue) | `secondary` or `navy` | Primary brand color |
+
+### Semantic Colors
+
+| Old Color | New Color | Reason |
+|-----------|-----------|--------|
+| `success` (#4CAF50) | `success` or `gold` | Now uses Amber Gold (#FDB330) |
+| `warning` (#FFC107) | `warning` or `gold-bright` | Now uses Bright Gold (#FAD643) |
+| `danger` (#F44336) | `danger` or `red` | Now uses Brand Red (#c5203e) |
+| `info` (#17A2B8) | `info` or `navy-ocean` | Now uses Ocean Blue (#006DAA) |
+
+### Removed Colors (Map to Brand Colors)
+
+| Removed Color | Map To | Notes |
+|---------------|--------|-------|
+| `orange` | `red` or `gold` | Context-dependent |
+| `yellow` | `gold` | Amber Gold is brand gold |
+| `blue-100` | `navy-sky` or `navy-ocean` | Use navy scale |
+| `spring` (#F5F1ED) | `cream` (#EEEDE9) | Use brand cream |
+| `desert` | `red` | Was using red anyway |
+| `pearl` (#EAE1D6) | `cream` | Similar tone |
+| `putty` (#e5c791) | `gold` or `gold-light` | Gold tone |
+| `brunt` (#ee7455) | `red` or `red-signal` | Red tone |
+| `jagged` (#BCE6DF) | `navy-sky` | Light blue tone |
+| `azure` (#00adff) | `navy-ocean` | Blue tone |
+| `alto` (#dedede) | `gray-100` (Silver) | Borders/dividers |
+| `teracotta` | `red` or `gold` | Context-dependent |
+| `scooter` | `navy-ocean` | Blue tone |
+| `ebb` (#e9e6e3) | `gray-50` or `cream` | Light neutral |
+| `pampas` (#ece8e4) | `cream` | Light background |
+| `gore` (#1f1f52) | `navy` or `navy-midnight` | Dark blue |
+| `porsche` (#ebb860) | `gold` | Gold tone |
+| `mandy` (#df5b6c) | `red` | Red tone |
+| `tan` (#d2a98e) | `gold` or `cream` | Warm neutral |
+| `mishcka` (#e2e2e8) | `gray-100` | Light gray |
+
+### Gray Scale Migration
+
+| Old Gray | New Gray | Color | Usage |
+|----------|----------|-------|-------|
+| `gray-50` | `gray-50` | #F8F9FA | Off White - light cards |
+| `gray-100` | `gray-100` | #DEE2E6 | Silver - borders, dividers |
+| `gray-200` | `gray-200` | #6C757D | Slate - secondary text |
+| `gray-300` | `gray-300` | #495057 | Charcoal - muted labels |
+| `gray-350` | `gray-100` | - | Use Silver |
+| `gray-400` | `gray-400` | #343A40 | Dark Gray - text blocks |
+| `gray-450` | `gray-50` | - | Use Off White |
+| `gray-500` | `gray-50` | - | Use Off White |
+| `gray-550` | `gray-50` | - | Use Off White |
+| `gray-600` | `gray-300` | - | Use Charcoal |
+| `gray-650` | `gray-100` | - | Use Silver |
+| `gray-700` | `gray-200` | - | Use Slate |
+| `gray-750` | `gray-50` | - | Use Off White |
+| `gray-800` | `gray-400` | - | Use Dark Gray |
+| `gray-850` | `gray-300` | - | Use Charcoal |
+
+---
+
+## New Brand Colors Available
+
+### Navy Blue Scale
+```
+navy (default): #091f40
+navy-midnight: #061A40
+navy-deep: #003559
+navy-royal: #0353A4
+navy-ocean: #006DAA
+navy-sky: #B9D6F2
+```
+
+### Red Scale
+```
+red (default): #c5203e
+red-signal: #C52233
+red-crimson: #A51C30
+red-dark: #74121D
+red-maroon: #580C1F
+```
+
+### Gold Scale
+```
+gold (default): #FDB330
+gold-light: #FFE169
+gold-bright: #FAD643
+gold-rich: #DBB42C
+gold-deep: #C9A227
+```
+
+### Base Colors
+```
+cream: #EEEDE9 (backgrounds)
+ink: #1A1823 (body text)
+white: #FFFFFF
+black: #000000
+```
+
+### Dark Mode Colors
+```
+dark (default): #1A1823
+dark-surface: #212529
+dark-elevated: #343A40
+dark-text: #F8F9FA
+dark-text-muted: #DEE2E6
+dark-text-disabled: #6C757D
+dark-accent: #84C1FF
+dark-accent-hover: #B9D6F2
+dark-error: #F38375
+dark-success: #FFE169
+dark-badge: #FAD643
+```
+
+---
+
+## Migration Strategy
+
+### Phase 1: High-Impact Components
+1. Navigation/Header
+2. Hero sections
+3. CTAs (Call-to-action buttons)
+4. Forms
+
+### Phase 2: Content Areas
+1. Blog components
+2. Course components
+3. Team/testimonials
+4. Services
+
+### Phase 3: Utility Components
+1. Alerts
+2. Badges
+3. Cards
+4. Modals
+
+### Phase 4: Admin/Dashboard
+1. Admin panels
+2. Dashboard components
+3. Data tables
+
+---
+
+## Testing Checklist
+
+- [ ] Header/navigation displays correctly
+- [ ] CTAs are prominent with brand red
+- [ ] Text has proper contrast (WCAG AA: 4.5:1 minimum)
+- [ ] Success states use gold (not green)
+- [ ] Info boxes use navy-sky
+- [ ] Links use navy-ocean
+- [ ] Dark mode colors work properly
+- [ ] No console errors about missing colors
+
+---
+
+## Quick Reference Commands
+
+### Find files using deprecated colors
+```bash
+grep -r "tw-bg-orange\|tw-text-orange\|tw-border-orange" src/
+grep -r "tw-bg-yellow\|tw-text-yellow\|tw-border-yellow" src/
+grep -r "tw-bg-spring\|tw-text-spring\|tw-border-spring" src/
+```
+
+### Find old gray scale usage
+```bash
+grep -r "gray-350\|gray-450\|gray-550\|gray-650\|gray-750\|gray-800\|gray-850" src/
+```

--- a/scripts/replace-deprecated-colors.js
+++ b/scripts/replace-deprecated-colors.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Replace deprecated colors with brand-approved colors
+ * Run with: node scripts/replace-deprecated-colors.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Color replacement mappings
+const colorReplacements = [
+  // Orange → Red or Gold (context-dependent, defaulting to red for CTAs)
+  { from: /tw-bg-orange(?!-)/g, to: 'tw-bg-red' },
+  { from: /tw-text-orange(?!-)/g, to: 'tw-text-red' },
+  { from: /tw-border-orange(?!-)/g, to: 'tw-border-red' },
+  { from: /tw-bg-orange-light/g, to: 'tw-bg-red-signal/10' },
+  { from: /tw-bg-orange-100/g, to: 'tw-bg-red-signal' },
+  { from: /tw-bg-orange-200/g, to: 'tw-bg-red-signal' },
+  { from: /tw-bg-orange-300/g, to: 'tw-bg-red' },
+  { from: /tw-text-orange-100/g, to: 'tw-text-red-signal' },
+  { from: /tw-text-orange-200/g, to: 'tw-text-red-signal' },
+  { from: /tw-text-orange-300/g, to: 'tw-text-red' },
+
+  // Yellow → Gold
+  { from: /tw-bg-yellow(?!-)/g, to: 'tw-bg-gold' },
+  { from: /tw-text-yellow(?!-)/g, to: 'tw-text-gold' },
+  { from: /tw-border-yellow(?!-)/g, to: 'tw-border-gold' },
+  { from: /tw-bg-yellow-100/g, to: 'tw-bg-gold-bright' },
+  { from: /tw-text-yellow-100/g, to: 'tw-text-gold-bright' },
+
+  // Blue-100 → Navy ocean or sky
+  { from: /tw-bg-blue-100/g, to: 'tw-bg-navy-sky' },
+  { from: /tw-text-blue-100/g, to: 'tw-text-navy-ocean' },
+  { from: /tw-border-blue-100/g, to: 'tw-border-navy-ocean' },
+
+  // Spring → Cream
+  { from: /tw-bg-spring/g, to: 'tw-bg-cream' },
+  { from: /tw-text-spring/g, to: 'tw-text-cream' },
+
+  // Desert → Red (it was using red anyway)
+  { from: /tw-bg-desert(?!-)/g, to: 'tw-bg-red' },
+  { from: /tw-text-desert(?!-)/g, to: 'tw-text-red' },
+  { from: /tw-border-desert(?!-)/g, to: 'tw-border-red' },
+  { from: /tw-bg-desert-100/g, to: 'tw-bg-cream' },
+
+  // Pearl → Cream
+  { from: /tw-bg-pearl/g, to: 'tw-bg-cream' },
+  { from: /tw-text-pearl/g, to: 'tw-text-cream' },
+
+  // Putty → Gold
+  { from: /tw-bg-putty/g, to: 'tw-bg-gold' },
+  { from: /tw-text-putty/g, to: 'tw-text-gold' },
+
+  // Brunt → Red
+  { from: /tw-bg-brunt/g, to: 'tw-bg-red' },
+  { from: /tw-text-brunt/g, to: 'tw-text-red' },
+
+  // Jagged → Navy sky
+  { from: /tw-bg-jagged/g, to: 'tw-bg-navy-sky' },
+  { from: /tw-text-jagged/g, to: 'tw-text-navy-sky' },
+
+  // Azure → Navy ocean
+  { from: /tw-bg-azure/g, to: 'tw-bg-navy-ocean' },
+  { from: /tw-text-azure/g, to: 'tw-text-navy-ocean' },
+  { from: /tw-border-azure/g, to: 'tw-border-navy-ocean' },
+
+  // Alto → Gray-100 (Silver)
+  { from: /tw-bg-alto/g, to: 'tw-bg-gray-100' },
+  { from: /tw-border-alto/g, to: 'tw-border-gray-100' },
+
+  // Teracotta → Red or Gold (defaulting to red)
+  { from: /tw-bg-teracotta(?!-)/g, to: 'tw-bg-red' },
+  { from: /tw-text-teracotta(?!-)/g, to: 'tw-text-red' },
+  { from: /tw-bg-teracotta-light/g, to: 'tw-bg-red-signal/10' },
+
+  // Scooter → Navy ocean
+  { from: /tw-bg-scooter(?!-)/g, to: 'tw-bg-navy-ocean' },
+  { from: /tw-text-scooter(?!-)/g, to: 'tw-text-navy-ocean' },
+  { from: /tw-bg-scooter-light/g, to: 'tw-bg-navy-sky' },
+
+  // Ebb → Cream or Gray-50
+  { from: /tw-bg-ebb/g, to: 'tw-bg-gray-50' },
+
+  // Pampas → Cream
+  { from: /tw-bg-pampas/g, to: 'tw-bg-cream' },
+
+  // Gore → Navy
+  { from: /tw-bg-gore/g, to: 'tw-bg-navy' },
+  { from: /tw-text-gore/g, to: 'tw-text-navy' },
+
+  // Porsche → Gold
+  { from: /tw-bg-porsche/g, to: 'tw-bg-gold' },
+  { from: /tw-text-porsche/g, to: 'tw-text-gold' },
+
+  // Mandy → Red
+  { from: /tw-bg-mandy/g, to: 'tw-bg-red' },
+  { from: /tw-text-mandy/g, to: 'tw-text-red' },
+
+  // Tan → Gold or Cream
+  { from: /tw-bg-tan/g, to: 'tw-bg-gold-light' },
+  { from: /tw-text-tan/g, to: 'tw-text-gold' },
+
+  // Mishcka → Gray-100
+  { from: /tw-bg-mishcka/g, to: 'tw-bg-gray-100' },
+  { from: /tw-text-mishcka/g, to: 'tw-text-gray-200' },
+
+  // Old gray scale replacements
+  { from: /tw-bg-gray-350/g, to: 'tw-bg-gray-100' },
+  { from: /tw-border-gray-350/g, to: 'tw-border-gray-100' },
+  { from: /tw-bg-gray-450/g, to: 'tw-bg-gray-50' },
+  { from: /tw-bg-gray-500/g, to: 'tw-bg-gray-50' },
+  { from: /tw-bg-gray-550/g, to: 'tw-bg-gray-50' },
+  { from: /tw-bg-gray-600/g, to: 'tw-bg-gray-300' },
+  { from: /tw-text-gray-600/g, to: 'tw-text-gray-300' },
+  { from: /tw-bg-gray-650/g, to: 'tw-bg-gray-100' },
+  { from: /tw-border-gray-650/g, to: 'tw-border-gray-100' },
+  { from: /tw-bg-gray-700/g, to: 'tw-bg-gray-200' },
+  { from: /tw-text-gray-700/g, to: 'tw-text-gray-200' },
+  { from: /tw-bg-gray-750/g, to: 'tw-bg-gray-50' },
+  { from: /tw-bg-gray-800/g, to: 'tw-bg-gray-400' },
+  { from: /tw-text-gray-800/g, to: 'tw-text-gray-400' },
+  { from: /tw-bg-gray-850/g, to: 'tw-bg-gray-300' },
+  { from: /tw-text-gray-850/g, to: 'tw-text-gray-300' },
+];
+
+function processFile(filePath) {
+  let content = fs.readFileSync(filePath, 'utf8');
+  let modified = false;
+
+  colorReplacements.forEach(({ from, to }) => {
+    if (from.test(content)) {
+      content = content.replace(from, to);
+      modified = true;
+    }
+  });
+
+  if (modified) {
+    fs.writeFileSync(filePath, content, 'utf8');
+    return true;
+  }
+
+  return false;
+}
+
+function findAndReplaceInDirectory(dir) {
+  const files = execSync(`find ${dir} -type f \\( -name "*.tsx" -o -name "*.ts" -o -name "*.jsx" -o -name "*.js" \\) ! -path "*/node_modules/*" ! -path "*/.next/*"`, {
+    encoding: 'utf8',
+  }).trim().split('\n').filter(Boolean);
+
+  let modifiedCount = 0;
+  const modifiedFiles = [];
+
+  files.forEach(file => {
+    if (processFile(file)) {
+      modifiedCount++;
+      modifiedFiles.push(file);
+    }
+  });
+
+  return { modifiedCount, modifiedFiles };
+}
+
+// Main execution
+console.log('🎨 Starting color replacement...\n');
+
+const srcDir = path.join(process.cwd(), 'src');
+const { modifiedCount, modifiedFiles } = findAndReplaceInDirectory(srcDir);
+
+console.log(`\n✅ Replaced deprecated colors in ${modifiedCount} files\n`);
+
+if (modifiedFiles.length > 0 && modifiedFiles.length <= 20) {
+  console.log('Modified files:');
+  modifiedFiles.forEach(file => {
+    console.log(`  - ${file.replace(process.cwd() + '/', '')}`);
+  });
+} else if (modifiedFiles.length > 20) {
+  console.log(`Modified ${modifiedFiles.length} files (too many to list)`);
+}
+
+console.log('\n✨ Color replacement complete!\n');

--- a/scripts/replace-tailwind-default-colors.js
+++ b/scripts/replace-tailwind-default-colors.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Replace standard Tailwind colors with brand-approved colors
+ * This handles orange-*, yellow-*, and other default Tailwind colors
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// Map standard Tailwind colors to brand colors
+const replacements = [
+  // Orange shades → Red shades
+  { from: /tw-bg-orange-50/g, to: 'tw-bg-red-signal/10' },
+  { from: /tw-border-orange-50/g, to: 'tw-border-red-signal/10' },
+  { from: /tw-bg-orange-100/g, to: 'tw-bg-red-signal/20' },
+  { from: /tw-bg-orange-200/g, to: 'tw-bg-red-signal/30' },
+  { from: /tw-border-orange-200/g, to: 'tw-border-red-signal/30' },
+  { from: /tw-bg-orange-300/g, to: 'tw-bg-red-signal' },
+  { from: /tw-bg-orange-400/g, to: 'tw-bg-red' },
+  { from: /tw-bg-orange-500/g, to: 'tw-bg-red' },
+  { from: /tw-bg-orange-600/g, to: 'tw-bg-red' },
+  { from: /tw-bg-orange-700/g, to: 'tw-bg-red-crimson' },
+  { from: /tw-bg-orange-800/g, to: 'tw-bg-red-dark' },
+  { from: /tw-bg-orange-900/g, to: 'tw-bg-red-maroon' },
+
+  { from: /tw-text-orange-50/g, to: 'tw-text-red-signal/10' },
+  { from: /tw-text-orange-100/g, to: 'tw-text-red-signal/20' },
+  { from: /tw-text-orange-200/g, to: 'tw-text-red-signal/30' },
+  { from: /tw-text-orange-300/g, to: 'tw-text-red-signal' },
+  { from: /tw-text-orange-400/g, to: 'tw-text-red' },
+  { from: /tw-text-orange-500/g, to: 'tw-text-red' },
+  { from: /tw-text-orange-600/g, to: 'tw-text-red' },
+  { from: /tw-text-orange-700/g, to: 'tw-text-red-crimson' },
+  { from: /tw-text-orange-800/g, to: 'tw-text-red-dark' },
+  { from: /tw-text-orange-900/g, to: 'tw-text-red-maroon' },
+
+  { from: /hover:tw-bg-orange-700/g, to: 'hover:tw-bg-red-crimson' },
+  { from: /hover:tw-text-orange-800/g, to: 'hover:tw-text-red-dark' },
+
+  // Yellow shades → Gold shades
+  { from: /tw-bg-yellow-50/g, to: 'tw-bg-gold-light/20' },
+  { from: /tw-bg-yellow-100/g, to: 'tw-bg-gold-light/30' },
+  { from: /tw-bg-yellow-200/g, to: 'tw-bg-gold-light' },
+  { from: /tw-bg-yellow-300/g, to: 'tw-bg-gold-bright' },
+  { from: /tw-bg-yellow-400/g, to: 'tw-bg-gold' },
+  { from: /tw-bg-yellow-500/g, to: 'tw-bg-gold' },
+  { from: /tw-bg-yellow-600/g, to: 'tw-bg-gold-rich' },
+  { from: /tw-bg-yellow-700/g, to: 'tw-bg-gold-deep' },
+  { from: /tw-bg-yellow-800/g, to: 'tw-bg-gold-deep' },
+
+  { from: /tw-text-yellow-50/g, to: 'tw-text-gold-light/20' },
+  { from: /tw-text-yellow-100/g, to: 'tw-text-gold-light/30' },
+  { from: /tw-text-yellow-200/g, to: 'tw-text-gold-light' },
+  { from: /tw-text-yellow-300/g, to: 'tw-text-gold-bright' },
+  { from: /tw-text-yellow-400/g, to: 'tw-text-gold' },
+  { from: /tw-text-yellow-500/g, to: 'tw-text-gold' },
+  { from: /tw-text-yellow-600/g, to: 'tw-text-gold-rich' },
+  { from: /tw-text-yellow-700/g, to: 'tw-text-gold-deep' },
+  { from: /tw-text-yellow-800/g, to: 'tw-text-gold-deep' },
+
+  { from: /tw-border-yellow-500/g, to: 'tw-border-gold' },
+
+  // Green shades → Gold shades (for success states)
+  { from: /tw-bg-green-50/g, to: 'tw-bg-gold-light/20' },
+  { from: /tw-bg-green-100/g, to: 'tw-bg-gold-light/30' },
+  { from: /tw-bg-green-500/g, to: 'tw-bg-gold' },
+  { from: /tw-bg-green-600/g, to: 'tw-bg-gold-rich' },
+  { from: /tw-text-green-600/g, to: 'tw-text-gold' },
+  { from: /tw-text-green-700/g, to: 'tw-text-gold-rich' },
+  { from: /tw-text-green-800/g, to: 'tw-text-gold-deep' },
+
+  // Blue shades → Navy shades
+  { from: /tw-bg-blue-50/g, to: 'tw-bg-navy-sky/20' },
+  { from: /tw-bg-blue-100/g, to: 'tw-bg-navy-sky/30' },
+  { from: /tw-bg-blue-500/g, to: 'tw-bg-navy-ocean' },
+  { from: /tw-bg-blue-600/g, to: 'tw-bg-navy-royal' },
+  { from: /tw-bg-blue-700/g, to: 'tw-bg-navy' },
+
+  { from: /tw-text-blue-50/g, to: 'tw-text-navy-sky/20' },
+  { from: /tw-text-blue-100/g, to: 'tw-text-navy-sky' },
+  { from: /tw-text-blue-500/g, to: 'tw-text-navy-ocean' },
+  { from: /tw-text-blue-600/g, to: 'tw-text-navy-royal' },
+  { from: /tw-text-blue-700/g, to: 'tw-text-navy' },
+
+  { from: /tw-border-blue-500/g, to: 'tw-border-navy-ocean' },
+  { from: /tw-border-blue-600/g, to: 'tw-border-navy-royal' },
+
+  // Purple/Indigo → Navy shades
+  { from: /tw-bg-purple-50/g, to: 'tw-bg-navy-sky/20' },
+  { from: /tw-bg-purple-500/g, to: 'tw-bg-navy-royal' },
+  { from: /tw-bg-purple-600/g, to: 'tw-bg-navy' },
+  { from: /tw-text-purple-600/g, to: 'tw-text-navy' },
+
+  { from: /tw-bg-indigo-50/g, to: 'tw-bg-navy-sky/20' },
+  { from: /tw-bg-indigo-500/g, to: 'tw-bg-navy-royal' },
+  { from: /tw-bg-indigo-600/g, to: 'tw-bg-navy' },
+  { from: /tw-text-indigo-600/g, to: 'tw-text-navy' },
+];
+
+function processFile(filePath) {
+  let content = fs.readFileSync(filePath, 'utf8');
+  let modified = false;
+
+  replacements.forEach(({ from, to }) => {
+    if (from.test(content)) {
+      content = content.replace(from, to);
+      modified = true;
+    }
+  });
+
+  if (modified) {
+    fs.writeFileSync(filePath, content, 'utf8');
+    return true;
+  }
+
+  return false;
+}
+
+function findAndReplaceInDirectory(dir) {
+  const files = execSync(
+    `find ${dir} -type f \\( -name "*.tsx" -o -name "*.ts" -o -name "*.jsx" -o -name "*.js" \\) ! -path "*/node_modules/*" ! -path "*/.next/*"`,
+    { encoding: 'utf8' }
+  )
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+  let modifiedCount = 0;
+  const modifiedFiles = [];
+
+  files.forEach((file) => {
+    if (processFile(file)) {
+      modifiedCount++;
+      modifiedFiles.push(file);
+    }
+  });
+
+  return { modifiedCount, modifiedFiles };
+}
+
+// Main execution
+console.log('🎨 Replacing standard Tailwind colors with brand colors...\n');
+
+const srcDir = path.join(process.cwd(), 'src');
+const { modifiedCount, modifiedFiles } = findAndReplaceInDirectory(srcDir);
+
+console.log(`\n✅ Updated ${modifiedCount} files\n`);
+
+if (modifiedFiles.length > 0 && modifiedFiles.length <= 20) {
+  console.log('Modified files:');
+  modifiedFiles.forEach((file) => {
+    console.log(`  - ${file.replace(process.cwd() + '/', '')}`);
+  });
+} else if (modifiedFiles.length > 20) {
+  console.log(`Modified ${modifiedFiles.length} files (too many to list)`);
+}
+
+console.log('\n✨ Complete!\n');

--- a/src/components/admin-dashboard-components.tsx
+++ b/src/components/admin-dashboard-components.tsx
@@ -23,7 +23,7 @@ const ProgressBar = ({ progress }: { progress: number }) => {
     };
 
     return (
-        <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-200">
+        <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-50">
             <div className={`tw-h-2 tw-rounded-full tw-bg-primary ${getWidthClass(progress)}`} />
         </div>
     );
@@ -41,9 +41,9 @@ export const OverviewStats = () => {
         <div className="tw-mb-8 tw-grid tw-grid-cols-1 tw-gap-6 md:tw-grid-cols-2 lg:tw-grid-cols-4">
             {stats.map((stat) => (
                 <div key={stat.label} className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                    <h3 className="tw-text-lg tw-font-semibold tw-text-gray-800">{stat.label}</h3>
+                    <h3 className="tw-text-lg tw-font-semibold tw-text-gray-400">{stat.label}</h3>
                     <p className="tw-mt-2 tw-text-3xl tw-font-bold tw-text-primary">{stat.value}</p>
-                    <p className="tw-mt-2 tw-text-sm tw-text-green-600">
+                    <p className="tw-mt-2 tw-text-sm tw-text-gold">
                         {stat.change} from last month
                     </p>
                 </div>
@@ -61,7 +61,7 @@ export const VerticalProgress = () => {
 
     return (
         <div className="tw-mb-8 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-            <h3 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-gray-800">
+            <h3 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-gray-400">
                 Course Verticals Progress
             </h3>
             <div className="tw-space-y-4">
@@ -71,8 +71,8 @@ export const VerticalProgress = () => {
                         className="tw-border-b tw-border-gray-200 tw-pb-4 last:tw-border-b-0"
                     >
                         <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between">
-                            <span className="tw-font-medium tw-text-gray-800">{vertical.name}</span>
-                            <span className="tw-text-sm tw-text-gray-600">
+                            <span className="tw-font-medium tw-text-gray-400">{vertical.name}</span>
+                            <span className="tw-text-sm tw-text-gray-300">
                                 {vertical.enrolled} enrolled · {vertical.avgProgress}% avg progress
                             </span>
                         </div>
@@ -88,7 +88,7 @@ export const AnalyticsCharts = () => {
     return (
         <div className="tw-mb-8 tw-grid tw-grid-cols-1 tw-gap-6 lg:tw-grid-cols-2">
             <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                <h3 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-gray-800">
+                <h3 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-gray-400">
                     Enrollment Trends
                 </h3>
                 <div className="tw-flex tw-h-64 tw-items-center tw-justify-center tw-rounded tw-bg-gray-50">
@@ -98,7 +98,7 @@ export const AnalyticsCharts = () => {
                 </div>
             </div>
             <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                <h3 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-gray-800">
+                <h3 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-gray-400">
                     Completion Rates
                 </h3>
                 <div className="tw-flex tw-h-64 tw-items-center tw-justify-center tw-rounded tw-bg-gray-50">
@@ -137,7 +137,7 @@ export const TabNavigation = ({
                         className={`tw-border-b-2 tw-px-1 tw-py-2 tw-text-sm tw-font-medium ${
                             activeTab === tab.id
                                 ? "tw-border-primary tw-text-primary"
-                                : "tw-border-transparent tw-text-gray-500 hover:tw-border-gray-300 hover:tw-text-gray-700"
+                                : "tw-border-transparent tw-text-gray-500 hover:tw-border-gray-300 hover:tw-text-gray-200"
                         }`}
                     >
                         {tab.label}
@@ -168,9 +168,9 @@ export const UserProgress = ({ progress }: { progress: number }) => {
     };
 
     return (
-        <div className="tw-w-full tw-rounded-full tw-bg-gray-200">
+        <div className="tw-w-full tw-rounded-full tw-bg-gray-50">
             <div className={`tw-h-2 tw-rounded-full tw-bg-primary ${getProgressWidth(progress)}`} />
-            <span className="tw-mt-1 tw-block tw-text-xs tw-text-gray-600">{progress}%</span>
+            <span className="tw-mt-1 tw-block tw-text-xs tw-text-gray-300">{progress}%</span>
         </div>
     );
 };
@@ -206,7 +206,7 @@ export const UserManagement = () => {
     return (
         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
             <div className="tw-mb-6 tw-flex tw-items-center tw-justify-between">
-                <h3 className="tw-text-xl tw-font-semibold tw-text-gray-800">User Management</h3>
+                <h3 className="tw-text-xl tw-font-semibold tw-text-gray-400">User Management</h3>
                 <button
                     type="button"
                     className="tw-rounded-md tw-bg-primary tw-px-4 tw-py-2 tw-text-white hover:tw-bg-primary/90"
@@ -241,7 +241,7 @@ export const UserManagement = () => {
                             <tr key={user.id}>
                                 <td className="tw-whitespace-nowrap tw-px-6 tw-py-4">
                                     <div>
-                                        <div className="tw-text-sm tw-font-medium tw-text-gray-900">
+                                        <div className="tw-text-sm tw-font-medium tw-text-ink">
                                             {user.name}
                                         </div>
                                         <div className="tw-text-sm tw-text-gray-500">
@@ -253,14 +253,14 @@ export const UserManagement = () => {
                                     <span
                                         className={`tw-inline-flex tw-rounded-full tw-px-2 tw-text-xs tw-font-semibold ${
                                             user.status === "Active"
-                                                ? "tw-bg-green-100 tw-text-green-800"
+                                                ? "tw-bg-gold-light/30 tw-text-gold-deep"
                                                 : "tw-bg-red-100 tw-text-red-800"
                                         }`}
                                     >
                                         {user.status}
                                     </span>
                                 </td>
-                                <td className="tw-whitespace-nowrap tw-px-6 tw-py-4 tw-text-sm tw-text-gray-900">
+                                <td className="tw-whitespace-nowrap tw-px-6 tw-py-4 tw-text-sm tw-text-ink">
                                     {user.enrolled}
                                 </td>
                                 <td className="tw-whitespace-nowrap tw-px-6 tw-py-4">

--- a/src/components/ai-assistant/AITeachingAssistant.tsx
+++ b/src/components/ai-assistant/AITeachingAssistant.tsx
@@ -225,7 +225,7 @@ export default function AITeachingAssistant({
                   'tw-max-w-[80%] tw-rounded-lg tw-px-4 tw-py-3 tw-shadow-sm',
                   msg.role === 'user'
                     ? 'tw-bg-primary tw-text-white'
-                    : 'tw-bg-gray-100 tw-text-gray-800'
+                    : 'tw-bg-gray-100 tw-text-gray-400'
                 )}
               >
                 <div className="tw-text-sm tw-whitespace-pre-wrap">{msg.content}</div>

--- a/src/components/blog-card/blog-03.tsx
+++ b/src/components/blog-card/blog-03.tsx
@@ -10,7 +10,7 @@ type TProps = Pick<IBlog, "image" | "path" | "title" | "category" | "postedAt"> 
 const BlogCard = forwardRef<HTMLDivElement, TProps>(
     ({ className, image, path, title, category, postedAt }, ref) => {
         return (
-            <div className={clsx("blog-card tw-group", className)} ref={ref}>
+            <div className={clsx("blog-card tw-group tw-rounded tw-bg-cream tw-p-5 tw-shadow-lg tw-shadow-heading/10", className)} ref={ref}>
                 <div className="tw-relative tw-h-[250px] tw-overflow-hidden tw-rounded">
                     {image?.src && (
                         <figure className="tw-h-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110">

--- a/src/components/code-editor/index.tsx
+++ b/src/components/code-editor/index.tsx
@@ -23,7 +23,7 @@ const AceEditor = dynamic(
         loading: () => (
             <div className="tw-flex tw-h-96 tw-items-center tw-justify-center tw-rounded tw-border tw-border-gray-300 tw-bg-gray-50">
                 <div className="tw-text-center">
-                    <div className="tw-mb-2 tw-text-gray-600">Loading editor...</div>
+                    <div className="tw-mb-2 tw-text-gray-300">Loading editor...</div>
                     <div className="tw-h-2 tw-w-32 tw-animate-pulse tw-rounded tw-bg-gray-300" />
                 </div>
             </div>

--- a/src/components/event-card/event-01.tsx
+++ b/src/components/event-card/event-01.tsx
@@ -14,7 +14,7 @@ const Event01 = forwardRef<HTMLDivElement, TProps>(
         return (
             <div
                 className={clsx(
-                    "event tw-group tw-relative tw-h-full tw-rounded tw-bg-gray-100",
+                    "event tw-group tw-relative tw-h-full tw-rounded tw-bg-cream",
                     "before:tw-absolute before:tw-inset-0 before:tw-opacity-0 before:tw-shadow-4xl before:tw-shadow-black/[0.12] before:tw-transition-opacity before:tw-duration-300 before:tw-content-['']",
                     "hover:before:tw-opacity-100",
                     className

--- a/src/components/event-card/event-02.tsx
+++ b/src/components/event-card/event-02.tsx
@@ -13,7 +13,7 @@ const Event02 = forwardRef<HTMLDivElement, TProps>(
         return (
             <div
                 className={clsx(
-                    "event-card tw-relative tw-z-10 tw-flex tw-flex-wrap tw-rounded tw-bg-light-100 tw-p-[31px] md:tw-flex-nowrap",
+                    "event-card tw-relative tw-z-10 tw-flex tw-flex-wrap tw-rounded tw-bg-cream tw-p-[31px] md:tw-flex-nowrap",
                     "before:tw-absolute before:tw-inset-0 before:-tw-z-1 before:tw-opacity-0 before:tw-shadow-lg before:tw-shadow-heading/10 before:tw-transition-opacity before:tw-duration-300 before:tw-content-['']",
                     "after:tw-absolute after:tw-inset-0 after:tw-right-auto after:tw-w-[3px] after:tw-rounded-bl after:tw-rounded-tl after:tw-bg-primary after:tw-opacity-0 after:tw-transition-opacity after:tw-duration-300 after:tw-content-['']",
                     "hover:tw-bg-white hover:before:tw-opacity-100 hover:after:tw-opacity-100",

--- a/src/components/forms/apply-form.tsx
+++ b/src/components/forms/apply-form.tsx
@@ -133,7 +133,7 @@ const ApplyForm = () => {
                         <h3 className="tw-mb-2 tw-text-center tw-text-3xl tw-font-bold tw-text-heading md:tw-text-left">
                             Application Form
                         </h3>
-                        <p className="tw-text-center tw-text-gray-600 md:tw-text-left">
+                        <p className="tw-text-center tw-text-gray-300 md:tw-text-left">
                             Complete all steps to submit your application
                         </p>
                     </div>
@@ -152,7 +152,7 @@ const ApplyForm = () => {
                                                 ? "tw-bg-primary tw-text-white"
                                                 : currentStep === index + 1
                                                 ? "tw-bg-secondary tw-text-white tw-ring-4 tw-ring-secondary-200"
-                                                : "tw-bg-gray-200 tw-text-gray-500"
+                                                : "tw-bg-gray-50 tw-text-gray-500"
                                         }`}
                                     >
                                         {currentStep > index + 1 ? "✓" : step.id}
@@ -171,7 +171,7 @@ const ApplyForm = () => {
                                 </div>
                             ))}
                         </div>
-                        <div className="tw-h-2 tw-w-full tw-overflow-hidden tw-rounded-full tw-bg-gray-200">
+                        <div className="tw-h-2 tw-w-full tw-overflow-hidden tw-rounded-full tw-bg-gray-50">
                             <motion.div
                                 className="tw-h-full tw-bg-gradient-to-r tw-from-secondary tw-to-primary"
                                 initial={{ width: 0 }}
@@ -607,7 +607,7 @@ const ApplyForm = () => {
                                                     })}
                                                 />
                                             </div>
-                                            <div className="tw-rounded-lg tw-border-2 tw-border-blue-200 tw-bg-blue-50 tw-p-4">
+                                            <div className="tw-rounded-lg tw-border-2 tw-border-blue-200 tw-bg-navy-sky/20 tw-p-4">
                                                 <h5 className="tw-mb-3 tw-text-lg tw-font-semibold tw-text-blue-900">
                                                     Prework Submission
                                                 </h5>

--- a/src/components/forms/mentor-form.tsx
+++ b/src/components/forms/mentor-form.tsx
@@ -78,13 +78,13 @@ const MentorMenteeForm = () => {
             <div className="tw-mb-7.5 tw-flex tw-gap-4">
                 <Button
                     onClick={() => handleRoleChange("mentor")}
-                    className={`tw-flex-1 ${role === "mentor" ? "" : "tw-bg-gray-300 tw-text-gray-700"}`}
+                    className={`tw-flex-1 ${role === "mentor" ? "" : "tw-bg-gray-300 tw-text-gray-200"}`}
                 >
                     Register as Mentor
                 </Button>
                 <Button
                     onClick={() => handleRoleChange("mentee")}
-                    className={`tw-flex-1 ${role === "mentee" ? "" : "tw-bg-gray-300 tw-text-gray-700"}`}
+                    className={`tw-flex-1 ${role === "mentee" ? "" : "tw-bg-gray-300 tw-text-gray-200"}`}
                 >
                     Register as Mentee
                 </Button>

--- a/src/components/game/AnswerButtons.tsx
+++ b/src/components/game/AnswerButtons.tsx
@@ -26,7 +26,7 @@ const AnswerButtons: React.FC<AnswerButtonsProps> = ({ onAnswer, branches, disab
                     key={branch}
                     onClick={() => onAnswer(branch)}
                     disabled={disabled}
-                    className="tw-flex tw-h-[80px] tw-flex-col tw-items-center tw-justify-center tw-rounded-lg tw-bg-gray-200 tw-px-4 tw-py-3 tw-font-medium tw-text-secondary tw-shadow-md tw-transition-all hover:tw-scale-105 hover:tw-bg-primary hover:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary focus:tw-ring-offset-2 disabled:tw-opacity-70"
+                    className="tw-flex tw-h-[80px] tw-flex-col tw-items-center tw-justify-center tw-rounded-lg tw-bg-gray-50 tw-px-4 tw-py-3 tw-font-medium tw-text-secondary tw-shadow-md tw-transition-all hover:tw-scale-105 hover:tw-bg-primary hover:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary focus:tw-ring-offset-2 disabled:tw-opacity-70"
                 >
                     <i className={`${branchIcons[branch]} tw-mb-2 tw-text-lg`} />
                     {branch}

--- a/src/components/gradation/index.tsx
+++ b/src/components/gradation/index.tsx
@@ -22,7 +22,7 @@ const Gradation = forwardRef<HTMLDivElement, TProps>(
                 )}
                 ref={ref}
             >
-                <div className="tw-absolute tw-left-[39px] tw-top-3.8 tw-h-full tw-w-px tw-bg-gray-550 group-last:tw-hidden lg:tw-left-3.8 lg:tw-top-6 lg:tw-h-px lg:tw-w-full" />
+                <div className="tw-absolute tw-left-[39px] tw-top-3.8 tw-h-full tw-w-px tw-bg-gray-50 group-last:tw-hidden lg:tw-left-3.8 lg:tw-top-6 lg:tw-h-px lg:tw-w-full" />
                 <div className="tw-relative tw-mb-14 tw-inline-block">
                     <div className="mask tw-invisible tw-opacity-0 group-hover:tw-visible group-hover:tw-opacity-100">
                         <div

--- a/src/components/media-card/index.tsx
+++ b/src/components/media-card/index.tsx
@@ -49,7 +49,7 @@ const MediaCard = forwardRef<HTMLDivElement, TProps>(
                     </a>
                 </h3>
                 {description && (
-                    <p className="tw-mb-3 tw-flex-grow tw-text-sm tw-text-gray-700">
+                    <p className="tw-mb-3 tw-flex-grow tw-text-sm tw-text-gray-200">
                         {description}
                     </p>
                 )}

--- a/src/components/pagination/pagination-01-button.tsx
+++ b/src/components/pagination/pagination-01-button.tsx
@@ -51,7 +51,7 @@ const Pagination = ({ numberOfPages, currentPage, className }: TProps) => {
                                 "tw-block tw-h-12 tw-w-12 tw-rounded-full tw-text-center tw-font-extrabold tw-uppercase tw-leading-[48px] -tw-tracking-tightest hover:tw-text-heading",
                                 currentPage !== i + 1 && "tw-text-gray-400",
                                 currentPage === i + 1 &&
-                                    "tw-pointer-events-none tw-bg-gray-500 tw-text-heading"
+                                    "tw-pointer-events-none tw-bg-gray-50 tw-text-heading"
                             )}
                             onClick={() => pagiHandler(`${i + 1}`)}
                         >

--- a/src/components/pagination/pagination-01.tsx
+++ b/src/components/pagination/pagination-01.tsx
@@ -78,7 +78,7 @@ const Pagination = ({ currentPage, numberOfPages, rootPage = "blog", className }
                                     "tw-block tw-h-12 tw-w-12 tw-rounded-full tw-text-center tw-leading-[48px] -tw-tracking-tightest hover:tw-text-heading",
                                     currentPage !== pagi && "tw-text-gray-400",
                                     currentPage === pagi &&
-                                        "tw-pointer-events-none tw-bg-gray-500 tw-text-heading"
+                                        "tw-pointer-events-none tw-bg-gray-50 tw-text-heading"
                                 )}
                                 path={`${
                                     pagi === 1 ? `/${rootPage}` : `/${rootPage}/page/${pagi}`

--- a/src/components/product-card/product-card.tsx
+++ b/src/components/product-card/product-card.tsx
@@ -70,7 +70,7 @@ const ProductCard = forwardRef<HTMLDivElement, TProps>(
 
                     {!product.availableForSale && (
                         <div className="tw-absolute tw-inset-0 tw-bg-black/50 tw-flex tw-items-center tw-justify-center">
-                            <span className="tw-bg-white tw-px-4 tw-py-2 tw-rounded-full tw-font-bold tw-text-gray-800">
+                            <span className="tw-bg-white tw-px-4 tw-py-2 tw-rounded-full tw-font-bold tw-text-gray-400">
                                 Sold Out
                             </span>
                         </div>
@@ -87,12 +87,12 @@ const ProductCard = forwardRef<HTMLDivElement, TProps>(
                             <Anchor path={`/store/products/${product.handle}`}>{product.title}</Anchor>
                         </h3>
                         {product.vendor && (
-                            <span className="tw-text-sm tw-text-gray-600">{product.vendor}</span>
+                            <span className="tw-text-sm tw-text-gray-300">{product.vendor}</span>
                         )}
                     </div>
 
                     {product.description && (
-                        <p className="tw-mt-2 tw-text-sm tw-text-gray-700 tw-line-clamp-2">
+                        <p className="tw-mt-2 tw-text-sm tw-text-gray-200 tw-line-clamp-2">
                             {product.description}
                         </p>
                     )}
@@ -109,7 +109,7 @@ const ProductCard = forwardRef<HTMLDivElement, TProps>(
                                 "tw-px-4 tw-py-2 tw-rounded-lg tw-font-semibold tw-text-sm tw-transition-all tw-duration-300",
                                 product.availableForSale
                                     ? "tw-bg-primary tw-text-white hover:tw-bg-primary-dark hover:tw-shadow-lg disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
-                                    : "tw-bg-gray-300 tw-text-gray-600 tw-cursor-not-allowed"
+                                    : "tw-bg-gray-300 tw-text-gray-300 tw-cursor-not-allowed"
                             )}
                         >
                             {isAdding ? "Adding..." : product.availableForSale ? "Add to Cart" : "Unavailable"}

--- a/src/components/program-card/index.tsx
+++ b/src/components/program-card/index.tsx
@@ -14,10 +14,10 @@ const ProgramCard = ({ program }: Props) => {
   return (
     <div className="tw-bg-white tw-rounded-xl tw-shadow-sm tw-p-6 tw-border tw-border-gray-200 tw-hover:tw-shadow-md tw-transition">
       <h2 className="tw-mb-2 tw-text-2xl tw-font-semibold">{program.title}</h2>
-      <p className="tw-mb-4 tw-text-gray-700">{program.description}</p>
+      <p className="tw-mb-4 tw-text-gray-200">{program.description}</p>
       <Link
         href={`/programs/${program.slug}`}
-        className="tw-focus:tw-outline-none tw-focus:tw-ring-2 tw-focus:tw-ring-blue-400 tw-mt-auto tw-inline-block tw-font-medium tw-text-blue-700 tw-underline"
+        className="tw-focus:tw-outline-none tw-focus:tw-ring-2 tw-focus:tw-ring-blue-400 tw-mt-auto tw-inline-block tw-font-medium tw-text-navy tw-underline"
         aria-label={`Learn more about ${program.title}`}
       >
         Learn more

--- a/src/components/section-title/index.tsx
+++ b/src/components/section-title/index.tsx
@@ -45,6 +45,7 @@ const SectionTitle = forwardRef<HTMLDivElement, TProps>(
                             "tw-mb-2.5 tw-block tw-text-base tw-font-medium tw-uppercase tw-leading-none -tw-tracking-tightest",
                             color === "A" && "tw-text-secondary-light",
                             color === "B" && "tw-text-secondary",
+                            color === "C" && "tw-text-white",
                             subtitleClass
                         )}
                         dangerouslySetInnerHTML={{ __html: subtitle }}

--- a/src/components/shopping-cart/shopping-cart.tsx
+++ b/src/components/shopping-cart/shopping-cart.tsx
@@ -69,7 +69,7 @@ const ShoppingCart: React.FC<ShoppingCartProps> = ({ isOpen, onClose }) => {
                     </h2>
                     <button
                         onClick={onClose}
-                        className="tw-text-gray-500 hover:tw-text-gray-700 tw-transition-colors"
+                        className="tw-text-gray-500 hover:tw-text-gray-200 tw-transition-colors"
                         aria-label="Close cart"
                     >
                         <svg
@@ -109,7 +109,7 @@ const ShoppingCart: React.FC<ShoppingCartProps> = ({ isOpen, onClose }) => {
                                     d="M16 11V7a4 4 0 00-8 0v4M5 9h14l1 12H4L5 9z"
                                 />
                             </svg>
-                            <p className="tw-text-gray-600 tw-text-lg tw-font-medium">
+                            <p className="tw-text-gray-300 tw-text-lg tw-font-medium">
                                 Your cart is empty
                             </p>
                             <p className="tw-text-gray-500 tw-text-sm tw-mt-1">
@@ -140,7 +140,7 @@ const ShoppingCart: React.FC<ShoppingCartProps> = ({ isOpen, onClose }) => {
                                         <h3 className="tw-font-semibold tw-text-secondary tw-truncate">
                                             {line.merchandise.product.title}
                                         </h3>
-                                        <p className="tw-text-sm tw-text-gray-600 tw-mt-1">
+                                        <p className="tw-text-sm tw-text-gray-300 tw-mt-1">
                                             {line.merchandise.title}
                                         </p>
                                         <p className="tw-font-bold tw-text-primary tw-mt-2">
@@ -157,7 +157,7 @@ const ShoppingCart: React.FC<ShoppingCartProps> = ({ isOpen, onClose }) => {
                                                     handleUpdateQuantity(line.id, line.quantity - 1)
                                                 }
                                                 disabled={line.quantity <= 1 || isLoading}
-                                                className="tw-w-8 tw-h-8 tw-flex tw-items-center tw-justify-center tw-bg-white tw-border tw-border-gray-300 tw-rounded tw-text-gray-700 hover:tw-bg-gray-100 disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
+                                                className="tw-w-8 tw-h-8 tw-flex tw-items-center tw-justify-center tw-bg-white tw-border tw-border-gray-300 tw-rounded tw-text-gray-200 hover:tw-bg-gray-100 disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
                                             >
                                                 -
                                             </button>
@@ -169,7 +169,7 @@ const ShoppingCart: React.FC<ShoppingCartProps> = ({ isOpen, onClose }) => {
                                                     handleUpdateQuantity(line.id, line.quantity + 1)
                                                 }
                                                 disabled={isLoading}
-                                                className="tw-w-8 tw-h-8 tw-flex tw-items-center tw-justify-center tw-bg-white tw-border tw-border-gray-300 tw-rounded tw-text-gray-700 hover:tw-bg-gray-100 disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
+                                                className="tw-w-8 tw-h-8 tw-flex tw-items-center tw-justify-center tw-bg-white tw-border tw-border-gray-300 tw-rounded tw-text-gray-200 hover:tw-bg-gray-100 disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
                                             >
                                                 +
                                             </button>
@@ -208,7 +208,7 @@ const ShoppingCart: React.FC<ShoppingCartProps> = ({ isOpen, onClose }) => {
                             Proceed to Checkout
                         </button>
 
-                        <p className="tw-text-xs tw-text-gray-600 tw-text-center tw-mt-3">
+                        <p className="tw-text-xs tw-text-gray-300 tw-text-center tw-mt-3">
                             Shipping and taxes calculated at checkout
                         </p>
                     </div>

--- a/src/components/team-card/index.tsx
+++ b/src/components/team-card/index.tsx
@@ -32,7 +32,7 @@ const TeamCard = forwardRef<HTMLDivElement, TProps>(
                             />
                         </div>
                     ) : (
-                        <div className="tw-flex tw-h-[430px] tw-w-[350px] tw-items-center tw-justify-center tw-bg-gray-200">
+                        <div className="tw-flex tw-h-[430px] tw-w-[350px] tw-items-center tw-justify-center tw-bg-gray-50">
                             <span className="tw-text-gray-500">No Image</span>
                         </div>
                     )}

--- a/src/components/testimonial/rating-box.tsx
+++ b/src/components/testimonial/rating-box.tsx
@@ -10,12 +10,12 @@ const RatingBox = ({ className, heading, text }: TProps) => {
     return (
         <div
             className={clsx(
-                "tw-max-w-[210px] tw-rounded tw-bg-white tw-px-[25px] tw-pb-9 tw-pt-14 tw-text-center tw-shadow-lg tw-shadow-heading/10",
+                "tw-max-w-[210px] tw-rounded tw-bg-cream tw-px-[25px] tw-pb-9 tw-pt-14 tw-text-center tw-shadow-lg tw-shadow-heading/10",
                 className
             )}
         >
             <h3 className="tw-leading-none tw-text-secondary">{heading}</h3>
-            <div className="tw-mb-2.5 tw-mt-[5px] tw-text-lg tw-text-yellow-100">
+            <div className="tw-mb-2.5 tw-mt-[5px] tw-text-lg tw-text-gold-bright">
                 <span className="fa fa-star tw-mx-0.5" />
                 <span className="fa fa-star tw-mx-0.5" />
                 <span className="fa fa-star tw-mx-0.5" />

--- a/src/components/testimonial/testimonial-03.tsx
+++ b/src/components/testimonial/testimonial-03.tsx
@@ -10,7 +10,7 @@ const Testimonial03 = ({ description, name, designation, image, className }: TPr
     return (
         <div
             className={clsx(
-                "testimonial tw-rounded tw-bg-white tw-px-[26px] tw-py-11 tw-text-center tw-shadow-lg tw-shadow-heading/10",
+                "testimonial tw-rounded tw-bg-cream tw-px-[26px] tw-py-11 tw-text-center tw-shadow-lg tw-shadow-heading/10",
                 className
             )}
         >

--- a/src/components/testimonial/testimonial-04.tsx
+++ b/src/components/testimonial/testimonial-04.tsx
@@ -9,7 +9,7 @@ const Testimonial04 = ({ title, className }: TProps) => {
     return (
         <div
             className={clsx(
-                "tw-max-w-[270px] tw-rounded tw-bg-white tw-px-[26px] tw-py-7.5 tw-shadow-lg tw-shadow-heading/10",
+                "tw-max-w-[270px] tw-rounded tw-bg-cream tw-px-[26px] tw-py-7.5 tw-shadow-lg tw-shadow-heading/10",
                 className
             )}
         >

--- a/src/components/translator/ResumeTranslator.tsx
+++ b/src/components/translator/ResumeTranslator.tsx
@@ -105,7 +105,7 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
                 <h1 className="tw-text-4xl tw-font-bold tw-text-[#091f40]">
                     Military Resume Translator
                 </h1>
-                <p className="tw-text-lg tw-text-gray-600 tw-max-w-2xl tw-mx-auto">
+                <p className="tw-text-lg tw-text-gray-300 tw-max-w-2xl tw-mx-auto">
                     Transform your military experience into civilian-friendly resume language.
                     Enter your military job details below and we'll help you translate them
                     into terms that civilian employers understand.
@@ -254,7 +254,7 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
                             <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-2">
                                 Job Title
                             </h3>
-                            <p className="tw-text-gray-700 tw-text-lg tw-font-medium">
+                            <p className="tw-text-gray-200 tw-text-lg tw-font-medium">
                                 {translatedProfile.jobTitle}
                             </p>
                         </div>
@@ -264,7 +264,7 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
                             <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-2">
                                 Professional Summary
                             </h3>
-                            <p className="tw-text-gray-700">{translatedProfile.summary}</p>
+                            <p className="tw-text-gray-200">{translatedProfile.summary}</p>
                         </div>
 
                         {/* Key Responsibilities */}
@@ -277,7 +277,7 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
                                     {translatedProfile.keyResponsibilities.map((resp, idx) => (
                                         <li
                                             key={idx}
-                                            className="tw-flex tw-items-start tw-text-gray-700"
+                                            className="tw-flex tw-items-start tw-text-gray-200"
                                         >
                                             <span className="tw-text-[#c5203e] tw-mr-3 tw-mt-1">
                                                 •
@@ -299,7 +299,7 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
                                     {translatedProfile.achievements.map((achievement, idx) => (
                                         <li
                                             key={idx}
-                                            className="tw-flex tw-items-start tw-text-gray-700"
+                                            className="tw-flex tw-items-start tw-text-gray-200"
                                         >
                                             <span className="tw-text-[#c5203e] tw-mr-3 tw-mt-1">
                                                 •
@@ -313,7 +313,7 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
 
                         {/* Suggestions */}
                         {suggestions.length > 0 && (
-                            <div className="tw-bg-blue-50 tw-p-6 tw-rounded-lg tw-border tw-border-blue-200">
+                            <div className="tw-bg-navy-sky/20 tw-p-6 tw-rounded-lg tw-border tw-border-blue-200">
                                 <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-3">
                                     Tips for Improvement
                                 </h3>
@@ -321,9 +321,9 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
                                     {suggestions.map((suggestion, idx) => (
                                         <li
                                             key={idx}
-                                            className="tw-flex tw-items-start tw-text-sm tw-text-gray-700"
+                                            className="tw-flex tw-items-start tw-text-sm tw-text-gray-200"
                                         >
-                                            <span className="tw-text-blue-600 tw-mr-2 tw-mt-0.5">
+                                            <span className="tw-text-navy-royal tw-mr-2 tw-mt-0.5">
                                                 ℹ️
                                             </span>
                                             <span>{suggestion}</span>
@@ -344,7 +344,7 @@ const ResumeTranslator: React.FC<ResumeTranslatorProps> = ({ className }) => {
                         </Button>
                         <Button
                             onClick={handleReset}
-                            className="tw-transform tw-rounded-lg tw-bg-gray-500 tw-px-6 tw-py-3 tw-font-semibold tw-text-white tw-transition tw-duration-200 tw-ease-in-out hover:tw-bg-gray-600 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-gray-500 focus:tw-ring-offset-2"
+                            className="tw-transform tw-rounded-lg tw-bg-gray-50 tw-px-6 tw-py-3 tw-font-semibold tw-text-white tw-transition tw-duration-200 tw-ease-in-out hover:tw-bg-gray-300 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-gray-500 focus:tw-ring-offset-2"
                         >
                             Translate Another Resume
                         </Button>

--- a/src/components/ui/alert/index.tsx
+++ b/src/components/ui/alert/index.tsx
@@ -11,7 +11,7 @@ const Alert = ({ className, children, color }: TProps) => {
         <div
             className={clsx(
                 "alert tw-rounded tw-py-2.5 tw-pl-3 tw-pr-3 nextIcon:tw-mr-2",
-                color === "light" && "tw-bg-gray-200 nextIcon:tw-text-azure",
+                color === "light" && "tw-bg-gray-50 nextIcon:tw-text-navy-ocean",
                 color === "warning" && "tw-bg-warning-100 tw-text-heading",
                 color === "secondary" && "tw-bg-secondary tw-text-white",
                 className

--- a/src/components/ui/badge/index.tsx
+++ b/src/components/ui/badge/index.tsx
@@ -14,8 +14,8 @@ const Badge = ({ children, className, color, size, variant }: TProps) => {
             className={clsx(
                 "tw-inline-flex tw-items-center tw-justify-center tw-leading-none",
                 variant === "contained" && [
-                    color === "teracotta" && "tw-bg-teracotta-light tw-text-teracotta",
-                    color === "scooter" && "tw-bg-scooter-light tw-text-scooter",
+                    color === "teracotta" && "tw-bg-red-signal/10 tw-text-red",
+                    color === "scooter" && "tw-bg-navy-sky tw-text-navy-ocean",
                     color === "primary" && "tw-bg-primary tw-text-white",
                     color === "gradient" && "tw-bg-strawGradient tw-text-white",
                 ],

--- a/src/components/ui/bottom-shape/shape-03.tsx
+++ b/src/components/ui/bottom-shape/shape-03.tsx
@@ -20,7 +20,7 @@ const BottomShape = ({ className, color }: TProps) => {
 };
 
 BottomShape.defaultProps = {
-    color: "tw-fill-light-100",
+    color: "tw-fill-white",
 };
 
 export default BottomShape;

--- a/src/components/ui/button/index.tsx
+++ b/src/components/ui/button/index.tsx
@@ -125,7 +125,7 @@ const Button = ({
     ];
 
     // Light Button
-    const containedLightClass = "tw-bg-light tw-border-light tw-text-heading tw-shadow-sm";
+    const containedLightClass = "tw-bg-white tw-border-white tw-text-navy tw-shadow-sm";
     const containedLightHoverClass =
         !disabled &&
         !active &&
@@ -142,7 +142,7 @@ const Button = ({
         lightHoverClass,
     ];
 
-    const outlinedLightClass = "tw-border-light tw-text-light";
+    const outlinedLightClass = "tw-border-white tw-text-white";
     const outlinedLightHoverClass =
         !disabled &&
         !active &&

--- a/src/components/ui/form-elements/checkbox.tsx
+++ b/src/components/ui/form-elements/checkbox.tsx
@@ -32,7 +32,7 @@ const Checkbox = forwardRef<HTMLInputElement, IProps>(
         ref
     ) => {
         const beforeClass =
-            "before:tw-absolute before:tw-content[''] before:tw-w-full before:tw-h-full before:tw-top-px before:tw-left-0 before:tw-transition-colors before:tw-duration-300 before:tw-bg-gray-200 before:tw-border before:tw-border-gray-200 before:tw-rounded-sm";
+            "before:tw-absolute before:tw-content[''] before:tw-w-full before:tw-h-full before:tw-top-px before:tw-left-0 before:tw-transition-colors before:tw-duration-300 before:tw-bg-gray-50 before:tw-border before:tw-border-gray-200 before:tw-rounded-sm";
         const disabledClass = disabled && "tw-opacity-50 before:tw-opacity-50 after:tw-opacity-50";
         const afterClass =
             "after:tw-absolute after:tw-content[''] after:tw-block after:tw-bg-primary after:tw-w-2 after:tw-h-2 after:tw-top-1/2 after:tw-left-1/2 after:-tw-translate-x-1/2 after:-tw-translate-y-1/2 after:tw-scale-0 after:tw-transition-transform after:tw-duration-300 after:tw-rounded-sm after:z-10";

--- a/src/components/ui/form-elements/input.tsx
+++ b/src/components/ui/form-elements/input.tsx
@@ -68,7 +68,7 @@ const Input = forwardRef<HTMLInputElement, IProps>(
                         focusBorderClass,
                         noFocusClass,
                         bg === "white" && "tw-bg-white",
-                        bg === "light" && "tw-bg-gray-200",
+                        bg === "light" && "tw-bg-gray-50",
                         className
                     )}
                     id={id}

--- a/src/components/ui/form-elements/textarea.tsx
+++ b/src/components/ui/form-elements/textarea.tsx
@@ -44,7 +44,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, IProps>(
         const successClass = !showErrorOnly && state === "success" && "!tw-border-success";
         const warningClass = !showErrorOnly && state === "warning" && "!tw-border-warning";
         const errorClass = state === "error" && "!tw-border-danger";
-        const focusBorderClass = customStyle !== "nofocus" && !state && "focus:tw-border-blue-100";
+        const focusBorderClass = customStyle !== "nofocus" && !state && "focus:tw-border-navy-ocean";
         const noFocusClass = customStyle === "nofocus" && "focus:tw-outline-0";
 
         return (
@@ -64,7 +64,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, IProps>(
                         focusBorderClass,
                         noFocusClass,
                         bg === "white" && "tw-bg-white",
-                        bg === "light" && "tw-bg-gray-200",
+                        bg === "light" && "tw-bg-gray-50",
                         className
                     )}
                     id={id}

--- a/src/components/ui/motto-text/index.tsx
+++ b/src/components/ui/motto-text/index.tsx
@@ -26,7 +26,7 @@ const MottoText = forwardRef<HTMLParagraphElement, TProps>(
                 path={path}
                 className={clsx(
                     "tw-relative tw-py-[3px] tw-font-bold tw-leading-none tw-text-primary",
-                    "before:tw-absolute before:tw-bottom-0 before:tw-left-0 before:tw-h-px before:tw-w-full before:tw-origin-right before:tw-scale-x-100 before:tw-bg-gray-350 before:tw-transition-transform before:tw-delay-300 before:tw-duration-600 before:tw-ease-in-expo before:tw-content-['']",
+                    "before:tw-absolute before:tw-bottom-0 before:tw-left-0 before:tw-h-px before:tw-w-full before:tw-origin-right before:tw-scale-x-100 before:tw-bg-gray-100 before:tw-transition-transform before:tw-delay-300 before:tw-duration-600 before:tw-ease-in-expo before:tw-content-['']",
                     "after:tw-absolute after:tw-bottom-0 after:tw-left-0 after:tw-h-px after:tw-w-full after:tw-origin-left after:tw-scale-x-0 after:tw-bg-primary after:tw-transition-transform after:tw-delay-75 after:tw-duration-600 after:tw-ease-in-expo after:tw-content-['']",
                     "hover:before:tw-scale-x-0 hover:before:tw-delay-75 hover:after:tw-scale-x-100 hover:after:tw-delay-300"
                 )}

--- a/src/components/ui/nice-select/index.tsx
+++ b/src/components/ui/nice-select/index.tsx
@@ -49,7 +49,7 @@ const NiceSelect = ({ className, options, setValue, prefix, defaultValue }: TPro
         <div
             className={clsx(
                 "nice-select tw-relative tw-rounded-md tw-border tw-transition-all",
-                !open && "tw-border-gray-200 tw-bg-gray-200",
+                !open && "tw-border-gray-200 tw-bg-gray-50",
                 "hover:tw-border-primary hover:tw-bg-transparent",
                 className,
                 open && "tw-border-primary tw-bg-transparent"

--- a/src/components/ui/progress-bar/index.tsx
+++ b/src/components/ui/progress-bar/index.tsx
@@ -61,7 +61,7 @@ const ProgressBar: FC<ProgressProps> = ({
         size === "lg" && "tw-h-5",
     ];
     return (
-        <div className={clsx("progress tw-rounded-sm tw-bg-gray-500", className)} {...restProps}>
+        <div className={clsx("progress tw-rounded-sm tw-bg-gray-50", className)} {...restProps}>
             <motion.div
                 role="progressbar"
                 aria-valuenow={now}

--- a/src/components/ui/star-rating/index.tsx
+++ b/src/components/ui/star-rating/index.tsx
@@ -31,7 +31,7 @@ const StarRating = ({ rating, className, align, size, space }: TProps) => {
                 <i
                     key={item}
                     className={clsx(
-                        "fas fa-star tw-text-yellow first:tw-ml-0",
+                        "fas fa-star tw-text-gold first:tw-ml-0",
                         space === "xs" && "tw-mx-px",
                         space === "sm" && "tw-mx-0.5"
                     )}
@@ -40,7 +40,7 @@ const StarRating = ({ rating, className, align, size, space }: TProps) => {
             {remainder > 0 && (
                 <i
                     className={clsx(
-                        "fas fa-star-half-alt tw-text-yellow first:tw-ml-0",
+                        "fas fa-star-half-alt tw-text-gold first:tw-ml-0",
                         space === "xs" && "tw-mx-px",
                         space === "sm" && "tw-mx-0.5"
                     )}

--- a/src/components/ui/wrapper/wrapper-01.tsx
+++ b/src/components/ui/wrapper/wrapper-01.tsx
@@ -20,7 +20,7 @@ const Wrapper = ({ children, className, color }: TProps) => {
 };
 
 Wrapper.defaultProps = {
-    color: "tw-bg-spring",
+    color: "tw-bg-cream",
 };
 
 export default Wrapper;

--- a/src/components/ui/wrapper/wrapper-02.tsx
+++ b/src/components/ui/wrapper/wrapper-02.tsx
@@ -20,7 +20,7 @@ const Wrapper = ({ children, className, color }: TProps) => {
 };
 
 Wrapper.defaultProps = {
-    color: "tw-bg-light-100",
+    color: "tw-bg-gray-50",
 };
 
 export default Wrapper;

--- a/src/components/ui/wrapper/wrapper-04.tsx
+++ b/src/components/ui/wrapper/wrapper-04.tsx
@@ -19,21 +19,21 @@ const Wrapper = ({ children, className, showBalls }: TProps) => {
             {showBalls && (
                 <>
                     <motion.div
-                        className="tw-absolute tw-left-[70px] tw-top-[164px] tw-h-[35px] tw-w-[35px] tw-rounded-full tw-bg-orange-100/70"
+                        className="tw-absolute tw-left-[70px] tw-top-[164px] tw-h-[35px] tw-w-[35px] tw-rounded-full tw-bg-red-signal/70"
                         animate={{
                             x: trans1().x,
                             y: trans1().y,
                         }}
                     />
                     <motion.div
-                        className="tw-absolute tw-right-32 tw-top-[70px] tw-h-9 tw-w-9 tw-rounded-full tw-bg-blue-100/70"
+                        className="tw-absolute tw-right-32 tw-top-[70px] tw-h-9 tw-w-9 tw-rounded-full tw-bg-navy-sky/70"
                         animate={{
                             x: trans1().x,
                             y: trans1().y,
                         }}
                     />
                     <motion.div
-                        className="tw-absolute -tw-right-6 -tw-top-[120px] tw-h-[46px] tw-w-[46px] tw-rounded-full tw-bg-jagged"
+                        className="tw-absolute -tw-right-6 -tw-top-[120px] tw-h-[46px] tw-w-[46px] tw-rounded-full tw-bg-navy-sky"
                         animate={{
                             x: trans2().x,
                             y: trans2().y,

--- a/src/components/url-preview-card/index.tsx
+++ b/src/components/url-preview-card/index.tsx
@@ -97,11 +97,11 @@ export default function URLPreviewCard({ url, className = '' }: URLPreviewCardPr
   if (loading) {
     return (
       <div className={`tw-animate-pulse tw-border tw-border-gray-200 tw-rounded-lg tw-overflow-hidden ${className}`}>
-        <div className="tw-h-48 tw-bg-gray-200" />
+        <div className="tw-h-48 tw-bg-gray-50" />
         <div className="tw-p-4">
-          <div className="tw-h-4 tw-bg-gray-200 tw-rounded tw-w-3/4 tw-mb-2" />
-          <div className="tw-h-3 tw-bg-gray-200 tw-rounded tw-w-full tw-mb-1" />
-          <div className="tw-h-3 tw-bg-gray-200 tw-rounded tw-w-5/6" />
+          <div className="tw-h-4 tw-bg-gray-50 tw-rounded tw-w-3/4 tw-mb-2" />
+          <div className="tw-h-3 tw-bg-gray-50 tw-rounded tw-w-full tw-mb-1" />
+          <div className="tw-h-3 tw-bg-gray-50 tw-rounded tw-w-5/6" />
         </div>
       </div>
     );
@@ -117,7 +117,7 @@ export default function URLPreviewCard({ url, className = '' }: URLPreviewCardPr
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="tw-text-blue-600 tw-text-sm tw-underline tw-break-all"
+          className="tw-text-navy-royal tw-text-sm tw-underline tw-break-all"
         >
           {url}
         </a>
@@ -165,11 +165,11 @@ export default function URLPreviewCard({ url, className = '' }: URLPreviewCardPr
             </span>
           </div>
         )}
-        <h3 className="tw-font-semibold tw-text-gray-900 tw-mb-2 tw-line-clamp-2 group-hover:tw-text-blue-600 tw-transition-colors">
+        <h3 className="tw-font-semibold tw-text-ink tw-mb-2 tw-line-clamp-2 group-hover:tw-text-navy-royal tw-transition-colors">
           {metadata.title}
         </h3>
         {metadata.description && (
-          <p className="tw-text-sm tw-text-gray-600 tw-line-clamp-2">
+          <p className="tw-text-sm tw-text-gray-300 tw-line-clamp-2">
             {metadata.description}
           </p>
         )}

--- a/src/components/widgets/popular-tags-widget.tsx
+++ b/src/components/widgets/popular-tags-widget.tsx
@@ -14,7 +14,7 @@ const PopularTagsWidget = ({ tags }: TProps) => {
                     <Anchor
                         key={tag.slug}
                         path={`/blogs/tag/${tag.slug}`}
-                        className="tw-m-[5px] tw-inline-block tw-rounded-[3px] tw-bg-gray-200 tw-px-3.8 tw-pb-1.5 tw-pt-[7px] tw-text-[13px] tw-font-medium tw-lowercase tw-leading-normal tw-text-gray-400 hover:tw-bg-primary hover:tw-text-white"
+                        className="tw-m-[5px] tw-inline-block tw-rounded-[3px] tw-bg-gray-50 tw-px-3.8 tw-pb-1.5 tw-pt-[7px] tw-text-[13px] tw-font-medium tw-lowercase tw-leading-normal tw-text-gray-400 hover:tw-bg-primary hover:tw-text-white"
                     >
                         {tag.title}
                     </Anchor>

--- a/src/components/zoom-card/index.tsx
+++ b/src/components/zoom-card/index.tsx
@@ -47,7 +47,7 @@ const ZoomCard = forwardRef<HTMLDivElement, TProps>(
                     </h3>
 
                     <div className="tw-mt-[7px] tw-flex tw-items-center">
-                        <span className="tw-text-[13px] tw-font-medium tw-uppercase tw-tracking-[1.73px] tw-text-gray-700">
+                        <span className="tw-text-[13px] tw-font-medium tw-uppercase tw-tracking-[1.73px] tw-text-gray-200">
                             Meeting ID:{" "}
                         </span>
                         <span className="tw-text-[16px] tw-font-semibold tw-tracking-[2.13px] tw-text-primary">

--- a/src/containers/about/layout-02/index.tsx
+++ b/src/containers/about/layout-02/index.tsx
@@ -70,7 +70,7 @@ const AboutArea = ({ data: { section_title, motto, images }, space, bg, titleSiz
                             y: trans1().y,
                         }}
                     >
-                        <span className="tw-block tw-h-[45px] tw-w-[45px] tw-rounded-full tw-border-[7px] tw-border-desert -tw-indent-[99999px] lg:tw-h-15 lg:tw-w-15">
+                        <span className="tw-block tw-h-[45px] tw-w-[45px] tw-rounded-full tw-border-[7px] tw-border-red -tw-indent-[99999px] lg:tw-h-15 lg:tw-w-15">
                             shape 1
                         </span>
                     </motion.div>
@@ -108,7 +108,7 @@ const AboutArea = ({ data: { section_title, motto, images }, space, bg, titleSiz
 };
 
 AboutArea.defaultProps = {
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-gray-50",
 };
 
 export default AboutArea;

--- a/src/containers/app-download/index.tsx
+++ b/src/containers/app-download/index.tsx
@@ -67,7 +67,7 @@ const AppDownloadArea = ({
                             y: trans2().y,
                         }}
                     >
-                        <span className="tw-block tw-h-[62px] tw-w-[62px] tw-rounded-full tw-border-8 tw-border-desert -tw-indent-[99999px]">
+                        <span className="tw-block tw-h-[62px] tw-w-[62px] tw-rounded-full tw-border-8 tw-border-red -tw-indent-[99999px]">
                             shape 1
                         </span>
                     </motion.div>

--- a/src/containers/blog/layout-01/index.tsx
+++ b/src/containers/blog/layout-01/index.tsx
@@ -146,7 +146,7 @@ const BlogArea = ({ data: { section_title, motto, blogs }, space, bg, titleSize 
 
 BlogArea.defaultProps = {
     space: "top-bottom",
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-gray-50",
 };
 
 export default BlogArea;

--- a/src/containers/blog/layout-02/index.tsx
+++ b/src/containers/blog/layout-02/index.tsx
@@ -71,7 +71,7 @@ const BlogArea = ({
 };
 
 BlogArea.defaultProps = {
-    bg: "tw-bg-spring",
+    bg: "tw-bg-cream",
 };
 
 export default BlogArea;

--- a/src/containers/blog/layout-03/index.tsx
+++ b/src/containers/blog/layout-03/index.tsx
@@ -24,6 +24,7 @@ const BlogArea = ({ data: { section_title, blogs }, space, bg, titleSize }: TPro
                     <AnimatedSectionTitle
                         {...section_title}
                         titleSize={titleSize}
+                        color="C"
                         className="tw-mb-7.5 md:tw-mb-15"
                         initial="offscreen"
                         whileInView="onscreen"
@@ -54,7 +55,7 @@ const BlogArea = ({ data: { section_title, blogs }, space, bg, titleSize }: TPro
 };
 
 BlogArea.defaultProps = {
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-navy",
 };
 
 export default BlogArea;

--- a/src/containers/course-details/curriculam-panel.tsx
+++ b/src/containers/course-details/curriculam-panel.tsx
@@ -23,7 +23,7 @@ const CurriculumPanel = ({ curriculum, courseSlug }: TProps) => {
             {curriculum.map(({ id, title, description, lessons }) => (
                 <div
                     key={id}
-                    className="tw-mt-[50px] tw-rounded tw-border tw-border-alto first:tw-mt-0"
+                    className="tw-mt-[50px] tw-rounded tw-border tw-border-gray-100 first:tw-mt-0"
                 >
                     <div className="tw-px-3.8 tw-py-5 md:tw-px-12 md:tw-py-[22px]">
                         <h5 className="tw-mb-0 tw-text-xl">{title}</h5>

--- a/src/containers/course-details/enrollment-sidebar.tsx
+++ b/src/containers/course-details/enrollment-sidebar.tsx
@@ -85,14 +85,14 @@ const EnrollmentSidebar = ({ course }: TProps) => {
             {/* Enrollment Card */}
             <div className="tw-rounded-lg tw-border tw-border-gray-200 tw-bg-white tw-p-6 tw-shadow-lg">
                 <div className="tw-mb-6 tw-text-center">
-                    <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-green-600">FREE</div>
-                    <p className="tw-text-gray-600">For veterans & military spouses</p>
+                    <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gold">FREE</div>
+                    <p className="tw-text-gray-300">For veterans & military spouses</p>
                 </div>
 
                 {checkingEnrollment ? (
                     <div className="tw-py-4 tw-text-center">
                         <div className="tw-mx-auto tw-h-8 tw-w-8 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
-                        <p className="tw-mt-2 tw-text-gray-600">Checking enrollment...</p>
+                        <p className="tw-mt-2 tw-text-gray-300">Checking enrollment...</p>
                     </div>
                 ) : (
                     <div>
@@ -100,7 +100,7 @@ const EnrollmentSidebar = ({ course }: TProps) => {
                             <div>
                                 {isEnrolled ? (
                                     <div className="tw-text-center">
-                                        <div className="tw-mb-4 tw-rounded-md tw-bg-green-100 tw-px-4 tw-py-2 tw-text-green-800">
+                                        <div className="tw-mb-4 tw-rounded-md tw-bg-gold-light/30 tw-px-4 tw-py-2 tw-text-gold-deep">
                                             ✓ Enrolled
                                         </div>
                                         <Link
@@ -132,7 +132,7 @@ const EnrollmentSidebar = ({ course }: TProps) => {
                                             </button>
                                         )}
 
-                                        <p className="tw-text-center tw-text-sm tw-text-gray-600">
+                                        <p className="tw-text-center tw-text-sm tw-text-gray-300">
                                             Access interactive lessons, assignments, and progress
                                             tracking
                                         </p>
@@ -147,7 +147,7 @@ const EnrollmentSidebar = ({ course }: TProps) => {
                                 >
                                     Sign In to Enroll
                                 </Link>
-                                <p className="tw-text-center tw-text-sm tw-text-gray-600">
+                                <p className="tw-text-center tw-text-sm tw-text-gray-300">
                                     Join the learning platform for hands-on experience
                                 </p>
                             </div>
@@ -157,10 +157,10 @@ const EnrollmentSidebar = ({ course }: TProps) => {
 
                 {/* Course Info */}
                 <div className="tw-mt-6 tw-border-t tw-border-gray-200 tw-pt-6">
-                    <h4 className="tw-mb-3 tw-font-semibold tw-text-gray-900">
+                    <h4 className="tw-mb-3 tw-font-semibold tw-text-ink">
                         What&apos;s Included:
                     </h4>
-                    <ul className="tw-space-y-2 tw-text-sm tw-text-gray-600">
+                    <ul className="tw-space-y-2 tw-text-sm tw-text-gray-300">
                         <li className="tw-flex tw-items-center">
                             <i className="fas fa-check tw-mr-2 tw-text-green-500" />
                             Course materials & resources
@@ -186,7 +186,7 @@ const EnrollmentSidebar = ({ course }: TProps) => {
 
                 {/* Quick Links */}
                 <div className="tw-mt-6 tw-border-t tw-border-gray-200 tw-pt-6">
-                    <h4 className="tw-mb-3 tw-font-semibold tw-text-gray-900">Quick Links:</h4>
+                    <h4 className="tw-mb-3 tw-font-semibold tw-text-ink">Quick Links:</h4>
                     <div className="tw-space-y-2">
                         <Link
                             href="/courses"

--- a/src/containers/course/layout-02/index.tsx
+++ b/src/containers/course/layout-02/index.tsx
@@ -86,7 +86,7 @@ const CtaArea = ({ data: { section_title, buttons }, space, bg }: TProps) => {
 };
 
 CtaArea.defaultProps = {
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-gray-50",
 };
 
 export default CtaArea;

--- a/src/containers/cta/layout-02/index.tsx
+++ b/src/containers/cta/layout-02/index.tsx
@@ -86,7 +86,7 @@ const CtaArea = ({ data: { section_title, buttons }, space, bg }: TProps) => {
 };
 
 CtaArea.defaultProps = {
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-gray-50",
 };
 
 export default CtaArea;

--- a/src/containers/gradation/index.tsx
+++ b/src/containers/gradation/index.tsx
@@ -41,7 +41,7 @@ const GradationArea = ({ data: { section_title, items } }: TProps) => {
                         viewport={{ once: true, amount: 0.4 }}
                         variants={scrollUpVariants}
                     >
-                        <mark className="tw-absolute tw-right-0 tw-top-1/2 -tw-z-1 -tw-translate-y-1/2 tw-bg-transparent tw-p-5 tw-text-[120px] tw-font-black tw-leading-[0.8] tw-text-gray-550">
+                        <mark className="tw-absolute tw-right-0 tw-top-1/2 -tw-z-1 -tw-translate-y-1/2 tw-bg-transparent tw-p-5 tw-text-[120px] tw-font-black tw-leading-[0.8] tw-text-gray-100">
                             {items?.length.toString() || "0"}
                         </mark>
                         Steps

--- a/src/containers/hero/layout-01/index.tsx
+++ b/src/containers/hero/layout-01/index.tsx
@@ -21,7 +21,7 @@ const HeroArea = ({ data: { headings, texts, buttons, images, popularCourse } }:
     const { trans1 } = useUI();
 
     return (
-        <div className="tw-relative tw-isolate tw-flex tw-h-full tw-items-center tw-overflow-hidden tw-bg-pearl tw-py-[50px] md:tw-min-h-[750px] xl:tw-min-h-[820px]">
+        <div className="tw-relative tw-isolate tw-flex tw-h-full tw-items-center tw-overflow-hidden tw-bg-cream tw-py-[50px] md:tw-min-h-[750px] xl:tw-min-h-[820px]">
             <h1 className="tw-sr-only">Home Page</h1>
             <div className="bgimg tw-absolute tw-inset-0 -tw-z-10 tw-hidden md:tw-block">
                 {images?.[0]?.src && (

--- a/src/containers/hero/layout-04/index.tsx
+++ b/src/containers/hero/layout-04/index.tsx
@@ -48,7 +48,7 @@ const HeroArea = ({ data: { images, headings, texts, buttons, video } }: TProps)
                                 left: 0,
                                 width: "100%",
                                 height: "100%",
-                                background: "linear-gradient(135deg, rgba(9, 31, 64, 0.85) 0%, rgba(197, 32, 62, 0.75) 100%)",
+                                background: "linear-gradient(135deg, rgba(9, 31, 64, 0.90) 0%, rgba(6, 26, 64, 0.85) 100%)",
                             }}
                         />
                     </div>
@@ -101,7 +101,7 @@ const HeroArea = ({ data: { images, headings, texts, buttons, video } }: TProps)
                         </div>
                     </div>
                 </motion.div>
-                <BottomShape color="tw-fill-light-100" />
+                <BottomShape color="tw-fill-white" />
             </div>
 
             {video && (

--- a/src/containers/hero/layout-05/index.tsx
+++ b/src/containers/hero/layout-05/index.tsx
@@ -16,7 +16,7 @@ type TProps = {
 
 const HeroArea = ({ data: { headings, texts, buttons, images } }: TProps) => {
     return (
-        <div className="hero-area tw-relative tw-flex tw-items-center tw-bg-ebb">
+        <div className="hero-area tw-relative tw-flex tw-items-center tw-bg-gray-50">
             <div className="tw-container tw-relative tw-z-10 tw-grid tw-grid-cols-1 tw-gap-7.5 lg:tw-grid-cols-2">
                 <motion.div
                     className="md:p-0 tw-self-center tw-px-3.8 tw-pb-10 tw-pt-[140px] tw-text-center md:tw-max-w-[460px] md:tw-text-left"

--- a/src/containers/hero/layout-06/index.tsx
+++ b/src/containers/hero/layout-06/index.tsx
@@ -21,7 +21,7 @@ const HeroArea = ({ data: { headings, texts, buttons, images, video } }: TProps)
     const y1 = useTransform(scrollY, [0, 300], [0, -100]);
 
     return (
-        <div className="hero-area tw-relative tw-bg-gore tw-pt-[120px] md:tw-pt-44 xl:tw-pt-[176px]">
+        <div className="hero-area tw-relative tw-bg-navy tw-pt-[120px] md:tw-pt-44 xl:tw-pt-[176px]">
             <div className="tw-container">
                 <motion.div
                     className="tw-relative tw-z-10 tw-mb-10 tw-text-center md:tw-mb-20"

--- a/src/containers/hero/layout-07/index.tsx
+++ b/src/containers/hero/layout-07/index.tsx
@@ -58,7 +58,7 @@ const HeroArea = ({ data: { items } }: TProps) => {
                                     className="tw-absolute tw-inset-0"
                                     style={{
                                         background:
-                                            "linear-gradient(135deg, rgba(9, 31, 64, 0.85) 0%, rgba(197, 32, 62, 0.75) 100%)",
+                                            "linear-gradient(135deg, rgba(9, 31, 64, 0.90) 0%, rgba(6, 26, 64, 0.85) 100%)",
                                     }}
                                 />
                             </div>

--- a/src/containers/profile/bio.tsx
+++ b/src/containers/profile/bio.tsx
@@ -70,7 +70,7 @@ const ProfileBio = () => {
                 <div className="tw-container tw-flex tw-min-h-[400px] tw-items-center tw-justify-center">
                     <div className="tw-text-center">
                         <div className="tw-mx-auto tw-h-16 tw-w-16 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
-                        <p className="tw-mt-4 tw-text-gray-600">Loading your profile...</p>
+                        <p className="tw-mt-4 tw-text-gray-300">Loading your profile...</p>
                     </div>
                 </div>
             </Section>
@@ -82,7 +82,7 @@ const ProfileBio = () => {
             <div className="tw-container">
                 {/* Header with Edit Button */}
                 <div className="tw-mb-8 tw-flex tw-items-center tw-justify-between">
-                    <h1 className="tw-text-3xl tw-font-bold tw-text-gray-900">Your Profile</h1>
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Your Profile</h1>
                     <div className="tw-flex tw-space-x-3">
                         {isEditing ? (
                             <>
@@ -92,7 +92,7 @@ const ProfileBio = () => {
                                         setIsEditing(false);
                                         setFormData(profile);
                                     }}
-                                    className="tw-rounded-md tw-border tw-border-gray-300 tw-px-4 tw-py-2 tw-text-gray-700 hover:tw-bg-gray-50"
+                                    className="tw-rounded-md tw-border tw-border-gray-300 tw-px-4 tw-py-2 tw-text-gray-200 hover:tw-bg-gray-50"
                                 >
                                     Cancel
                                 </button>
@@ -139,7 +139,7 @@ const ProfileBio = () => {
                                     <div>
                                         <label
                                             htmlFor="name"
-                                            className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                            className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                         >
                                             Name
                                         </label>
@@ -156,7 +156,7 @@ const ProfileBio = () => {
                                     <div>
                                         <label
                                             htmlFor="title"
-                                            className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                            className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                         >
                                             Job Title
                                         </label>
@@ -174,7 +174,7 @@ const ProfileBio = () => {
                                     <div>
                                         <label
                                             htmlFor="bio"
-                                            className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                            className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                         >
                                             Bio
                                         </label>

--- a/src/containers/quote/layout-01/index.tsx
+++ b/src/containers/quote/layout-01/index.tsx
@@ -74,7 +74,7 @@ const QuoteArea = ({ data: { items }, space, bg }: TProps) => {
                         y: trans1().y,
                     }}
                 >
-                    <span className="tw-block tw-h-[35px] tw-w-[35px] tw-rounded-full tw-bg-orange-200" />
+                    <span className="tw-block tw-h-[35px] tw-w-[35px] tw-rounded-full tw-bg-red-signal" />
                 </motion.div>
                 <motion.div
                     className="tw-absolute tw-left-0 tw-top-[155px] tw-z-20 lg:tw-left-5 lg:tw-top-[300px]"
@@ -83,7 +83,7 @@ const QuoteArea = ({ data: { items }, space, bg }: TProps) => {
                         y: trans1().y,
                     }}
                 >
-                    <span className="tw-block tw-h-[54px] tw-w-[54px] tw-rounded-full tw-bg-porsche" />
+                    <span className="tw-block tw-h-[54px] tw-w-[54px] tw-rounded-full tw-bg-gold" />
                 </motion.div>
                 <motion.div
                     className="tw-absolute tw-right-0 tw-top-[-100px] tw-z-20 lg:-tw-right-5"
@@ -92,7 +92,7 @@ const QuoteArea = ({ data: { items }, space, bg }: TProps) => {
                         y: trans1().y,
                     }}
                 >
-                    <span className="tw-block tw-h-[46px] tw-w-[46px] tw-rounded-full tw-bg-jagged" />
+                    <span className="tw-block tw-h-[46px] tw-w-[46px] tw-rounded-full tw-bg-navy-sky" />
                 </motion.div>
                 <motion.div
                     className="tw-absolute tw-right-7.5 tw-top-0 tw-z-20"
@@ -101,7 +101,7 @@ const QuoteArea = ({ data: { items }, space, bg }: TProps) => {
                         y: trans1().y,
                     }}
                 >
-                    <span className="tw-block tw-h-9 tw-w-9 tw-rounded-full tw-bg-blue-100/60" />
+                    <span className="tw-block tw-h-9 tw-w-9 tw-rounded-full tw-bg-navy-sky/60" />
                 </motion.div>
                 <motion.div
                     className="tw-absolute tw-right-0 tw-top-[155px] tw-z-20 lg:tw-right-12 lg:tw-top-[233px]"
@@ -110,7 +110,7 @@ const QuoteArea = ({ data: { items }, space, bg }: TProps) => {
                         y: trans2().y,
                     }}
                 >
-                    <span className="tw-block tw-h-[38px] tw-w-[38px] tw-rounded-full tw-bg-mandy/70" />
+                    <span className="tw-block tw-h-[38px] tw-w-[38px] tw-rounded-full tw-bg-red/70" />
                 </motion.div>
             </div>
         </Section>
@@ -118,7 +118,7 @@ const QuoteArea = ({ data: { items }, space, bg }: TProps) => {
 };
 
 QuoteArea.defaultProps = {
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-gray-50",
 };
 
 export default QuoteArea;

--- a/src/containers/service/layout-06/index.tsx
+++ b/src/containers/service/layout-06/index.tsx
@@ -77,7 +77,7 @@ const ServiceArea = ({ data: { section_title, items, images }, space, bg, titleS
                             y: trans1().y,
                         }}
                     >
-                        <span className="tw-block tw-h-[35px] tw-w-[35px] tw-rounded-full tw-bg-orange-300" />
+                        <span className="tw-block tw-h-[35px] tw-w-[35px] tw-rounded-full tw-bg-red" />
                     </motion.div>
                     <motion.div
                         className="tw-absolute -tw-bottom-28 tw-left-0 tw-z-1"
@@ -86,7 +86,7 @@ const ServiceArea = ({ data: { section_title, items, images }, space, bg, titleS
                             y: trans2().y,
                         }}
                     >
-                        <span className="tw-block tw-h-[54px] tw-w-[54px] tw-rounded-full tw-bg-porsche" />
+                        <span className="tw-block tw-h-[54px] tw-w-[54px] tw-rounded-full tw-bg-gold" />
                     </motion.div>
                     <motion.div
                         className="tw-absolute tw-right-0 tw-top-15 tw-z-1"
@@ -95,7 +95,7 @@ const ServiceArea = ({ data: { section_title, items, images }, space, bg, titleS
                             y: trans2().y,
                         }}
                     >
-                        <span className="tw-block tw-h-[46px] tw-w-[46px] tw-rounded-full tw-bg-jagged" />
+                        <span className="tw-block tw-h-[46px] tw-w-[46px] tw-rounded-full tw-bg-navy-sky" />
                     </motion.div>{" "}
                     <motion.div
                         className="tw-absolute tw-bottom-16 tw-right-10 tw-z-1"
@@ -104,7 +104,7 @@ const ServiceArea = ({ data: { section_title, items, images }, space, bg, titleS
                             y: trans2().y,
                         }}
                     >
-                        <span className="tw-block tw-h-[38px] tw-w-[38px] tw-rounded-full tw-bg-mandy/70" />
+                        <span className="tw-block tw-h-[38px] tw-w-[38px] tw-rounded-full tw-bg-red/70" />
                     </motion.div>
                     <motion.div
                         className="tw-absolute -tw-bottom-24 tw-right-0 tw-z-1"
@@ -113,7 +113,7 @@ const ServiceArea = ({ data: { section_title, items, images }, space, bg, titleS
                             y: trans1().y,
                         }}
                     >
-                        <span className="tw-block tw-h-9 tw-w-9 tw-rounded-full tw-bg-blue-100/60" />
+                        <span className="tw-block tw-h-9 tw-w-9 tw-rounded-full tw-bg-navy-sky/60" />
                     </motion.div>
                 </div>
             </div>

--- a/src/containers/testimonial/layout-03/index.tsx
+++ b/src/containers/testimonial/layout-03/index.tsx
@@ -66,7 +66,7 @@ const TestimonialArea = ({
                         {items.map((item) => (
                             <SwiperSlide key={item.id}>
                                 <Testimonial
-                                    className="!tw-bg-gray-200 tw-shadow-[0_16px_40px_-40px]"
+                                    className="!tw-bg-gray-50 tw-shadow-[0_16px_40px_-40px]"
                                     name={item.name}
                                     designation={item.designation}
                                     title={item.title}

--- a/src/containers/testimonial/layout-04/index.tsx
+++ b/src/containers/testimonial/layout-04/index.tsx
@@ -128,7 +128,7 @@ const TestimonialArea = ({
                     variants={scrollUpVariants}
                 >
                     {section_title && (
-                        <SectionTitle {...section_title} align="left" titleSize={titleSize} />
+                        <SectionTitle {...section_title} align="left" titleSize={titleSize} color="C" />
                     )}
 
                     {buttons?.[0]?.content && (
@@ -143,7 +143,7 @@ const TestimonialArea = ({
 };
 
 TestimonialArea.defaultProps = {
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-navy",
 };
 
 export default TestimonialArea;

--- a/src/containers/video/layout-01/index.tsx
+++ b/src/containers/video/layout-01/index.tsx
@@ -122,7 +122,7 @@ const VideoArea = ({ data: { section_title, images, video }, space, bg }: TProps
 };
 
 VideoArea.defaultProps = {
-    bg: "tw-bg-spring",
+    bg: "tw-bg-cream",
     space: "top-bottom",
 };
 

--- a/src/containers/video/layout-03/index.tsx
+++ b/src/containers/video/layout-03/index.tsx
@@ -106,7 +106,7 @@ const VideoArea = ({
 };
 
 VideoArea.defaultProps = {
-    bg: "tw-bg-gray-200",
+    bg: "tw-bg-gray-50",
 };
 
 export default VideoArea;

--- a/src/containers/video/layout-05/index.tsx
+++ b/src/containers/video/layout-05/index.tsx
@@ -17,7 +17,7 @@ type TProps = {
 
 const VideoArea = ({ data: { images, video, section_title } }: TProps) => {
     return (
-        <div className="tw-relative tw-z-10 tw-mb-15 tw-bg-gray-200 md:tw-mb-[140px]">
+        <div className="tw-relative tw-z-10 tw-mb-15 tw-bg-gray-50 md:tw-mb-[140px]">
             <div className="tw-container">
                 {section_title && (
                     <AnimatedSectionTitle

--- a/src/containers/video/layout-07/index.tsx
+++ b/src/containers/video/layout-07/index.tsx
@@ -115,7 +115,7 @@ const VideoArea = ({ data: { section_title, images, video }, space, bg }: TProps
 };
 
 VideoArea.defaultProps = {
-    bg: "tw-bg-spring",
+    bg: "tw-bg-cream",
     space: "top-bottom",
 };
 

--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -12,8 +12,8 @@ const Footer01 = ({ mode }: TProps) => {
         <footer
             className={clsx(
                 "tw-pb-[50px] tw-pt-[70px] tw-relative",
-                mode === "dark" && "tw-bg-gradient-to-b tw-from-gray-900 tw-to-gray-950 tw-text-gray-300",
-                mode === "light" && "tw-bg-light-100"
+                mode === "dark" && "tw-bg-gradient-to-b tw-from-dark tw-to-dark-surface tw-text-gray-300",
+                mode === "light" && "tw-bg-gray-50"
             )}
         >
             {mode === "dark" && (

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -34,7 +34,7 @@ const Header = ({ shadow, fluid }: TProps) => {
             <header className="header tw-relative">
                 <div
                     className={clsx(
-                        "header-top tw-bg-gray-200 tw-py-2.5 tw-z-[60] tw-w-full tw-transition-all",
+                        "header-top tw-bg-gray-50 tw-py-2.5 tw-z-[60] tw-w-full tw-transition-all",
                         sticky && "tw-fixed tw-top-0 tw-left-0 tw-shadow-md"
                     )}
                 >

--- a/src/pages/_offline.tsx
+++ b/src/pages/_offline.tsx
@@ -38,11 +38,11 @@ const OfflinePage: PageWithLayout = () => {
                         </svg>
                     </div>
 
-                    <h1 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-gray-900">
+                    <h1 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-ink">
                         You're Offline
                     </h1>
 
-                    <p className="tw-mb-8 tw-text-lg tw-text-gray-600">
+                    <p className="tw-mb-8 tw-text-lg tw-text-gray-300">
                         No internet connection found. Please check your connection and try again.
                     </p>
 
@@ -58,7 +58,7 @@ const OfflinePage: PageWithLayout = () => {
                         <button
                             type="button"
                             onClick={() => window.history.back()}
-                            className="tw-w-full tw-rounded-lg tw-bg-gray-200 tw-px-6 tw-py-3 tw-font-medium tw-text-gray-800 tw-transition-colors hover:tw-bg-gray-300"
+                            className="tw-w-full tw-rounded-lg tw-bg-gray-50 tw-px-6 tw-py-3 tw-font-medium tw-text-gray-400 tw-transition-colors hover:tw-bg-gray-300"
                         >
                             Go Back
                         </button>

--- a/src/pages/admin/courses.tsx
+++ b/src/pages/admin/courses.tsx
@@ -115,7 +115,7 @@ const AdminCoursesPage: PageWithLayout = () => {
             <div className="tw-container tw-py-16">
                 <div className="tw-text-center">
                     <div className="tw-mx-auto tw-h-32 tw-w-32 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
-                    <p className="tw-mt-4 tw-text-gray-600">Loading courses...</p>
+                    <p className="tw-mt-4 tw-text-gray-300">Loading courses...</p>
                 </div>
             </div>
         );
@@ -126,10 +126,10 @@ const AdminCoursesPage: PageWithLayout = () => {
         return (
             <div className="tw-container tw-py-16">
                 <div className="tw-text-center">
-                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-gray-900">
+                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
                         Access Denied
                     </h1>
-                    <p className="tw-text-gray-600">Administrator access required.</p>
+                    <p className="tw-text-gray-300">Administrator access required.</p>
                     <Link href="/admin" className="tw-mt-4 tw-inline-block tw-text-primary">
                         ← Back to Admin
                     </Link>
@@ -151,9 +151,9 @@ const AdminCoursesPage: PageWithLayout = () => {
 
     const getStatusBadge = (courseStatus: Course["status"]) => {
         const styles = {
-            published: "tw-bg-green-100 tw-text-green-800",
-            draft: "tw-bg-yellow-100 tw-text-yellow-800",
-            archived: "tw-bg-gray-100 tw-text-gray-800",
+            published: "tw-bg-gold-light/30 tw-text-gold-deep",
+            draft: "tw-bg-gold-bright tw-text-gold-deep",
+            archived: "tw-bg-gray-100 tw-text-gray-400",
         };
         return (
             <span
@@ -166,9 +166,9 @@ const AdminCoursesPage: PageWithLayout = () => {
 
     const getLevelBadge = (level: Course["level"]) => {
         const styles = {
-            Beginner: "tw-bg-blue-100 tw-text-blue-800",
+            Beginner: "tw-bg-navy-sky tw-text-blue-800",
             Intermediate: "tw-bg-purple-100 tw-text-purple-800",
-            Advanced: "tw-bg-orange-100 tw-text-orange-800",
+            Advanced: "tw-bg-red-signal tw-text-red-dark",
         };
         return (
             <span
@@ -195,10 +195,10 @@ const AdminCoursesPage: PageWithLayout = () => {
                 {/* Header */}
                 <div className="tw-mb-8 tw-flex tw-items-center tw-justify-between">
                     <div>
-                        <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gray-900">
+                        <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-ink">
                             Course Management
                         </h1>
-                        <p className="tw-text-gray-600">Create and manage learning content</p>
+                        <p className="tw-text-gray-300">Create and manage learning content</p>
                     </div>
                     <div className="tw-flex tw-space-x-3">
                         <button
@@ -210,7 +210,7 @@ const AdminCoursesPage: PageWithLayout = () => {
                         </button>
                         <Link
                             href="/admin"
-                            className="tw-rounded-md tw-bg-gray-100 tw-px-4 tw-py-2 tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-200"
+                            className="tw-rounded-md tw-bg-gray-100 tw-px-4 tw-py-2 tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                         >
                             <i className="fas fa-arrow-left tw-mr-2" />
                             Back to Admin
@@ -225,7 +225,7 @@ const AdminCoursesPage: PageWithLayout = () => {
                         <div className="md:tw-col-span-2">
                             <label
                                 htmlFor="search"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Search Courses
                             </label>
@@ -243,7 +243,7 @@ const AdminCoursesPage: PageWithLayout = () => {
                         <div>
                             <label
                                 htmlFor="status"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Status
                             </label>
@@ -266,7 +266,7 @@ const AdminCoursesPage: PageWithLayout = () => {
                         <div>
                             <label
                                 htmlFor="level"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Level
                             </label>
@@ -287,7 +287,7 @@ const AdminCoursesPage: PageWithLayout = () => {
 
                         {/* Results Count */}
                         <div className="tw-flex tw-items-end">
-                            <div className="tw-text-sm tw-text-gray-600">
+                            <div className="tw-text-sm tw-text-gray-300">
                                 Showing {filteredCourses.length} of {courses.length} courses
                             </div>
                         </div>
@@ -309,14 +309,14 @@ const AdminCoursesPage: PageWithLayout = () => {
                                 <div className="tw-flex tw-space-x-1">
                                     <button
                                         type="button"
-                                        className="tw-text-blue-600 hover:tw-text-blue-900"
+                                        className="tw-text-navy-royal hover:tw-text-blue-900"
                                         title="Edit Course"
                                     >
                                         <i className="fas fa-edit" />
                                     </button>
                                     <button
                                         type="button"
-                                        className="tw-text-green-600 hover:tw-text-green-900"
+                                        className="tw-text-gold hover:tw-text-green-900"
                                         title="View Course"
                                     >
                                         <i className="fas fa-eye" />
@@ -331,11 +331,11 @@ const AdminCoursesPage: PageWithLayout = () => {
                                 </div>
                             </div>
 
-                            <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-ink">
                                 {course.title}
                             </h3>
 
-                            <p className="tw-mb-4 tw-line-clamp-2 tw-text-sm tw-text-gray-600">
+                            <p className="tw-mb-4 tw-line-clamp-2 tw-text-sm tw-text-gray-300">
                                 {course.description}
                             </p>
 

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -42,10 +42,10 @@ const AdminDashboard: PageWithLayout = () => {
                 />
                 <div className="tw-container tw-py-16">
                     <div className="tw-text-center">
-                        <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-gray-900">
+                        <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
                             Admin Access Denied
                         </h1>
-                        <p className="tw-mx-auto tw-max-w-2xl tw-text-xl tw-text-gray-600">
+                        <p className="tw-mx-auto tw-max-w-2xl tw-text-xl tw-text-gray-300">
                             This area is restricted to authorized administrators only.
                         </p>
                     </div>
@@ -66,10 +66,10 @@ const AdminDashboard: PageWithLayout = () => {
             <div className="tw-min-h-screen tw-bg-gray-50 tw-py-8">
                 <div className="tw-mx-auto tw-max-w-7xl tw-px-4 sm:tw-px-6 lg:tw-px-8">
                     <div className="tw-mb-8">
-                        <h1 className="tw-text-3xl tw-font-bold tw-text-gray-900">
+                        <h1 className="tw-text-3xl tw-font-bold tw-text-ink">
                             Admin Dashboard
                         </h1>
-                        <p className="tw-mt-2 tw-text-gray-600">
+                        <p className="tw-mt-2 tw-text-gray-300">
                             Welcome back, {currentSession.user.name}! Manage your VWC platform here.
                         </p>
                     </div>
@@ -80,28 +80,28 @@ const AdminDashboard: PageWithLayout = () => {
                                 Total Students
                             </h3>
                             <p className="tw-text-3xl tw-font-bold tw-text-primary">312</p>
-                            <p className="tw-text-sm tw-text-green-600">+12% from last month</p>
+                            <p className="tw-text-sm tw-text-gold">+12% from last month</p>
                         </div>
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow">
                             <h3 className="tw-text-sm tw-font-medium tw-text-gray-500">
                                 Active Courses
                             </h3>
                             <p className="tw-text-3xl tw-font-bold tw-text-primary">24</p>
-                            <p className="tw-text-sm tw-text-green-600">+3 new this month</p>
+                            <p className="tw-text-sm tw-text-gold">+3 new this month</p>
                         </div>
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow">
                             <h3 className="tw-text-sm tw-font-medium tw-text-gray-500">
                                 Completion Rate
                             </h3>
                             <p className="tw-text-3xl tw-font-bold tw-text-primary">78%</p>
-                            <p className="tw-text-sm tw-text-green-600">+5% improvement</p>
+                            <p className="tw-text-sm tw-text-gold">+5% improvement</p>
                         </div>
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow">
                             <h3 className="tw-text-sm tw-font-medium tw-text-gray-500">
                                 Monthly Revenue
                             </h3>
                             <p className="tw-text-3xl tw-font-bold tw-text-primary">$45,2K</p>
-                            <p className="tw-text-sm tw-text-green-600">+18% growth</p>
+                            <p className="tw-text-sm tw-text-gold">+18% growth</p>
                         </div>
                     </div>
                 </div>

--- a/src/pages/admin/users.tsx
+++ b/src/pages/admin/users.tsx
@@ -107,7 +107,7 @@ const AdminUsersPage: PageWithLayout = () => {
             <div className="tw-container tw-py-16">
                 <div className="tw-text-center">
                     <div className="tw-mx-auto tw-h-32 tw-w-32 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
-                    <p className="tw-mt-4 tw-text-gray-600">Loading users...</p>
+                    <p className="tw-mt-4 tw-text-gray-300">Loading users...</p>
                 </div>
             </div>
         );
@@ -118,10 +118,10 @@ const AdminUsersPage: PageWithLayout = () => {
         return (
             <div className="tw-container tw-py-16">
                 <div className="tw-text-center">
-                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-gray-900">
+                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
                         Access Denied
                     </h1>
-                    <p className="tw-text-gray-600">Administrator access required.</p>
+                    <p className="tw-text-gray-300">Administrator access required.</p>
                     <Link href="/admin" className="tw-mt-4 tw-inline-block tw-text-primary">
                         ← Back to Admin
                     </Link>
@@ -153,8 +153,8 @@ const AdminUsersPage: PageWithLayout = () => {
 
     const getStatusBadge = (userStatus: User["status"]) => {
         const styles = {
-            active: "tw-bg-green-100 tw-text-green-800",
-            inactive: "tw-bg-yellow-100 tw-text-yellow-800",
+            active: "tw-bg-gold-light/30 tw-text-gold-deep",
+            inactive: "tw-bg-gold-bright tw-text-gold-deep",
             suspended: "tw-bg-red-100 tw-text-red-800",
         };
         return (
@@ -167,8 +167,8 @@ const AdminUsersPage: PageWithLayout = () => {
     };
 
     const getProgressColor = (progress: number) => {
-        if (progress >= 75) return "tw-bg-green-500";
-        if (progress >= 50) return "tw-bg-yellow-500";
+        if (progress >= 75) return "tw-bg-gold-light/200";
+        if (progress >= 50) return "tw-bg-gold-light/200";
         return "tw-bg-red-500";
     };
 
@@ -196,16 +196,16 @@ const AdminUsersPage: PageWithLayout = () => {
                 {/* Header */}
                 <div className="tw-mb-8 tw-flex tw-items-center tw-justify-between">
                     <div>
-                        <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gray-900">
+                        <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-ink">
                             User Management
                         </h1>
-                        <p className="tw-text-gray-600">
+                        <p className="tw-text-gray-300">
                             Manage student accounts and monitor progress
                         </p>
                     </div>
                     <Link
                         href="/admin"
-                        className="tw-rounded-md tw-bg-gray-100 tw-px-4 tw-py-2 tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-200"
+                        className="tw-rounded-md tw-bg-gray-100 tw-px-4 tw-py-2 tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                     >
                         <i className="fas fa-arrow-left tw-mr-2" />
                         Back to Admin
@@ -219,7 +219,7 @@ const AdminUsersPage: PageWithLayout = () => {
                         <div>
                             <label
                                 htmlFor="search"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Search Users
                             </label>
@@ -237,7 +237,7 @@ const AdminUsersPage: PageWithLayout = () => {
                         <div>
                             <label
                                 htmlFor="status"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Status
                             </label>
@@ -260,7 +260,7 @@ const AdminUsersPage: PageWithLayout = () => {
                         <div>
                             <label
                                 htmlFor="sort"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Sort By
                             </label>
@@ -278,7 +278,7 @@ const AdminUsersPage: PageWithLayout = () => {
 
                         {/* Results Count */}
                         <div className="tw-flex tw-items-end">
-                            <div className="tw-text-sm tw-text-gray-600">
+                            <div className="tw-text-sm tw-text-gray-300">
                                 Showing {filteredUsers.length} of {users.length} users
                             </div>
                         </div>
@@ -327,11 +327,11 @@ const AdminUsersPage: PageWithLayout = () => {
                                                     />
                                                 ) : (
                                                     <div className="tw-mr-4 tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-gray-300">
-                                                        <i className="fas fa-user tw-text-gray-600" />
+                                                        <i className="fas fa-user tw-text-gray-300" />
                                                     </div>
                                                 )}
                                                 <div>
-                                                    <div className="tw-text-sm tw-font-medium tw-text-gray-900">
+                                                    <div className="tw-text-sm tw-font-medium tw-text-ink">
                                                         {user.name}
                                                     </div>
                                                     <div className="tw-text-sm tw-text-gray-500">
@@ -343,7 +343,7 @@ const AdminUsersPage: PageWithLayout = () => {
                                         <td className="tw-whitespace-nowrap tw-px-6 tw-py-4">
                                             {user.militaryBranch && user.rank ? (
                                                 <div>
-                                                    <div className="tw-text-sm tw-font-medium tw-text-gray-900">
+                                                    <div className="tw-text-sm tw-font-medium tw-text-ink">
                                                         {user.rank}
                                                     </div>
                                                     <div className="tw-text-sm tw-text-gray-500">
@@ -356,15 +356,15 @@ const AdminUsersPage: PageWithLayout = () => {
                                                 </span>
                                             )}
                                         </td>
-                                        <td className="tw-whitespace-nowrap tw-px-6 tw-py-4 tw-text-sm tw-text-gray-900">
+                                        <td className="tw-whitespace-nowrap tw-px-6 tw-py-4 tw-text-sm tw-text-ink">
                                             {user.enrollments} enrolled
                                         </td>
                                         <td className="tw-whitespace-nowrap tw-px-6 tw-py-4">
                                             <div className="tw-flex tw-items-center">
-                                                <div className="tw-mr-2 tw-w-16 tw-text-sm tw-text-gray-900">
+                                                <div className="tw-mr-2 tw-w-16 tw-text-sm tw-text-ink">
                                                     {user.progress}%
                                                 </div>
-                                                <div className="tw-relative tw-h-2 tw-w-20 tw-overflow-hidden tw-rounded-full tw-bg-gray-200">
+                                                <div className="tw-relative tw-h-2 tw-w-20 tw-overflow-hidden tw-rounded-full tw-bg-gray-50">
                                                     <div
                                                         className={`tw-absolute tw-left-0 tw-top-0 tw-h-full tw-rounded-full ${getProgressColor(user.progress)} ${getProgressWidth(user.progress)}`}
                                                     />
@@ -388,7 +388,7 @@ const AdminUsersPage: PageWithLayout = () => {
                                                 </button>
                                                 <button
                                                     type="button"
-                                                    className="tw-text-green-600 hover:tw-text-green-900"
+                                                    className="tw-text-gold hover:tw-text-green-900"
                                                     title="Send Message"
                                                 >
                                                     <i className="fas fa-envelope" />

--- a/src/pages/assessment.tsx
+++ b/src/pages/assessment.tsx
@@ -257,17 +257,17 @@ const Assessment: PageWithLayout = () => {
                             <div className="tw-mx-auto tw-mb-4 tw-flex tw-h-20 tw-w-20 tw-items-center tw-justify-center tw-rounded-full tw-bg-success tw-text-white">
                                 <i className="fas fa-check tw-text-3xl" />
                             </div>
-                            <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gray-900">
+                            <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-ink">
                                 Assessment Complete!
                             </h1>
-                            <p className="tw-text-lg tw-text-gray-600">
+                            <p className="tw-text-lg tw-text-gray-300">
                                 Great job completing the coding assessment
                             </p>
                         </div>
 
                         <div className="tw-mb-8 tw-space-y-4">
                             <div className="tw-rounded-lg tw-bg-gray-50 tw-p-6">
-                                <div className="tw-mb-2 tw-text-sm tw-font-medium tw-text-gray-600">
+                                <div className="tw-mb-2 tw-text-sm tw-font-medium tw-text-gray-300">
                                     Your Score
                                 </div>
                                 <div className="tw-text-4xl tw-font-bold tw-text-secondary">
@@ -276,7 +276,7 @@ const Assessment: PageWithLayout = () => {
                             </div>
 
                             <div className="tw-rounded-lg tw-bg-primary/10 tw-p-6">
-                                <div className="tw-mb-2 tw-text-sm tw-font-medium tw-text-gray-600">
+                                <div className="tw-mb-2 tw-text-sm tw-font-medium tw-text-gray-300">
                                     Skill Level
                                 </div>
                                 <div className="tw-text-3xl tw-font-bold tw-text-primary">
@@ -285,10 +285,10 @@ const Assessment: PageWithLayout = () => {
                             </div>
 
                             <div className="tw-rounded-lg tw-border tw-border-gray-200 tw-p-6">
-                                <div className="tw-mb-4 tw-text-sm tw-font-medium tw-text-gray-600">
+                                <div className="tw-mb-4 tw-text-sm tw-font-medium tw-text-gray-300">
                                     What this means
                                 </div>
-                                <p className="tw-text-sm tw-text-gray-700">
+                                <p className="tw-text-sm tw-text-gray-200">
                                     {skillLevel === "NEWBIE" &&
                                         "You're just getting started! Focus on learning basic syntax and programming concepts."}
                                     {skillLevel === "BEGINNER" &&
@@ -315,7 +315,7 @@ const Assessment: PageWithLayout = () => {
                             <button
                                 type="button"
                                 onClick={() => router.push("/courses")}
-                                className="tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-50"
+                                className="tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                             >
                                 <i className="fas fa-book tw-mr-2" />
                                 Browse Courses
@@ -344,10 +344,10 @@ const Assessment: PageWithLayout = () => {
                 <div
                     className={`tw-fixed tw-right-4 tw-top-4 tw-z-50 tw-rounded-lg tw-p-4 tw-shadow-lg tw-duration-300 tw-animate-in tw-fade-in tw-slide-in-from-top-5 ${
                         notification.type === "success"
-                            ? "tw-border tw-border-green-200 tw-bg-green-50 tw-text-green-800"
+                            ? "tw-border tw-border-green-200 tw-bg-gold-light/20 tw-text-gold-deep"
                             : notification.type === "error"
                               ? "tw-border tw-border-red-200 tw-bg-red-50 tw-text-red-800"
-                              : "tw-border tw-border-blue-200 tw-bg-blue-50 tw-text-blue-800"
+                              : "tw-border tw-border-blue-200 tw-bg-navy-sky/20 tw-text-blue-800"
                     }`}
                 >
                     <div className="tw-flex tw-items-center tw-space-x-2">
@@ -370,27 +370,27 @@ const Assessment: PageWithLayout = () => {
                 <div className="tw-mb-6">
                     <div className="tw-mb-4 tw-flex tw-items-center tw-justify-between">
                         <div>
-                            <h1 className="tw-text-2xl tw-font-bold tw-text-gray-900">
+                            <h1 className="tw-text-2xl tw-font-bold tw-text-ink">
                                 Coding Assessment
                             </h1>
-                            <p className="tw-text-gray-600">
+                            <p className="tw-text-gray-300">
                                 Complete the challenges to determine your skill level
                             </p>
                         </div>
                         <div className="tw-text-right">
-                            <div className="tw-text-sm tw-text-gray-600">Current Score</div>
+                            <div className="tw-text-sm tw-text-gray-300">Current Score</div>
                             <div className="tw-text-2xl tw-font-bold tw-text-primary">{score}</div>
                         </div>
                     </div>
 
                     {/* Progress Bar */}
-                    <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between tw-text-sm tw-text-gray-600">
+                    <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between tw-text-sm tw-text-gray-300">
                         <span>
                             Question {currentQuestionIndex + 1} of {assessmentQuestions.length}
                         </span>
                         <span>{Math.round(progress)}% Complete</span>
                     </div>
-                    <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-200">
+                    <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-50">
                         <div
                             className="tw-h-2 tw-rounded-full tw-bg-primary tw-transition-all tw-duration-300"
                             style={{ width: `${progress}%` }}
@@ -404,22 +404,22 @@ const Assessment: PageWithLayout = () => {
                         <div className="tw-mb-4 tw-inline-block tw-rounded tw-bg-primary/10 tw-px-3 tw-py-1 tw-text-sm tw-font-semibold tw-uppercase tw-text-primary">
                             {currentQuestion.level}
                         </div>
-                        <h2 className="tw-mb-2 tw-text-xl tw-font-bold tw-text-gray-900">
+                        <h2 className="tw-mb-2 tw-text-xl tw-font-bold tw-text-ink">
                             {currentQuestion.title}
                         </h2>
-                        <p className="tw-mb-4 tw-text-gray-600">{currentQuestion.description}</p>
+                        <p className="tw-mb-4 tw-text-gray-300">{currentQuestion.description}</p>
 
                         <div className="tw-mb-4 tw-rounded-lg tw-bg-gray-50 tw-p-4">
-                            <h3 className="tw-mb-2 tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-2 tw-font-semibold tw-text-ink">
                                 Instructions
                             </h3>
-                            <p className="tw-text-sm tw-text-gray-700">
+                            <p className="tw-text-sm tw-text-gray-200">
                                 {currentQuestion.instructions}
                             </p>
                         </div>
 
                         <div className="tw-mb-4">
-                            <h3 className="tw-mb-2 tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-2 tw-font-semibold tw-text-ink">
                                 Test Cases
                             </h3>
                             <div className="tw-space-y-2">
@@ -428,11 +428,11 @@ const Assessment: PageWithLayout = () => {
                                         key={index}
                                         className="tw-rounded tw-bg-gray-50 tw-p-3 tw-text-sm"
                                     >
-                                        <div className="tw-mb-1 tw-font-mono tw-text-xs tw-text-gray-600">
+                                        <div className="tw-mb-1 tw-font-mono tw-text-xs tw-text-gray-300">
                                             {testCase.input || "No input"}
                                         </div>
                                         <div className="tw-flex tw-items-center tw-justify-between">
-                                            <span className="tw-text-gray-700">
+                                            <span className="tw-text-gray-200">
                                                 {testCase.description}
                                             </span>
                                             <span className="tw-font-mono tw-text-xs tw-text-success">
@@ -448,7 +448,7 @@ const Assessment: PageWithLayout = () => {
                             <div
                                 className={`tw-rounded-lg tw-p-4 ${
                                     testResults.passed === testResults.total
-                                        ? "tw-border tw-border-green-200 tw-bg-green-50"
+                                        ? "tw-border tw-border-green-200 tw-bg-gold-light/20"
                                         : "tw-border tw-border-red-200 tw-bg-red-50"
                                 }`}
                             >
@@ -456,14 +456,14 @@ const Assessment: PageWithLayout = () => {
                                     <i
                                         className={`fas ${
                                             testResults.passed === testResults.total
-                                                ? "fa-check-circle tw-text-green-600"
+                                                ? "fa-check-circle tw-text-gold"
                                                 : "fa-times-circle tw-text-red-600"
                                         }`}
                                     />
                                     <span
                                         className={
                                             testResults.passed === testResults.total
-                                                ? "tw-text-green-800"
+                                                ? "tw-text-gold-deep"
                                                 : "tw-text-red-800"
                                         }
                                     >
@@ -473,13 +473,13 @@ const Assessment: PageWithLayout = () => {
                             </div>
                         )}
 
-                        <div className="tw-mt-4 tw-flex tw-items-center tw-justify-between tw-text-sm tw-text-gray-600">
+                        <div className="tw-mt-4 tw-flex tw-items-center tw-justify-between tw-text-sm tw-text-gray-300">
                             <span>
                                 <i className="fas fa-clock tw-mr-1" />
                                 Est. {currentQuestion.timeEstimate} min
                             </span>
                             <span>
-                                <i className="fas fa-star tw-mr-1 tw-text-yellow-500" />
+                                <i className="fas fa-star tw-mr-1 tw-text-gold-light/200" />
                                 {currentQuestion.points} points
                             </span>
                         </div>
@@ -487,7 +487,7 @@ const Assessment: PageWithLayout = () => {
 
                     {/* Code Editor Panel */}
                     <div className="tw-flex tw-flex-col tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                        <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                        <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                             Your Solution
                         </h3>
                         <div className="tw-mb-4 tw-flex-1">
@@ -509,7 +509,7 @@ const Assessment: PageWithLayout = () => {
                                     type="button"
                                     onClick={handlePrevious}
                                     disabled={currentQuestionIndex === 0}
-                                    className="tw-flex-1 tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-4 tw-py-3 tw-font-semibold tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-50 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+                                    className="tw-flex-1 tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-4 tw-py-3 tw-font-semibold tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
                                 >
                                     <i className="fas fa-arrow-left tw-mr-2" />
                                     Previous

--- a/src/pages/assignments/submit/[assignmentId].tsx
+++ b/src/pages/assignments/submit/[assignmentId].tsx
@@ -67,7 +67,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
             <div className="tw-container tw-py-16">
                 <div className="tw-text-center">
                     <div className="tw-mx-auto tw-h-32 tw-w-32 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
-                    <p className="tw-mt-4 tw-text-gray-600">Loading assignment...</p>
+                    <p className="tw-mt-4 tw-text-gray-300">Loading assignment...</p>
                 </div>
             </div>
         );
@@ -95,33 +95,33 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                 <div className="tw-container tw-py-16">
                     <div className="tw-mx-auto tw-max-w-2xl tw-text-center">
                         <div className="tw-mb-8">
-                            <div className="tw-mx-auto tw-mb-4 tw-flex tw-h-20 tw-w-20 tw-items-center tw-justify-center tw-rounded-full tw-bg-green-100">
-                                <i className="fas fa-check tw-text-3xl tw-text-green-600" />
+                            <div className="tw-mx-auto tw-mb-4 tw-flex tw-h-20 tw-w-20 tw-items-center tw-justify-center tw-rounded-full tw-bg-gold-light/30">
+                                <i className="fas fa-check tw-text-3xl tw-text-gold" />
                             </div>
-                            <h1 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-gray-900">
+                            <h1 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-ink">
                                 Assignment Submitted Successfully!
                             </h1>
-                            <p className="tw-text-xl tw-text-gray-600">
+                            <p className="tw-text-xl tw-text-gray-300">
                                 Your submission for &quot;{assignment.title}&quot; has been received
                                 and will be reviewed by your mentor.
                             </p>
                         </div>
 
-                        <div className="tw-mb-8 tw-rounded-lg tw-bg-blue-50 tw-p-6">
+                        <div className="tw-mb-8 tw-rounded-lg tw-bg-navy-sky/20 tw-p-6">
                             <h3 className="tw-mb-2 tw-font-semibold tw-text-blue-900">
                                 What happens next?
                             </h3>
                             <ul className="tw-space-y-2 tw-text-left tw-text-blue-800">
                                 <li className="tw-flex tw-items-center">
-                                    <i className="fas fa-clock tw-mr-2 tw-text-blue-600" />
+                                    <i className="fas fa-clock tw-mr-2 tw-text-navy-royal" />
                                     Your mentor will review your submission within 2-3 business days
                                 </li>
                                 <li className="tw-flex tw-items-center">
-                                    <i className="fas fa-comments tw-mr-2 tw-text-blue-600" />
+                                    <i className="fas fa-comments tw-mr-2 tw-text-navy-royal" />
                                     You&apos;ll receive detailed feedback on your work
                                 </li>
                                 <li className="tw-flex tw-items-center">
-                                    <i className="fas fa-trophy tw-mr-2 tw-text-blue-600" />
+                                    <i className="fas fa-trophy tw-mr-2 tw-text-navy-royal" />
                                     Upon approval, you can continue to the next lesson
                                 </li>
                             </ul>
@@ -137,7 +137,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                             </Link>
                             <Link
                                 href="/courses/web-development"
-                                className="tw-rounded-md tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-medium tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-50"
+                                className="tw-rounded-md tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-medium tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                             >
                                 <i className="fas fa-book tw-mr-2" />
                                 Back to Course
@@ -166,27 +166,27 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                 <div className="tw-mx-auto tw-max-w-4xl">
                     {/* Assignment Header */}
                     <div className="tw-mb-8">
-                        <div className="tw-mb-2 tw-text-sm tw-text-gray-600">
+                        <div className="tw-mb-2 tw-text-sm tw-text-gray-300">
                             {assignment.module} • {assignment.lesson}
                         </div>
-                        <h1 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-gray-900">
+                        <h1 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-ink">
                             Submit Assignment: {assignment.title}
                         </h1>
-                        <p className="tw-text-gray-600">{assignment.description}</p>
+                        <p className="tw-text-gray-300">{assignment.description}</p>
                     </div>
 
                     <div className="tw-grid tw-grid-cols-1 tw-gap-8 lg:tw-grid-cols-3">
                         {/* Assignment Details */}
                         <div className="lg:tw-col-span-1">
                             <div className="tw-mb-6 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                     Assignment Requirements
                                 </h3>
                                 <ul className="tw-space-y-2">
                                     {assignment.requirements.map((requirement) => (
                                         <li
                                             key={requirement}
-                                            className="tw-flex tw-items-start tw-text-gray-700"
+                                            className="tw-flex tw-items-start tw-text-gray-200"
                                         >
                                             <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-green-500" />
                                             {requirement}
@@ -195,12 +195,12 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                 </ul>
                             </div>
 
-                            <div className="tw-mb-6 tw-rounded-lg tw-bg-orange-50 tw-p-6">
-                                <h3 className="tw-mb-2 tw-font-semibold tw-text-orange-900">
+                            <div className="tw-mb-6 tw-rounded-lg tw-bg-red-signal/10 tw-p-6">
+                                <h3 className="tw-mb-2 tw-font-semibold tw-text-red-maroon">
                                     <i className="fas fa-exclamation-triangle tw-mr-2" />
                                     Important Information
                                 </h3>
-                                <div className="tw-space-y-2 tw-text-sm tw-text-orange-800">
+                                <div className="tw-space-y-2 tw-text-sm tw-text-red-dark">
                                     <p>
                                         <strong>Due Date:</strong> {assignment.dueDate}
                                     </p>
@@ -223,7 +223,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                     <div>
                                         <label
                                             htmlFor="github-url"
-                                            className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                            className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                         >
                                             GitHub Repository URL (Recommended)
                                         </label>
@@ -233,7 +233,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                             value={githubUrl}
                                             onChange={(e) => setGithubUrl(e.target.value)}
                                             placeholder="https://github.com/username/repository"
-                                            className="tw-block tw-w-full tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-2 tw-text-gray-900 tw-placeholder-gray-500 focus:tw-border-primary focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-primary"
+                                            className="tw-block tw-w-full tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-2 tw-text-ink tw-placeholder-gray-500 focus:tw-border-primary focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-primary"
                                         />
                                         <p className="tw-mt-1 tw-text-sm tw-text-gray-500">
                                             Share your code via GitHub for easy review and
@@ -245,7 +245,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                     <div>
                                         <label
                                             htmlFor="files"
-                                            className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                            className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                         >
                                             Upload Files (Alternative to GitHub)
                                         </label>
@@ -269,7 +269,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                                 </span>
                                                 <div className="tw-text-center">
                                                     <i className="fas fa-cloud-upload-alt tw-mb-2 tw-text-2xl tw-text-gray-400" />
-                                                    <p className="tw-text-sm tw-text-gray-600">
+                                                    <p className="tw-text-sm tw-text-gray-300">
                                                         <span className="tw-font-medium tw-text-primary">
                                                             Click to upload
                                                         </span>{" "}
@@ -284,14 +284,14 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                         </div>
                                         {files && files.length > 0 && (
                                             <div className="tw-mt-2">
-                                                <p className="tw-text-sm tw-font-medium tw-text-gray-700">
+                                                <p className="tw-text-sm tw-font-medium tw-text-gray-200">
                                                     Selected files:
                                                 </p>
                                                 <ul className="tw-mt-1 tw-space-y-1">
                                                     {Array.from(files).map((file) => (
                                                         <li
                                                             key={`${file.name}-${file.size}`}
-                                                            className="tw-text-sm tw-text-gray-600"
+                                                            className="tw-text-sm tw-text-gray-300"
                                                         >
                                                             {file.name} (
                                                             {Math.round(file.size / 1024)} KB)
@@ -306,7 +306,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                     <div>
                                         <label
                                             htmlFor="notes"
-                                            className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                            className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                         >
                                             Additional Notes (Optional)
                                         </label>
@@ -316,7 +316,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                                             value={notes}
                                             onChange={(e) => setNotes(e.target.value)}
                                             placeholder="Any additional information about your submission, challenges faced, or questions for your mentor..."
-                                            className="tw-block tw-w-full tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-2 tw-text-gray-900 tw-placeholder-gray-500 focus:tw-border-primary focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-primary"
+                                            className="tw-block tw-w-full tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-2 tw-text-ink tw-placeholder-gray-500 focus:tw-border-primary focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-primary"
                                         />
                                     </div>
 

--- a/src/pages/auth/error.tsx
+++ b/src/pages/auth/error.tsx
@@ -93,7 +93,7 @@ const AuthError: PageWithLayout = () => {
             <div className="tw-sm:mx-auto tw-sm:w-full tw-sm:max-w-md">
                 <div className="tw-sm:rounded-lg tw-sm:px-10 tw-bg-white tw-px-4 tw-py-8 tw-shadow">
                     <div className="tw-text-center">
-                        <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-ink">
                             {error.title}
                         </h2>
                         <div className="tw-mb-6 tw-rounded-md tw-bg-red-50 tw-p-4">

--- a/src/pages/certificates/[certificateId].tsx
+++ b/src/pages/certificates/[certificateId].tsx
@@ -69,7 +69,7 @@ const CertificatePage: PageWithLayout = () => {
       <div className="tw-container tw-py-16">
         <div className="tw-text-center">
           <div className="tw-mx-auto tw-h-32 tw-w-32 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
-          <p className="tw-mt-4 tw-text-gray-600">Loading certificate...</p>
+          <p className="tw-mt-4 tw-text-gray-300">Loading certificate...</p>
         </div>
       </div>
     );
@@ -79,10 +79,10 @@ const CertificatePage: PageWithLayout = () => {
     return (
       <div className="tw-container tw-py-16">
         <div className="tw-text-center">
-          <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-gray-900">
+          <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
             Certificate Not Found
           </h1>
-          <p className="tw-mb-8 tw-text-gray-600">
+          <p className="tw-mb-8 tw-text-gray-300">
             {error || "The certificate you're looking for doesn't exist."}
           </p>
           <button
@@ -158,27 +158,27 @@ const CertificatePage: PageWithLayout = () => {
           <div className="tw-border-8 tw-border-double tw-border-primary tw-p-8">
             {/* Header */}
             <div className="tw-mb-8 tw-text-center">
-              <h1 className="tw-mb-2 tw-text-5xl tw-font-bold tw-text-gray-900">
+              <h1 className="tw-mb-2 tw-text-5xl tw-font-bold tw-text-ink">
                 Certificate of Completion
               </h1>
               <div className="tw-mx-auto tw-my-4 tw-h-1 tw-w-32 tw-bg-primary"></div>
-              <p className="tw-text-xl tw-text-gray-600">
+              <p className="tw-text-xl tw-text-gray-300">
                 Vets Who Code
               </p>
             </div>
 
             {/* Body */}
             <div className="tw-mb-8 tw-text-center">
-              <p className="tw-mb-6 tw-text-lg tw-text-gray-700">
+              <p className="tw-mb-6 tw-text-lg tw-text-gray-200">
                 This is to certify that
               </p>
               <h2 className="tw-mb-6 tw-text-4xl tw-font-bold tw-text-primary">
                 {certificate.student.name}
               </h2>
-              <p className="tw-mb-6 tw-text-lg tw-text-gray-700">
+              <p className="tw-mb-6 tw-text-lg tw-text-gray-200">
                 has successfully completed the course
               </p>
-              <h3 className="tw-mb-6 tw-text-3xl tw-font-semibold tw-text-gray-900">
+              <h3 className="tw-mb-6 tw-text-3xl tw-font-semibold tw-text-ink">
                 {certificate.course.title}
               </h3>
             </div>
@@ -187,26 +187,26 @@ const CertificatePage: PageWithLayout = () => {
             <div className="tw-mb-8 tw-rounded-lg tw-bg-gray-50 tw-p-6">
               <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-3">
                 <div className="tw-text-center">
-                  <p className="tw-text-sm tw-font-semibold tw-text-gray-600">
+                  <p className="tw-text-sm tw-font-semibold tw-text-gray-300">
                     Category
                   </p>
-                  <p className="tw-text-lg tw-text-gray-900">
+                  <p className="tw-text-lg tw-text-ink">
                     {certificate.course.category}
                   </p>
                 </div>
                 <div className="tw-text-center">
-                  <p className="tw-text-sm tw-font-semibold tw-text-gray-600">
+                  <p className="tw-text-sm tw-font-semibold tw-text-gray-300">
                     Difficulty
                   </p>
-                  <p className="tw-text-lg tw-text-gray-900">
+                  <p className="tw-text-lg tw-text-ink">
                     {certificate.course.difficulty}
                   </p>
                 </div>
                 <div className="tw-text-center">
-                  <p className="tw-text-sm tw-font-semibold tw-text-gray-600">
+                  <p className="tw-text-sm tw-font-semibold tw-text-gray-300">
                     Estimated Hours
                   </p>
-                  <p className="tw-text-lg tw-text-gray-900">
+                  <p className="tw-text-lg tw-text-ink">
                     {certificate.course.estimatedHours} hours
                   </p>
                 </div>
@@ -217,15 +217,15 @@ const CertificatePage: PageWithLayout = () => {
             <div className="tw-mb-6 tw-flex tw-items-center tw-justify-between">
               <div className="tw-text-center">
                 <div className="tw-mb-2 tw-h-px tw-w-48 tw-bg-gray-400"></div>
-                <p className="tw-text-sm tw-text-gray-600">Date of Completion</p>
-                <p className="tw-font-semibold tw-text-gray-900">
+                <p className="tw-text-sm tw-text-gray-300">Date of Completion</p>
+                <p className="tw-font-semibold tw-text-ink">
                   {formatDate(certificate.issuedAt)}
                 </p>
               </div>
               <div className="tw-text-center">
                 <div className="tw-mb-2 tw-h-px tw-w-48 tw-bg-gray-400"></div>
-                <p className="tw-text-sm tw-text-gray-600">Authorized Signature</p>
-                <p className="tw-font-semibold tw-text-gray-900">Vets Who Code</p>
+                <p className="tw-text-sm tw-text-gray-300">Authorized Signature</p>
+                <p className="tw-font-semibold tw-text-ink">Vets Who Code</p>
               </div>
             </div>
 
@@ -242,7 +242,7 @@ const CertificatePage: PageWithLayout = () => {
         </div>
 
         {/* Verification Notice - Hidden on print */}
-        <div className="tw-mx-auto tw-mt-8 tw-max-w-2xl tw-rounded-lg tw-bg-blue-50 tw-p-6 print:tw-hidden">
+        <div className="tw-mx-auto tw-mt-8 tw-max-w-2xl tw-rounded-lg tw-bg-navy-sky/20 tw-p-6 print:tw-hidden">
           <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-blue-900">
             Certificate Verification
           </h3>

--- a/src/pages/courses/ai-engineering.tsx
+++ b/src/pages/courses/ai-engineering.tsx
@@ -128,7 +128,7 @@ const AIEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                             AI Engineering
                         </h1>
                         <div className="tw-mx-auto tw-mb-6 tw-h-1 tw-w-24 tw-rounded tw-bg-success" />
-                        <p className="tw-mx-auto tw-max-w-3xl tw-text-xl tw-leading-relaxed tw-text-gray-700 md:tw-text-2xl">
+                        <p className="tw-mx-auto tw-max-w-3xl tw-text-xl tw-leading-relaxed tw-text-gray-200 md:tw-text-2xl">
                             Develop AI/ML models, work with neural networks, and build intelligent
                             systems for real-world applications using cutting-edge technology.
                         </p>
@@ -168,10 +168,10 @@ const AIEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                                         {index + 1}
                                     </div>
                                     <div>
-                                        <h3 className="tw-text-xl tw-font-bold tw-text-gray-900">
+                                        <h3 className="tw-text-xl tw-font-bold tw-text-ink">
                                             {module.title}
                                         </h3>
-                                        <p className="tw-text-gray-600">{module.description}</p>
+                                        <p className="tw-text-gray-300">{module.description}</p>
                                     </div>
                                 </div>
                                 <div className="tw-flex tw-items-center tw-space-x-4">
@@ -204,7 +204,7 @@ const AIEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                             {selectedModule === module.id && (
                                 <div className="tw-border-t tw-border-gray-200 tw-bg-gray-50 tw-p-6">
                                     <div className="tw-mb-4">
-                                        <h4 className="tw-mb-3 tw-font-semibold tw-text-gray-900">
+                                        <h4 className="tw-mb-3 tw-font-semibold tw-text-ink">
                                             Technologies Covered:
                                         </h4>
                                         <div className="tw-flex tw-flex-wrap tw-gap-2">
@@ -229,7 +229,7 @@ const AIEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                                             </Link>
                                             <button
                                                 type="button"
-                                                className="tw-inline-flex tw-items-center tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-50"
+                                                className="tw-inline-flex tw-items-center tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                                             >
                                                 <i className="fas fa-bookmark tw-mr-2" />
                                                 Save for Later
@@ -245,10 +245,10 @@ const AIEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                 {/* Prerequisites & What You'll Build */}
                 <div className="tw-mt-16 tw-grid tw-grid-cols-1 tw-gap-8 lg:tw-grid-cols-2">
                     <div className="tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white tw-p-8 tw-shadow-lg">
-                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-ink">
                             Prerequisites
                         </h3>
-                        <ul className="tw-space-y-3 tw-text-gray-700">
+                        <ul className="tw-space-y-3 tw-text-gray-200">
                             <li className="tw-flex tw-items-center">
                                 <i className="fas fa-check tw-mr-3 tw-text-success" />
                                 Strong programming skills (Python preferred)
@@ -269,10 +269,10 @@ const AIEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                     </div>
 
                     <div className="tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white tw-p-8 tw-shadow-lg">
-                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-ink">
                             What You&apos;ll Build
                         </h3>
-                        <ul className="tw-space-y-3 tw-text-gray-700">
+                        <ul className="tw-space-y-3 tw-text-gray-200">
                             <li className="tw-flex tw-items-center">
                                 <i className="fas fa-rocket tw-mr-3 tw-text-success" />
                                 Image classification system

--- a/src/pages/courses/data-engineering.tsx
+++ b/src/pages/courses/data-engineering.tsx
@@ -128,7 +128,7 @@ const DataEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                             Data Engineering
                         </h1>
                         <div className="tw-mx-auto tw-mb-6 tw-h-1 tw-w-24 tw-rounded tw-bg-secondary" />
-                        <p className="tw-mx-auto tw-max-w-3xl tw-text-xl tw-leading-relaxed tw-text-gray-700 md:tw-text-2xl">
+                        <p className="tw-mx-auto tw-max-w-3xl tw-text-xl tw-leading-relaxed tw-text-gray-200 md:tw-text-2xl">
                             Build data pipelines, work with big data technologies, and create robust
                             data infrastructure systems that power modern analytics.
                         </p>
@@ -168,10 +168,10 @@ const DataEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                                         {index + 1}
                                     </div>
                                     <div>
-                                        <h3 className="tw-text-xl tw-font-bold tw-text-gray-900">
+                                        <h3 className="tw-text-xl tw-font-bold tw-text-ink">
                                             {module.title}
                                         </h3>
-                                        <p className="tw-text-gray-600">{module.description}</p>
+                                        <p className="tw-text-gray-300">{module.description}</p>
                                     </div>
                                 </div>
                                 <div className="tw-flex tw-items-center tw-space-x-4">
@@ -204,7 +204,7 @@ const DataEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                             {selectedModule === module.id && (
                                 <div className="tw-border-t tw-border-gray-200 tw-bg-gray-50 tw-p-6">
                                     <div className="tw-mb-4">
-                                        <h4 className="tw-mb-3 tw-font-semibold tw-text-gray-900">
+                                        <h4 className="tw-mb-3 tw-font-semibold tw-text-ink">
                                             Technologies Covered:
                                         </h4>
                                         <div className="tw-flex tw-flex-wrap tw-gap-2">
@@ -229,7 +229,7 @@ const DataEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                                             </Link>
                                             <button
                                                 type="button"
-                                                className="tw-inline-flex tw-items-center tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-50"
+                                                className="tw-inline-flex tw-items-center tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                                             >
                                                 <i className="fas fa-bookmark tw-mr-2" />
                                                 Save for Later
@@ -245,10 +245,10 @@ const DataEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                 {/* Prerequisites & What You'll Build */}
                 <div className="tw-mt-16 tw-grid tw-grid-cols-1 tw-gap-8 lg:tw-grid-cols-2">
                     <div className="tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white tw-p-8 tw-shadow-lg">
-                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-ink">
                             Prerequisites
                         </h3>
-                        <ul className="tw-space-y-3 tw-text-gray-700">
+                        <ul className="tw-space-y-3 tw-text-gray-200">
                             <li className="tw-flex tw-items-center">
                                 <i className="fas fa-check tw-mr-3 tw-text-success" />
                                 Programming experience (Python preferred)
@@ -269,10 +269,10 @@ const DataEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                     </div>
 
                     <div className="tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white tw-p-8 tw-shadow-lg">
-                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-ink">
                             What You&apos;ll Build
                         </h3>
-                        <ul className="tw-space-y-3 tw-text-gray-700">
+                        <ul className="tw-space-y-3 tw-text-gray-200">
                             <li className="tw-flex tw-items-center">
                                 <i className="fas fa-rocket tw-mr-3 tw-text-secondary" />
                                 Automated ETL data pipeline

--- a/src/pages/courses/devops.tsx
+++ b/src/pages/courses/devops.tsx
@@ -197,17 +197,17 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
                             </div>
                         </div>
 
-                        <div className="tw-min-w-[300px] tw-rounded-lg tw-bg-white tw-p-6 tw-text-gray-900">
+                        <div className="tw-min-w-[300px] tw-rounded-lg tw-bg-white tw-p-6 tw-text-ink">
                             <div className="tw-mb-4 tw-text-center">
-                                <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-green-600">
+                                <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gold">
                                     FREE
                                 </div>
-                                <p className="tw-text-gray-600">For veterans & military spouses</p>
+                                <p className="tw-text-gray-300">For veterans & military spouses</p>
                             </div>
 
                             {isEnrolled ? (
                                 <div className="tw-text-center">
-                                    <div className="tw-mb-4 tw-rounded-md tw-bg-green-100 tw-px-4 tw-py-2 tw-text-green-800">
+                                    <div className="tw-mb-4 tw-rounded-md tw-bg-gold-light/30 tw-px-4 tw-py-2 tw-text-gold-deep">
                                         ✓ Enrolled
                                     </div>
                                     <Link
@@ -228,7 +228,7 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
                                 </button>
                             )}
 
-                            <div className="tw-mt-4 tw-text-center tw-text-sm tw-text-gray-600">
+                            <div className="tw-mt-4 tw-text-center tw-text-sm tw-text-gray-300">
                                 <p>Includes:</p>
                                 <ul className="tw-mt-2 tw-space-y-1">
                                     <li>• Lifetime access</li>
@@ -244,7 +244,7 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
                 {/* Course Description */}
                 <div className="tw-mb-16 tw-grid tw-grid-cols-1 tw-gap-12 lg:tw-grid-cols-3">
                     <div className="lg:tw-col-span-2">
-                        <h2 className="tw-mb-6 tw-text-3xl tw-font-bold tw-text-gray-900">
+                        <h2 className="tw-mb-6 tw-text-3xl tw-font-bold tw-text-ink">
                             Course Overview
                         </h2>
                         <div className="tw-prose tw-prose-lg tw-max-w-none">
@@ -270,7 +270,7 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
                             </p>
                         </div>
 
-                        <h3 className="tw-mb-4 tw-mt-8 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-4 tw-mt-8 tw-text-2xl tw-font-bold tw-text-ink">
                             What You&apos;ll Master
                         </h3>
                         <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
@@ -318,20 +318,20 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
                     </div>
 
                     <div>
-                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-ink">
                             Prerequisites
                         </h3>
-                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-600">
+                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-300">
                             <li>• Basic command line familiarity</li>
                             <li>• Programming fundamentals (any language)</li>
                             <li>• Military background (veteran or spouse)</li>
                             <li>• Commitment to 20-25 hours/week</li>
                         </ul>
 
-                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-ink">
                             Career Outcomes
                         </h3>
-                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-600">
+                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-300">
                             <li>• DevOps Engineer</li>
                             <li>• Site Reliability Engineer (SRE)</li>
                             <li>• Cloud Infrastructure Engineer</li>
@@ -340,13 +340,13 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
                         </ul>
 
                         <div className="tw-rounded-lg tw-bg-gray-50 tw-p-4">
-                            <h4 className="tw-mb-2 tw-font-semibold tw-text-gray-900">
+                            <h4 className="tw-mb-2 tw-font-semibold tw-text-ink">
                                 Average Salary Range
                             </h4>
-                            <div className="tw-text-2xl tw-font-bold tw-text-green-600">
+                            <div className="tw-text-2xl tw-font-bold tw-text-gold">
                                 $90K - $180K
                             </div>
-                            <p className="tw-mt-1 tw-text-sm tw-text-gray-600">
+                            <p className="tw-mt-1 tw-text-sm tw-text-gray-300">
                                 Based on location and experience
                             </p>
                         </div>
@@ -355,7 +355,7 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
 
                 {/* Course Curriculum */}
                 <div className="tw-mb-16">
-                    <h2 className="tw-mb-8 tw-text-3xl tw-font-bold tw-text-gray-900">
+                    <h2 className="tw-mb-8 tw-text-3xl tw-font-bold tw-text-ink">
                         Course Curriculum
                     </h2>
                     <div className="tw-space-y-4">
@@ -371,10 +371,10 @@ const DevOpsCourse: PageWithLayout = ({ user: _user }) => {
                                                 {index + 1}
                                             </div>
                                             <div>
-                                                <h3 className="tw-text-xl tw-font-semibold tw-text-gray-900">
+                                                <h3 className="tw-text-xl tw-font-semibold tw-text-ink">
                                                     {module.title}
                                                 </h3>
-                                                <p className="tw-text-gray-600">
+                                                <p className="tw-text-gray-300">
                                                     {module.description}
                                                 </p>
                                             </div>

--- a/src/pages/courses/index.tsx
+++ b/src/pages/courses/index.tsx
@@ -55,7 +55,7 @@ const CoursesIndex: PageWithLayout = ({ user }) => {
 
                     {/* User Menu */}
                     <div className="tw-flex tw-items-center tw-space-x-4">
-                        <div className="tw-flex tw-items-center tw-space-x-2 tw-text-sm tw-text-gray-600">
+                        <div className="tw-flex tw-items-center tw-space-x-2 tw-text-sm tw-text-gray-300">
                             {user.image && (
                                 <img
                                     src={user.image}
@@ -70,7 +70,7 @@ const CoursesIndex: PageWithLayout = ({ user }) => {
                         <div className="tw-flex tw-space-x-2">
                             <Link
                                 href="/profile"
-                                className="tw-rounded-md tw-bg-gray-100 tw-px-3 tw-py-2 tw-text-sm tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-200"
+                                className="tw-rounded-md tw-bg-gray-100 tw-px-3 tw-py-2 tw-text-sm tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                                 title="View Profile"
                             >
                                 <i className="fas fa-user tw-mr-1" />
@@ -114,7 +114,7 @@ const CoursesIndex: PageWithLayout = ({ user }) => {
                         </div>
                         <div className="tw-p-8">
                             <div className="tw-mb-6 tw-flex tw-items-center tw-justify-between">
-                                <div className="tw-flex tw-items-center tw-rounded-full tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-700">
+                                <div className="tw-flex tw-items-center tw-rounded-full tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-200">
                                     <i className="fas fa-clock tw-mr-2 tw-text-primary" />
                                     <span>16-20 weeks</span>
                                 </div>
@@ -166,7 +166,7 @@ const CoursesIndex: PageWithLayout = ({ user }) => {
                         </div>
                         <div className="tw-p-8">
                             <div className="tw-mb-6 tw-flex tw-items-center tw-justify-between">
-                                <div className="tw-flex tw-items-center tw-rounded-full tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-700">
+                                <div className="tw-flex tw-items-center tw-rounded-full tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-200">
                                     <i className="fas fa-clock tw-mr-2 tw-text-secondary" />
                                     <span>18-22 weeks</span>
                                 </div>
@@ -218,7 +218,7 @@ const CoursesIndex: PageWithLayout = ({ user }) => {
                         </div>
                         <div className="tw-p-8">
                             <div className="tw-mb-6 tw-flex tw-items-center tw-justify-between">
-                                <div className="tw-flex tw-items-center tw-rounded-full tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-700">
+                                <div className="tw-flex tw-items-center tw-rounded-full tw-bg-gray-50 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gray-200">
                                     <i className="fas fa-clock tw-mr-2 tw-text-success" />
                                     <span>20-24 weeks</span>
                                 </div>

--- a/src/pages/courses/software-engineering.tsx
+++ b/src/pages/courses/software-engineering.tsx
@@ -128,7 +128,7 @@ const SoftwareEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                             Software Engineering
                         </h1>
                         <div className="tw-mx-auto tw-mb-6 tw-h-1 tw-w-24 tw-rounded tw-bg-primary" />
-                        <p className="tw-mx-auto tw-max-w-3xl tw-text-xl tw-leading-relaxed tw-text-gray-700 md:tw-text-2xl">
+                        <p className="tw-mx-auto tw-max-w-3xl tw-text-xl tw-leading-relaxed tw-text-gray-200 md:tw-text-2xl">
                             Master full-stack development, system design, and software architecture
                             to build scalable applications that solve real-world problems.
                         </p>
@@ -168,10 +168,10 @@ const SoftwareEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                                         {index + 1}
                                     </div>
                                     <div>
-                                        <h3 className="tw-text-xl tw-font-bold tw-text-gray-900">
+                                        <h3 className="tw-text-xl tw-font-bold tw-text-ink">
                                             {module.title}
                                         </h3>
-                                        <p className="tw-text-gray-600">{module.description}</p>
+                                        <p className="tw-text-gray-300">{module.description}</p>
                                     </div>
                                 </div>
                                 <div className="tw-flex tw-items-center tw-space-x-4">
@@ -204,7 +204,7 @@ const SoftwareEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                             {selectedModule === module.id && (
                                 <div className="tw-border-t tw-border-gray-200 tw-bg-gray-50 tw-p-6">
                                     <div className="tw-mb-4">
-                                        <h4 className="tw-mb-3 tw-font-semibold tw-text-gray-900">
+                                        <h4 className="tw-mb-3 tw-font-semibold tw-text-ink">
                                             Technologies Covered:
                                         </h4>
                                         <div className="tw-flex tw-flex-wrap tw-gap-2">
@@ -229,7 +229,7 @@ const SoftwareEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                                             </Link>
                                             <button
                                                 type="button"
-                                                className="tw-inline-flex tw-items-center tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-50"
+                                                className="tw-inline-flex tw-items-center tw-rounded-lg tw-border tw-border-gray-300 tw-bg-white tw-px-6 tw-py-3 tw-font-semibold tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                                             >
                                                 <i className="fas fa-bookmark tw-mr-2" />
                                                 Save for Later
@@ -245,10 +245,10 @@ const SoftwareEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                 {/* Prerequisites & What You'll Build */}
                 <div className="tw-mt-16 tw-grid tw-grid-cols-1 tw-gap-8 lg:tw-grid-cols-2">
                     <div className="tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white tw-p-8 tw-shadow-lg">
-                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-ink">
                             Prerequisites
                         </h3>
-                        <ul className="tw-space-y-3 tw-text-gray-700">
+                        <ul className="tw-space-y-3 tw-text-gray-200">
                             <li className="tw-flex tw-items-center">
                                 <i className="fas fa-check tw-mr-3 tw-text-success" />
                                 Basic computer skills and familiarity with the internet
@@ -269,10 +269,10 @@ const SoftwareEngineeringCourse: PageWithLayout = ({ user: _user }) => {
                     </div>
 
                     <div className="tw-rounded-xl tw-border tw-border-gray-200 tw-bg-white tw-p-8 tw-shadow-lg">
-                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-ink">
                             What You&apos;ll Build
                         </h3>
-                        <ul className="tw-space-y-3 tw-text-gray-700">
+                        <ul className="tw-space-y-3 tw-text-gray-200">
                             <li className="tw-flex tw-items-center">
                                 <i className="fas fa-rocket tw-mr-3 tw-text-primary" />
                                 Personal portfolio website

--- a/src/pages/courses/web-development.tsx
+++ b/src/pages/courses/web-development.tsx
@@ -142,7 +142,7 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                                     <h1 className="tw-mb-2 tw-text-4xl tw-font-bold">
                                         Web Development
                                     </h1>
-                                    <p className="tw-text-lg tw-text-blue-100">
+                                    <p className="tw-text-lg tw-text-navy-ocean">
                                         Build modern, responsive web applications from frontend to
                                         backend
                                     </p>
@@ -152,19 +152,19 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                             <div className="tw-mb-6 tw-grid tw-grid-cols-2 tw-gap-6 md:tw-grid-cols-4">
                                 <div>
                                     <div className="tw-text-2xl tw-font-bold">12-16</div>
-                                    <div className="tw-text-blue-100">weeks</div>
+                                    <div className="tw-text-navy-ocean">weeks</div>
                                 </div>
                                 <div>
                                     <div className="tw-text-2xl tw-font-bold">158</div>
-                                    <div className="tw-text-blue-100">hours</div>
+                                    <div className="tw-text-navy-ocean">hours</div>
                                 </div>
                                 <div>
                                     <div className="tw-text-2xl tw-font-bold">176</div>
-                                    <div className="tw-text-blue-100">lessons</div>
+                                    <div className="tw-text-navy-ocean">lessons</div>
                                 </div>
                                 <div>
                                     <div className="tw-text-2xl tw-font-bold">9</div>
-                                    <div className="tw-text-blue-100">modules</div>
+                                    <div className="tw-text-navy-ocean">modules</div>
                                 </div>
                             </div>
 
@@ -190,17 +190,17 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                             </div>
                         </div>
 
-                        <div className="tw-min-w-[300px] tw-rounded-lg tw-bg-white tw-p-6 tw-text-gray-900">
+                        <div className="tw-min-w-[300px] tw-rounded-lg tw-bg-white tw-p-6 tw-text-ink">
                             <div className="tw-mb-4 tw-text-center">
-                                <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-green-600">
+                                <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gold">
                                     FREE
                                 </div>
-                                <p className="tw-text-gray-600">For veterans & military spouses</p>
+                                <p className="tw-text-gray-300">For veterans & military spouses</p>
                             </div>
 
                             {isEnrolled ? (
                                 <div className="tw-text-center">
-                                    <div className="tw-mb-4 tw-rounded-md tw-bg-green-100 tw-px-4 tw-py-2 tw-text-green-800">
+                                    <div className="tw-mb-4 tw-rounded-md tw-bg-gold-light/30 tw-px-4 tw-py-2 tw-text-gold-deep">
                                         ✓ Enrolled
                                     </div>
                                     <Link
@@ -221,7 +221,7 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                                 </button>
                             )}
 
-                            <div className="tw-mt-4 tw-text-center tw-text-sm tw-text-gray-600">
+                            <div className="tw-mt-4 tw-text-center tw-text-sm tw-text-gray-300">
                                 <p>Includes:</p>
                                 <ul className="tw-mt-2 tw-space-y-1">
                                     <li>• Lifetime access</li>
@@ -237,7 +237,7 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                 {/* Course Description */}
                 <div className="tw-mb-16 tw-grid tw-grid-cols-1 tw-gap-12 lg:tw-grid-cols-3">
                     <div className="lg:tw-col-span-2">
-                        <h2 className="tw-mb-6 tw-text-3xl tw-font-bold tw-text-gray-900">
+                        <h2 className="tw-mb-6 tw-text-3xl tw-font-bold tw-text-ink">
                             Course Overview
                         </h2>
                         <div className="tw-prose tw-prose-lg tw-max-w-none">
@@ -261,7 +261,7 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                             </p>
                         </div>
 
-                        <h3 className="tw-mb-4 tw-mt-8 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-4 tw-mt-8 tw-text-2xl tw-font-bold tw-text-ink">
                             What You&apos;ll Learn
                         </h3>
                         <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
@@ -309,20 +309,20 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                     </div>
 
                     <div>
-                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-ink">
                             Prerequisites
                         </h3>
-                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-600">
+                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-300">
                             <li>• Basic computer literacy</li>
                             <li>• Willingness to learn and practice</li>
                             <li>• Military background (veteran or spouse)</li>
                             <li>• Commitment to 15-20 hours/week</li>
                         </ul>
 
-                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-gray-900">
+                        <h3 className="tw-mb-4 tw-text-xl tw-font-bold tw-text-ink">
                             Career Outcomes
                         </h3>
-                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-600">
+                        <ul className="tw-mb-6 tw-space-y-2 tw-text-gray-300">
                             <li>• Frontend Developer</li>
                             <li>• Full-Stack Developer</li>
                             <li>• React Developer</li>
@@ -331,13 +331,13 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                         </ul>
 
                         <div className="tw-rounded-lg tw-bg-gray-50 tw-p-4">
-                            <h4 className="tw-mb-2 tw-font-semibold tw-text-gray-900">
+                            <h4 className="tw-mb-2 tw-font-semibold tw-text-ink">
                                 Average Salary Range
                             </h4>
-                            <div className="tw-text-2xl tw-font-bold tw-text-green-600">
+                            <div className="tw-text-2xl tw-font-bold tw-text-gold">
                                 $65K - $120K
                             </div>
-                            <p className="tw-mt-1 tw-text-sm tw-text-gray-600">
+                            <p className="tw-mt-1 tw-text-sm tw-text-gray-300">
                                 Based on location and experience
                             </p>
                         </div>
@@ -346,7 +346,7 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
 
                 {/* Course Curriculum */}
                 <div className="tw-mb-16">
-                    <h2 className="tw-mb-8 tw-text-3xl tw-font-bold tw-text-gray-900">
+                    <h2 className="tw-mb-8 tw-text-3xl tw-font-bold tw-text-ink">
                         Course Curriculum
                     </h2>
                     <div className="tw-space-y-4">
@@ -362,10 +362,10 @@ const WebDevelopmentCourse: PageWithLayout = ({ user: _user }) => {
                                                 {index + 1}
                                             </div>
                                             <div>
-                                                <h3 className="tw-text-xl tw-font-semibold tw-text-gray-900">
+                                                <h3 className="tw-text-xl tw-font-semibold tw-text-ink">
                                                     {module.title}
                                                 </h3>
-                                                <p className="tw-text-gray-600">
+                                                <p className="tw-text-gray-300">
                                                     {module.description}
                                                 </p>
                                             </div>

--- a/src/pages/courses/web-development/[moduleId]/[lessonId].tsx
+++ b/src/pages/courses/web-development/[moduleId]/[lessonId].tsx
@@ -63,16 +63,16 @@ const AssignmentSection: React.FC<{
     if (!assignment) return null;
 
     return (
-        <div className="tw-mb-8 tw-rounded-lg tw-border tw-border-orange-200 tw-bg-orange-50 tw-p-6">
+        <div className="tw-mb-8 tw-rounded-lg tw-border tw-border-red-signal/30 tw-bg-red-signal/10 tw-p-6">
             <div className="tw-mb-4 tw-flex tw-items-center tw-justify-between">
-                <h3 className="tw-text-xl tw-font-bold tw-text-orange-900">
+                <h3 className="tw-text-xl tw-font-bold tw-text-red-maroon">
                     <i className="fas fa-tasks tw-mr-2" />
                     Assignment: {assignment.title}
                 </h3>
                 <button
                     type="button"
                     onClick={() => setShowAssignment(!showAssignment)}
-                    className="tw-text-orange-600 hover:tw-text-orange-800"
+                    className="tw-text-red hover:tw-text-red-dark"
                 >
                     {showAssignment ? (
                         <i className="fas fa-chevron-up" />
@@ -84,13 +84,13 @@ const AssignmentSection: React.FC<{
 
             {showAssignment && (
                 <div>
-                    <p className="tw-mb-4 tw-text-orange-800">{assignment.description}</p>
+                    <p className="tw-mb-4 tw-text-red-dark">{assignment.description}</p>
 
-                    <h4 className="tw-mb-2 tw-font-semibold tw-text-orange-900">Requirements:</h4>
+                    <h4 className="tw-mb-2 tw-font-semibold tw-text-red-maroon">Requirements:</h4>
                     <ul className="tw-mb-4 tw-space-y-1">
                         {assignment.requirements.map((req) => (
-                            <li key={req} className="tw-flex tw-items-start tw-text-orange-800">
-                                <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-orange-600" />
+                            <li key={req} className="tw-flex tw-items-start tw-text-red-dark">
+                                <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-red" />
                                 {req}
                             </li>
                         ))}
@@ -99,7 +99,7 @@ const AssignmentSection: React.FC<{
                     {assignment.submissionUrl && (
                         <Link
                             href={assignment.submissionUrl}
-                            className="tw-inline-flex tw-items-center tw-rounded-md tw-bg-orange-600 tw-px-4 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-orange-700"
+                            className="tw-inline-flex tw-items-center tw-rounded-md tw-bg-red tw-px-4 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-red-crimson"
                         >
                             <i className="fas fa-upload tw-mr-2" />
                             Submit Assignment
@@ -168,11 +168,11 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
                 {/* Header */}
                 <div className="tw-mb-8 tw-flex tw-flex-col tw-items-start tw-justify-between lg:tw-flex-row lg:tw-items-center">
                     <div className="tw-mb-4 tw-flex-1 lg:tw-mb-0">
-                        <div className="tw-mb-2 tw-text-sm tw-text-gray-600">{module.title}</div>
-                        <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gray-900">
+                        <div className="tw-mb-2 tw-text-sm tw-text-gray-300">{module.title}</div>
+                        <h1 className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-ink">
                             {lesson.title}
                         </h1>
-                        <p className="tw-text-gray-600">{lesson.description}</p>
+                        <p className="tw-text-gray-300">{lesson.description}</p>
                     </div>
                     <div className="tw-flex tw-items-center tw-space-x-4">
                         <div className="tw-text-sm tw-text-gray-500">
@@ -180,7 +180,7 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
                             {lesson.duration}
                         </div>
                         {completed && (
-                            <div className="tw-flex tw-items-center tw-rounded-full tw-bg-green-100 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-green-800">
+                            <div className="tw-flex tw-items-center tw-rounded-full tw-bg-gold-light/30 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-gold-deep">
                                 <i className="fas fa-check tw-mr-1" />
                                 Completed
                             </div>
@@ -194,7 +194,7 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
                         {/* Video Player */}
                         {lesson.videoUrl && (
                             <div className="tw-mb-8">
-                                <div className="tw-aspect-video tw-overflow-hidden tw-rounded-lg tw-bg-gray-900">
+                                <div className="tw-aspect-video tw-overflow-hidden tw-rounded-lg tw-bg-ink">
                                     <iframe
                                         src={lesson.videoUrl}
                                         title={lesson.title}
@@ -208,7 +208,7 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
 
                         {/* Lesson Content */}
                         <div className="tw-mb-8 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                            <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-gray-900">
+                            <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-ink">
                                 Lesson Content
                             </h2>
                             <div
@@ -243,7 +243,7 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
                                     <button
                                         type="button"
                                         onClick={markAsCompleted}
-                                        className="tw-rounded-md tw-bg-green-600 tw-px-6 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-green-700"
+                                        className="tw-rounded-md tw-bg-gold-rich tw-px-6 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-green-700"
                                     >
                                         <i className="fas fa-check tw-mr-2" />
                                         Mark as Complete
@@ -267,29 +267,29 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
                     <div className="lg:tw-col-span-1">
                         {/* Course Progress */}
                         <div className="tw-mb-6 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                 Course Progress
                             </h3>
-                            <div className="tw-mb-2 tw-flex tw-justify-between tw-text-sm tw-text-gray-600">
+                            <div className="tw-mb-2 tw-flex tw-justify-between tw-text-sm tw-text-gray-300">
                                 <span>Module Progress</span>
                                 <span>3/12 lessons</span>
                             </div>
-                            <div className="tw-mb-4 tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-200">
-                                <div className="tw-h-2 tw-w-[25%] tw-rounded-full tw-bg-blue-600" />
+                            <div className="tw-mb-4 tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-50">
+                                <div className="tw-h-2 tw-w-[25%] tw-rounded-full tw-bg-navy-royal" />
                             </div>
 
-                            <div className="tw-mb-2 tw-flex tw-justify-between tw-text-sm tw-text-gray-600">
+                            <div className="tw-mb-2 tw-flex tw-justify-between tw-text-sm tw-text-gray-300">
                                 <span>Overall Progress</span>
                                 <span>15%</span>
                             </div>
-                            <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-200">
-                                <div className="tw-h-2 tw-w-[15%] tw-rounded-full tw-bg-green-600" />
+                            <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-50">
+                                <div className="tw-h-2 tw-w-[15%] tw-rounded-full tw-bg-gold-rich" />
                             </div>
                         </div>
 
                         {/* Quick Links */}
                         <div className="tw-mb-6 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                 Quick Links
                             </h3>
                             <div className="tw-space-y-2">
@@ -326,17 +326,17 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
 
                         {/* AI Teaching Assistant */}
                         <div className="tw-mb-6 tw-rounded-lg tw-bg-gradient-to-br tw-from-purple-50 tw-to-blue-50 tw-p-6 tw-shadow-md tw-border tw-border-purple-200">
-                            <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-gray-900">
-                                <i className="fas fa-robot tw-mr-2 tw-text-purple-600" />
+                            <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-ink">
+                                <i className="fas fa-robot tw-mr-2 tw-text-navy" />
                                 AI Teaching Assistant
                             </h3>
-                            <p className="tw-mb-4 tw-text-sm tw-text-gray-600">
+                            <p className="tw-mb-4 tw-text-sm tw-text-gray-300">
                                 Need help? Ask J0d!e for explanations and guidance!
                             </p>
                             <button
                                 type="button"
                                 onClick={() => setIsAIAssistantOpen(true)}
-                                className="tw-w-full tw-rounded-md tw-bg-purple-600 tw-px-4 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-purple-700"
+                                className="tw-w-full tw-rounded-md tw-bg-navy tw-px-4 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-purple-700"
                             >
                                 <i className="fas fa-comment-dots tw-mr-2" />
                                 Ask J0d!e
@@ -348,7 +348,7 @@ const LessonPage: PageWithLayout = ({ lesson, module }) => {
 
                         {/* Resources */}
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                 Lesson Resources
                             </h3>
                             <div className="tw-space-y-2">

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -26,7 +26,7 @@ const Dashboard: PageWithLayout = () => {
             <div className="tw-container tw-py-16">
                 <div className="tw-text-center">
                     <div className="tw-mx-auto tw-h-32 tw-w-32 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
-                    <p className="tw-mt-4 tw-text-gray-600">Loading your dashboard...</p>
+                    <p className="tw-mt-4 tw-text-gray-300">Loading your dashboard...</p>
                 </div>
             </div>
         );
@@ -36,10 +36,10 @@ const Dashboard: PageWithLayout = () => {
         return (
             <div className="tw-container tw-py-16">
                 <div className="tw-text-center">
-                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-gray-900">
+                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
                         Access Denied
                     </h1>
-                    <p className="tw-mb-8 tw-text-gray-600">
+                    <p className="tw-mb-8 tw-text-gray-300">
                         Please sign in to access your dashboard.
                     </p>
                     <Link
@@ -65,10 +65,10 @@ const Dashboard: PageWithLayout = () => {
             <div className="tw-container tw-py-16">
                 {/* Welcome Section */}
                 <div className="tw-mb-12">
-                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-gray-900">
+                    <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
                         Welcome back, {session.user?.name || "Veteran"}!
                     </h1>
-                    <p className="tw-text-xl tw-text-gray-600">
+                    <p className="tw-text-xl tw-text-gray-300">
                         Continue your journey to a successful tech career
                     </p>
                 </div>
@@ -76,31 +76,31 @@ const Dashboard: PageWithLayout = () => {
                 {/* Quick Stats */}
                 <div className="tw-mb-12 tw-grid tw-grid-cols-1 tw-gap-6 md:tw-grid-cols-4">
                     <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-text-center tw-shadow-md">
-                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-blue-600">1</div>
-                        <div className="tw-text-gray-600">Courses Enrolled</div>
+                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-navy-royal">1</div>
+                        <div className="tw-text-gray-300">Courses Enrolled</div>
                     </div>
                     <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-text-center tw-shadow-md">
-                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-green-600">0</div>
-                        <div className="tw-text-gray-600">Courses Completed</div>
+                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-gold">0</div>
+                        <div className="tw-text-gray-300">Courses Completed</div>
                     </div>
                     <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-text-center tw-shadow-md">
-                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-purple-600">
+                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-navy">
                             12
                         </div>
-                        <div className="tw-text-gray-600">Hours Studied</div>
+                        <div className="tw-text-gray-300">Hours Studied</div>
                     </div>
                     <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-text-center tw-shadow-md">
-                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-orange-600">
+                        <div className="tw-mb-2 tw-text-3xl tw-font-bold tw-text-red">
                             85%
                         </div>
-                        <div className="tw-text-gray-600">Average Progress</div>
+                        <div className="tw-text-gray-300">Average Progress</div>
                     </div>
                 </div>
 
                 <div className="tw-grid tw-grid-cols-1 tw-gap-8 lg:tw-grid-cols-3">
                     {/* Current Courses */}
                     <div className="lg:tw-col-span-2">
-                        <h2 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-gray-900">
+                        <h2 className="tw-mb-6 tw-text-2xl tw-font-bold tw-text-ink">
                             Your Current Courses
                         </h2>
 
@@ -114,31 +114,31 @@ const Dashboard: PageWithLayout = () => {
                                                 <i className="fab fa-html5 tw-text-2xl tw-text-white" />
                                             </div>
                                             <div>
-                                                <h3 className="tw-text-xl tw-font-semibold tw-text-gray-900">
+                                                <h3 className="tw-text-xl tw-font-semibold tw-text-ink">
                                                     Web Development
                                                 </h3>
-                                                <p className="tw-text-gray-600">
+                                                <p className="tw-text-gray-300">
                                                     Build modern web applications
                                                 </p>
                                             </div>
                                         </div>
-                                        <span className="tw-rounded-full tw-bg-green-100 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-green-800">
+                                        <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-gold-deep">
                                             Active
                                         </span>
                                     </div>
 
                                     <div className="tw-mb-4">
-                                        <div className="tw-mb-2 tw-flex tw-justify-between tw-text-sm tw-text-gray-600">
+                                        <div className="tw-mb-2 tw-flex tw-justify-between tw-text-sm tw-text-gray-300">
                                             <span>Progress</span>
                                             <span>15%</span>
                                         </div>
-                                        <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-200">
-                                            <div className="tw-h-2 tw-w-[15%] tw-rounded-full tw-bg-blue-600" />
+                                        <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-50">
+                                            <div className="tw-h-2 tw-w-[15%] tw-rounded-full tw-bg-navy-royal" />
                                         </div>
                                     </div>
 
                                     <div className="tw-flex tw-items-center tw-justify-between">
-                                        <div className="tw-text-sm tw-text-gray-600">
+                                        <div className="tw-text-sm tw-text-gray-300">
                                             Next: CSS Styling & Layout
                                         </div>
                                         <Link
@@ -154,10 +154,10 @@ const Dashboard: PageWithLayout = () => {
                             {/* Empty state for additional courses */}
                             <div className="tw-rounded-lg tw-border-2 tw-border-dashed tw-border-gray-300 tw-bg-gray-50 tw-p-8 tw-text-center">
                                 <i className="fas fa-plus-circle tw-mb-4 tw-text-4xl tw-text-gray-400" />
-                                <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-ink">
                                     Enroll in More Courses
                                 </h3>
-                                <p className="tw-mb-4 tw-text-gray-600">
+                                <p className="tw-mb-4 tw-text-gray-300">
                                     Expand your skills with additional courses
                                 </p>
                                 <Link
@@ -174,55 +174,55 @@ const Dashboard: PageWithLayout = () => {
                     <div>
                         {/* Upcoming Assignments */}
                         <div className="tw-mb-8 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                 Upcoming Assignments
                             </h3>
                             <div className="tw-space-y-4">
-                                <div className="tw-border-l-4 tw-border-orange-500 tw-pl-4">
-                                    <div className="tw-font-medium tw-text-gray-900">
+                                <div className="tw-border-l-4 tw-border-red-signal/100 tw-pl-4">
+                                    <div className="tw-font-medium tw-text-ink">
                                         HTML Portfolio Project
                                     </div>
-                                    <div className="tw-text-sm tw-text-gray-600">Due in 3 days</div>
+                                    <div className="tw-text-sm tw-text-gray-300">Due in 3 days</div>
                                 </div>
-                                <div className="tw-border-l-4 tw-border-blue-500 tw-pl-4">
-                                    <div className="tw-font-medium tw-text-gray-900">
+                                <div className="tw-border-l-4 tw-border-navy-ocean tw-pl-4">
+                                    <div className="tw-font-medium tw-text-ink">
                                         CSS Layout Exercise
                                     </div>
-                                    <div className="tw-text-sm tw-text-gray-600">Due in 1 week</div>
+                                    <div className="tw-text-sm tw-text-gray-300">Due in 1 week</div>
                                 </div>
                             </div>
                         </div>
 
                         {/* Recent Activity */}
                         <div className="tw-mb-8 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                 Recent Activity
                             </h3>
                             <div className="tw-space-y-3">
                                 <div className="tw-text-sm">
-                                    <div className="tw-font-medium tw-text-gray-900">
+                                    <div className="tw-font-medium tw-text-ink">
                                         Completed: HTML Fundamentals
                                     </div>
-                                    <div className="tw-text-gray-600">2 days ago</div>
+                                    <div className="tw-text-gray-300">2 days ago</div>
                                 </div>
                                 <div className="tw-text-sm">
-                                    <div className="tw-font-medium tw-text-gray-900">
+                                    <div className="tw-font-medium tw-text-ink">
                                         Started: CSS Styling & Layout
                                     </div>
-                                    <div className="tw-text-gray-600">3 days ago</div>
+                                    <div className="tw-text-gray-300">3 days ago</div>
                                 </div>
                                 <div className="tw-text-sm">
-                                    <div className="tw-font-medium tw-text-gray-900">
+                                    <div className="tw-font-medium tw-text-ink">
                                         Enrolled in Web Development
                                     </div>
-                                    <div className="tw-text-gray-600">1 week ago</div>
+                                    <div className="tw-text-gray-300">1 week ago</div>
                                 </div>
                             </div>
                         </div>
 
                         {/* Quick Links */}
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                            <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                 Quick Links
                             </h3>
                             <div className="tw-space-y-2">

--- a/src/pages/dev-access.tsx
+++ b/src/pages/dev-access.tsx
@@ -39,7 +39,7 @@ const DevAccess: NextPage = () => {
           <h1 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-red-600">
             Not Available in Production
           </h1>
-          <p className="tw-text-gray-700">
+          <p className="tw-text-gray-200">
             This page is only available in development mode.
           </p>
         </div>
@@ -53,10 +53,10 @@ const DevAccess: NextPage = () => {
         <div className="tw-mb-4">
           <i className="fas fa-cog fa-spin tw-text-6xl tw-text-primary" />
         </div>
-        <h1 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-gray-900">
+        <h1 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-ink">
           Dev Access Enabled
         </h1>
-        <p className="tw-mb-4 tw-text-gray-700">
+        <p className="tw-mb-4 tw-text-gray-200">
           Setting up development bypass...
         </p>
         <p className="tw-text-sm tw-text-gray-500">

--- a/src/pages/dev-login.tsx
+++ b/src/pages/dev-login.tsx
@@ -48,7 +48,7 @@ const DevLogin: PageWithLayout = () => {
                     <p className="tw-text-center tw-text-secondary">
                         Quick bypass for testing the platform
                     </p>
-                    <div className="tw-rounded tw-bg-yellow-50 tw-p-3 tw-text-sm tw-text-yellow-600">
+                    <div className="tw-rounded tw-bg-gold-light/20 tw-p-3 tw-text-sm tw-text-gold-rich">
                         ⚠️ This is for development only - bypasses GitHub OAuth
                     </div>
                 </div>

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -33,7 +33,7 @@ const Faq: PageProps = ({ data }) => {
                 pages={[{ path: "/", label: "home" }]}
                 currentPage="FAQ"
                 showTitle={false}
-                className="tw-bg-gray-200"
+                className="tw-bg-gray-50"
             />
             <QuoteArea data={content?.["quote-area"]} />
             <FaqArea data={content?.["faq-area"]} />

--- a/src/pages/jobs/[id].tsx
+++ b/src/pages/jobs/[id].tsx
@@ -51,10 +51,10 @@ const JobDetailPage: PageWithLayout = ({ job }) => {
         <div className="tw-mb-8 tw-rounded-lg tw-bg-white tw-p-8 tw-shadow-md">
           <div className="tw-mb-6 tw-flex tw-items-start tw-justify-between">
             <div className="tw-flex-1">
-              <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-gray-900">
+              <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
                 {job.title}
               </h1>
-              <div className="tw-mb-4 tw-flex tw-flex-wrap tw-gap-4 tw-text-lg tw-text-gray-600">
+              <div className="tw-mb-4 tw-flex tw-flex-wrap tw-gap-4 tw-text-lg tw-text-gray-300">
                 {job.company && (
                   <div className="tw-flex tw-items-center">
                     <i className="fas fa-building tw-mr-2 tw-text-primary" />
@@ -82,13 +82,13 @@ const JobDetailPage: PageWithLayout = ({ job }) => {
               </div>
               <div className="tw-flex tw-flex-wrap tw-gap-2">
                 {job.category && (
-                  <span className="tw-rounded-full tw-bg-blue-100 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-blue-800">
+                  <span className="tw-rounded-full tw-bg-navy-sky tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-blue-800">
                     <i className="fas fa-tag tw-mr-1" />
                     {job.category}
                   </span>
                 )}
                 {job.pubDate && (
-                  <span className="tw-rounded-full tw-bg-gray-100 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-700">
+                  <span className="tw-rounded-full tw-bg-gray-100 tw-px-4 tw-py-2 tw-text-sm tw-text-gray-200">
                     <i className="fas fa-calendar tw-mr-1" />
                     Posted {new Date(job.pubDate).toLocaleDateString()}
                   </span>
@@ -139,11 +139,11 @@ const JobDetailPage: PageWithLayout = ({ job }) => {
           <div className="lg:tw-col-span-2">
             {/* Job Description */}
             <div className="tw-mb-8 tw-rounded-lg tw-bg-white tw-p-8 tw-shadow-md">
-              <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-gray-900">
+              <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-ink">
                 Job Description
               </h2>
               <div
-                className="prose tw-max-w-none tw-text-gray-700"
+                className="prose tw-max-w-none tw-text-gray-200"
                 dangerouslySetInnerHTML={{ __html: job.description }}
               />
             </div>
@@ -151,40 +151,40 @@ const JobDetailPage: PageWithLayout = ({ job }) => {
             {/* Additional Info */}
             {(job.company || job.type || job.salary) && (
               <div className="tw-rounded-lg tw-bg-white tw-p-8 tw-shadow-md">
-                <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-gray-900">
+                <h2 className="tw-mb-4 tw-text-2xl tw-font-bold tw-text-ink">
                   Additional Information
                 </h2>
                 <dl className="tw-space-y-4">
                   {job.company && (
                     <div>
-                      <dt className="tw-font-semibold tw-text-gray-900">Company</dt>
-                      <dd className="tw-text-gray-700">{job.company}</dd>
+                      <dt className="tw-font-semibold tw-text-ink">Company</dt>
+                      <dd className="tw-text-gray-200">{job.company}</dd>
                     </div>
                   )}
                   {job.location && (
                     <div>
-                      <dt className="tw-font-semibold tw-text-gray-900">Location</dt>
-                      <dd className="tw-text-gray-700">{job.location}</dd>
+                      <dt className="tw-font-semibold tw-text-ink">Location</dt>
+                      <dd className="tw-text-gray-200">{job.location}</dd>
                     </div>
                   )}
                   {job.type && (
                     <div>
-                      <dt className="tw-font-semibold tw-text-gray-900">
+                      <dt className="tw-font-semibold tw-text-ink">
                         Employment Type
                       </dt>
-                      <dd className="tw-text-gray-700">{job.type}</dd>
+                      <dd className="tw-text-gray-200">{job.type}</dd>
                     </div>
                   )}
                   {job.salary && (
                     <div>
-                      <dt className="tw-font-semibold tw-text-gray-900">Salary Range</dt>
-                      <dd className="tw-text-gray-700">{job.salary}</dd>
+                      <dt className="tw-font-semibold tw-text-ink">Salary Range</dt>
+                      <dd className="tw-text-gray-200">{job.salary}</dd>
                     </div>
                   )}
                   {job.category && (
                     <div>
-                      <dt className="tw-font-semibold tw-text-gray-900">Category</dt>
-                      <dd className="tw-text-gray-700">{job.category}</dd>
+                      <dt className="tw-font-semibold tw-text-ink">Category</dt>
+                      <dd className="tw-text-gray-200">{job.category}</dd>
                     </div>
                   )}
                 </dl>
@@ -213,44 +213,44 @@ const JobDetailPage: PageWithLayout = ({ job }) => {
 
             {/* Resources */}
             <div className="tw-mb-8 tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-              <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+              <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                 <i className="fas fa-tools tw-mr-2 tw-text-primary" />
                 Application Resources
               </h3>
               <div className="tw-space-y-3">
                 <Link
                   href="/resume-translator"
-                  className="tw-block tw-rounded-md tw-border tw-border-gray-200 tw-p-3 tw-transition-colors hover:tw-border-primary hover:tw-bg-blue-50"
+                  className="tw-block tw-rounded-md tw-border tw-border-gray-200 tw-p-3 tw-transition-colors hover:tw-border-primary hover:tw-bg-navy-sky/20"
                 >
-                  <div className="tw-font-medium tw-text-gray-900">
+                  <div className="tw-font-medium tw-text-ink">
                     <i className="fas fa-file-alt tw-mr-2 tw-text-primary" />
                     Resume Translator
                   </div>
-                  <div className="tw-text-sm tw-text-gray-600">
+                  <div className="tw-text-sm tw-text-gray-300">
                     Translate military skills to civilian terms
                   </div>
                 </Link>
                 <Link
                   href="/courses"
-                  className="tw-block tw-rounded-md tw-border tw-border-gray-200 tw-p-3 tw-transition-colors hover:tw-border-primary hover:tw-bg-blue-50"
+                  className="tw-block tw-rounded-md tw-border tw-border-gray-200 tw-p-3 tw-transition-colors hover:tw-border-primary hover:tw-bg-navy-sky/20"
                 >
-                  <div className="tw-font-medium tw-text-gray-900">
+                  <div className="tw-font-medium tw-text-ink">
                     <i className="fas fa-graduation-cap tw-mr-2 tw-text-primary" />
                     Skill Development
                   </div>
-                  <div className="tw-text-sm tw-text-gray-600">
+                  <div className="tw-text-sm tw-text-gray-300">
                     Enhance your tech skills
                   </div>
                 </Link>
                 <Link
                   href="/profile"
-                  className="tw-block tw-rounded-md tw-border tw-border-gray-200 tw-p-3 tw-transition-colors hover:tw-border-primary hover:tw-bg-blue-50"
+                  className="tw-block tw-rounded-md tw-border tw-border-gray-200 tw-p-3 tw-transition-colors hover:tw-border-primary hover:tw-bg-navy-sky/20"
                 >
-                  <div className="tw-font-medium tw-text-gray-900">
+                  <div className="tw-font-medium tw-text-ink">
                     <i className="fas fa-user-edit tw-mr-2 tw-text-primary" />
                     Update Profile
                   </div>
-                  <div className="tw-text-sm tw-text-gray-600">
+                  <div className="tw-text-sm tw-text-gray-300">
                     Keep your info current
                   </div>
                 </Link>
@@ -258,26 +258,26 @@ const JobDetailPage: PageWithLayout = ({ job }) => {
             </div>
 
             {/* Tips */}
-            <div className="tw-rounded-lg tw-border-2 tw-border-blue-200 tw-bg-blue-50 tw-p-6">
-              <h3 className="tw-mb-3 tw-text-lg tw-font-semibold tw-text-gray-900">
-                <i className="fas fa-lightbulb tw-mr-2 tw-text-blue-600" />
+            <div className="tw-rounded-lg tw-border-2 tw-border-blue-200 tw-bg-navy-sky/20 tw-p-6">
+              <h3 className="tw-mb-3 tw-text-lg tw-font-semibold tw-text-ink">
+                <i className="fas fa-lightbulb tw-mr-2 tw-text-navy-royal" />
                 Application Tips
               </h3>
-              <ul className="tw-space-y-2 tw-text-sm tw-text-gray-700">
+              <ul className="tw-space-y-2 tw-text-sm tw-text-gray-200">
                 <li className="tw-flex tw-items-start">
-                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-green-600" />
+                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-gold" />
                   <span>Tailor your resume to the job description</span>
                 </li>
                 <li className="tw-flex tw-items-start">
-                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-green-600" />
+                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-gold" />
                   <span>Highlight your military skills and experience</span>
                 </li>
                 <li className="tw-flex tw-items-start">
-                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-green-600" />
+                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-gold" />
                   <span>Include relevant certifications and training</span>
                 </li>
                 <li className="tw-flex tw-items-start">
-                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-green-600" />
+                  <i className="fas fa-check tw-mr-2 tw-mt-1 tw-text-gold" />
                   <span>Follow up after submitting your application</span>
                 </li>
               </ul>
@@ -287,10 +287,10 @@ const JobDetailPage: PageWithLayout = ({ job }) => {
 
         {/* Bottom CTA */}
         <div className="tw-mt-12 tw-rounded-lg tw-bg-gray-100 tw-p-8 tw-text-center">
-          <h3 className="tw-mb-3 tw-text-2xl tw-font-bold tw-text-gray-900">
+          <h3 className="tw-mb-3 tw-text-2xl tw-font-bold tw-text-ink">
             Not the right fit?
           </h3>
-          <p className="tw-mb-6 tw-text-gray-700">
+          <p className="tw-mb-6 tw-text-gray-200">
             Browse more exclusive opportunities on our job board
           </p>
           <Link

--- a/src/pages/jobs/index.tsx
+++ b/src/pages/jobs/index.tsx
@@ -86,17 +86,17 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
         {/* Header */}
         <div className="tw-mb-12">
           <div className="tw-mb-4 tw-flex tw-items-center tw-justify-between">
-            <h1 className="tw-text-4xl tw-font-bold tw-text-gray-900">
+            <h1 className="tw-text-4xl tw-font-bold tw-text-ink">
               Vets Who Code Job Board
             </h1>
             {user.hasEnrollment && (
-              <span className="tw-rounded-full tw-bg-green-100 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-green-800">
+              <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gold-deep">
                 <i className="fas fa-check-circle tw-mr-2" />
                 VWC Alumni
               </span>
             )}
           </div>
-          <p className="tw-text-xl tw-text-gray-600">
+          <p className="tw-text-xl tw-text-gray-300">
             Exclusive tech opportunities for our veteran community
           </p>
         </div>
@@ -108,7 +108,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
             <div className="md:tw-col-span-2">
               <label
                 htmlFor="search"
-                className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-200"
               >
                 Search Jobs
               </label>
@@ -126,7 +126,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
             <div>
               <label
                 htmlFor="category"
-                className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-200"
               >
                 Category
               </label>
@@ -149,7 +149,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
             <div>
               <label
                 htmlFor="type"
-                className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                className="tw-mb-2 tw-block tw-text-sm tw-font-medium tw-text-gray-200"
               >
                 Job Type
               </label>
@@ -172,7 +172,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
           {/* Active Filters */}
           {(searchQuery || selectedCategory || selectedType) && (
             <div className="tw-mt-4 tw-flex tw-items-center tw-gap-2">
-              <span className="tw-text-sm tw-text-gray-600">Active filters:</span>
+              <span className="tw-text-sm tw-text-gray-300">Active filters:</span>
               {searchQuery && (
                 <span className="tw-rounded-full tw-bg-primary tw-bg-opacity-10 tw-px-3 tw-py-1 tw-text-sm tw-text-primary">
                   Search: &quot;{searchQuery}&quot;
@@ -199,7 +199,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
         </div>
 
         {/* Results Count */}
-        <div className="tw-mb-6 tw-text-gray-600">
+        <div className="tw-mb-6 tw-text-gray-300">
           Showing {filteredJobs.length} {filteredJobs.length === 1 ? 'job' : 'jobs'}
           {jobs.length !== filteredJobs.length && ` of ${jobs.length} total`}
         </div>
@@ -208,10 +208,10 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
         {filteredJobs.length === 0 ? (
           <div className="tw-rounded-lg tw-bg-white tw-p-12 tw-text-center tw-shadow-md">
             <i className="fas fa-briefcase tw-mb-4 tw-text-6xl tw-text-gray-300" />
-            <h3 className="tw-mb-2 tw-text-xl tw-font-semibold tw-text-gray-900">
+            <h3 className="tw-mb-2 tw-text-xl tw-font-semibold tw-text-ink">
               {jobs.length === 0 ? 'No jobs available yet' : 'No jobs match your filters'}
             </h3>
-            <p className="tw-mb-4 tw-text-gray-600">
+            <p className="tw-mb-4 tw-text-gray-300">
               {jobs.length === 0
                 ? 'Check back soon for new opportunities!'
                 : 'Try adjusting your search or filters to see more results.'}
@@ -235,10 +235,10 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
                 <div className="tw-p-6">
                   <div className="tw-mb-4 tw-flex tw-items-start tw-justify-between">
                     <div className="tw-flex-1">
-                      <h2 className="tw-mb-2 tw-text-2xl tw-font-bold tw-text-gray-900">
+                      <h2 className="tw-mb-2 tw-text-2xl tw-font-bold tw-text-ink">
                         {job.title}
                       </h2>
-                      <div className="tw-mb-3 tw-flex tw-flex-wrap tw-gap-3 tw-text-gray-600">
+                      <div className="tw-mb-3 tw-flex tw-flex-wrap tw-gap-3 tw-text-gray-300">
                         {job.company && (
                           <div className="tw-flex tw-items-center">
                             <i className="fas fa-building tw-mr-2 tw-text-primary" />
@@ -265,7 +265,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
                         )}
                       </div>
                       {job.category && (
-                        <span className="tw-inline-block tw-rounded-full tw-bg-blue-100 tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-blue-800">
+                        <span className="tw-inline-block tw-rounded-full tw-bg-navy-sky tw-px-3 tw-py-1 tw-text-sm tw-font-medium tw-text-blue-800">
                           {job.category}
                         </span>
                       )}
@@ -277,7 +277,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
                     )}
                   </div>
 
-                  <p className="tw-mb-4 tw-line-clamp-3 tw-text-gray-700">
+                  <p className="tw-mb-4 tw-line-clamp-3 tw-text-gray-200">
                     {job.description}
                   </p>
 
@@ -305,12 +305,12 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
         )}
 
         {/* Help Section */}
-        <div className="tw-mt-12 tw-rounded-lg tw-border-2 tw-border-blue-200 tw-bg-blue-50 tw-p-6">
-          <h3 className="tw-mb-3 tw-text-lg tw-font-semibold tw-text-gray-900">
-            <i className="fas fa-info-circle tw-mr-2 tw-text-blue-600" />
+        <div className="tw-mt-12 tw-rounded-lg tw-border-2 tw-border-blue-200 tw-bg-navy-sky/20 tw-p-6">
+          <h3 className="tw-mb-3 tw-text-lg tw-font-semibold tw-text-ink">
+            <i className="fas fa-info-circle tw-mr-2 tw-text-navy-royal" />
             Need Help with Your Job Search?
           </h3>
-          <p className="tw-mb-4 tw-text-gray-700">
+          <p className="tw-mb-4 tw-text-gray-200">
             Leverage our resources to improve your chances of landing your dream role:
           </p>
           <div className="tw-grid tw-grid-cols-1 tw-gap-3 md:tw-grid-cols-3">

--- a/src/pages/media.tsx
+++ b/src/pages/media.tsx
@@ -63,7 +63,7 @@ const MediaPage: PageWithLayout = ({ allMediaItems, page }) => {
                         <div className="tw-flex-1">
                             <label
                                 htmlFor="mediaTypeFilter"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Filter by Type
                             </label>
@@ -86,7 +86,7 @@ const MediaPage: PageWithLayout = ({ allMediaItems, page }) => {
                         <div className="tw-flex-1">
                             <label
                                 htmlFor="yearFilter"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Filter by Year
                             </label>
@@ -109,7 +109,7 @@ const MediaPage: PageWithLayout = ({ allMediaItems, page }) => {
                         <div className="tw-flex-1">
                             <label
                                 htmlFor="searchTerm"
-                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                             >
                                 Search
                             </label>
@@ -135,7 +135,7 @@ const MediaPage: PageWithLayout = ({ allMediaItems, page }) => {
                                     setYearFilter("");
                                     setSearchTerm("");
                                 }}
-                                className="h-12 tw-mt-1 tw-w-full tw-rounded-md tw-border tw-border-gray-300 tw-bg-white tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-gray-700 tw-shadow-sm hover:tw-bg-gray-50 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary focus:tw-ring-offset-2 sm:tw-mt-0 sm:tw-w-auto"
+                                className="h-12 tw-mt-1 tw-w-full tw-rounded-md tw-border tw-border-gray-300 tw-bg-white tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-gray-200 tw-shadow-sm hover:tw-bg-gray-50 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary focus:tw-ring-offset-2 sm:tw-mt-0 sm:tw-w-auto"
                             >
                                 Reset
                             </button>

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -235,7 +235,7 @@ const Profile: PageWithLayout = ({ user }) => {
                 <div
                     className={`tw-fixed tw-top-4 tw-right-4 tw-z-50 tw-rounded-lg tw-p-4 tw-shadow-lg tw-animate-in tw-fade-in tw-slide-in-from-top-5 tw-duration-300 ${
                         notification.type === "success"
-                            ? "tw-bg-green-50 tw-text-green-800 tw-border tw-border-green-200"
+                            ? "tw-bg-gold-light/20 tw-text-gold-deep tw-border tw-border-green-200"
                             : "tw-bg-red-50 tw-text-red-800 tw-border tw-border-red-200"
                     }`}
                 >
@@ -251,7 +251,7 @@ const Profile: PageWithLayout = ({ user }) => {
                         <button
                             type="button"
                             onClick={() => setNotification(null)}
-                            className="tw-ml-4 tw-text-gray-500 hover:tw-text-gray-700"
+                            className="tw-ml-4 tw-text-gray-500 hover:tw-text-gray-200"
                             aria-label="Close notification"
                         >
                             <i className="fas fa-times" />
@@ -393,7 +393,7 @@ const Profile: PageWithLayout = ({ user }) => {
 
                                 {/* Recent Activity */}
                                 <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                                    <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                    <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                         Recent Activity
                                     </h3>
                                     <div className="tw-space-y-4">
@@ -404,7 +404,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                             >
                                                 <div className="tw-h-2 tw-w-2 tw-rounded-full tw-bg-primary" />
                                                 <div className="tw-flex-1">
-                                                    <div className="tw-text-sm tw-font-medium tw-text-gray-900">
+                                                    <div className="tw-text-sm tw-font-medium tw-text-ink">
                                                         {activity.action}: {activity.content}
                                                     </div>
                                                     <div className="tw-text-xs tw-text-secondary">
@@ -420,7 +420,7 @@ const Profile: PageWithLayout = ({ user }) => {
                             {/* Profile Details */}
                             <div className="tw-col-span-1">
                                 <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                                    <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                    <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                         Profile Details
                                     </h3>
 
@@ -429,7 +429,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                             <div>
                                                 <label
                                                     htmlFor="bio"
-                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                                 >
                                                     Bio
                                                 </label>
@@ -447,7 +447,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                             <div>
                                                 <label
                                                     htmlFor="title"
-                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                                 >
                                                     Current Title
                                                 </label>
@@ -465,7 +465,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                             <div>
                                                 <label
                                                     htmlFor="location"
-                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                                 >
                                                     Location
                                                 </label>
@@ -483,7 +483,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                             <div>
                                                 <label
                                                     htmlFor="branch"
-                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-700"
+                                                    className="tw-block tw-text-sm tw-font-medium tw-text-gray-200"
                                                 >
                                                     Military Branch
                                                 </label>
@@ -528,7 +528,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                                         setIsEditing(false);
                                                     }}
                                                     disabled={isSaving}
-                                                    className="tw-flex-1 tw-rounded-lg tw-border tw-border-gray-300 tw-px-4 tw-py-2 tw-font-semibold tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-50 disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
+                                                    className="tw-flex-1 tw-rounded-lg tw-border tw-border-gray-300 tw-px-4 tw-py-2 tw-font-semibold tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50 disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
                                                 >
                                                     Cancel
                                                 </button>
@@ -537,7 +537,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                     ) : (
                                         <div className="tw-space-y-4 tw-text-sm">
                                             <div>
-                                                <div className="tw-font-medium tw-text-gray-900">
+                                                <div className="tw-font-medium tw-text-ink">
                                                     Bio
                                                 </div>
                                                 <div className="tw-text-secondary">
@@ -546,7 +546,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                                 </div>
                                             </div>
                                             <div>
-                                                <div className="tw-font-medium tw-text-gray-900">
+                                                <div className="tw-font-medium tw-text-ink">
                                                     Location
                                                 </div>
                                                 <div className="tw-text-secondary">
@@ -554,7 +554,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                                 </div>
                                             </div>
                                             <div>
-                                                <div className="tw-font-medium tw-text-gray-900">
+                                                <div className="tw-font-medium tw-text-ink">
                                                     Military Branch
                                                 </div>
                                                 <div className="tw-text-secondary">
@@ -562,7 +562,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                                 </div>
                                             </div>
                                             <div>
-                                                <div className="tw-font-medium tw-text-gray-900">
+                                                <div className="tw-font-medium tw-text-ink">
                                                     Member Since
                                                 </div>
                                                 <div className="tw-text-secondary">August 2025</div>
@@ -578,7 +578,7 @@ const Profile: PageWithLayout = ({ user }) => {
                         <div className="tw-col-span-1 tw-space-y-6 lg:tw-col-span-3">
                             {/* Progress Overview */}
                             <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                     Learning Progress
                                 </h3>
                                 <div className="tw-mb-4">
@@ -586,7 +586,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                         <span>Overall Progress</span>
                                         <span>{progressPercentage}%</span>
                                     </div>
-                                    <div className="tw-mt-2 tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-200">
+                                    <div className="tw-mt-2 tw-h-2 tw-w-full tw-rounded-full tw-bg-gray-50">
                                         <div
                                             className={`tw-h-2 tw-rounded-full tw-bg-primary tw-transition-all tw-duration-300 tw-w-[${progressPercentage}%]`}
                                         />
@@ -600,20 +600,20 @@ const Profile: PageWithLayout = ({ user }) => {
 
                             {/* Current Courses */}
                             <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                     Current Enrollments
                                 </h3>
                                 <div className="tw-space-y-4">
                                     <div className="tw-rounded-lg tw-border tw-border-gray-200 tw-p-4">
                                         <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between">
-                                            <h4 className="tw-font-medium tw-text-gray-900">
+                                            <h4 className="tw-font-medium tw-text-ink">
                                                 Software Engineering
                                             </h4>
                                             <span className="tw-rounded tw-bg-primary/10 tw-px-2 tw-py-1 tw-text-xs tw-text-secondary">
                                                 In Progress
                                             </span>
                                         </div>
-                                        <div className="tw-mb-2 tw-h-1.5 tw-w-full tw-rounded-full tw-bg-gray-200">
+                                        <div className="tw-mb-2 tw-h-1.5 tw-w-full tw-rounded-full tw-bg-gray-50">
                                             <div className="tw-h-1.5 tw-w-1/3 tw-rounded-full tw-bg-primary" />
                                         </div>
                                         <div className="tw-text-sm tw-text-secondary">
@@ -628,7 +628,7 @@ const Profile: PageWithLayout = ({ user }) => {
                     {activeTab === "achievements" && (
                         <div className="tw-col-span-1 tw-space-y-6 lg:tw-col-span-3">
                             <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                     Achievements
                                 </h3>
                                 <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
@@ -651,7 +651,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                                 <i className="fas fa-trophy" />
                                             </div>
                                             <div>
-                                                <h4 className="tw-font-medium tw-text-gray-900">
+                                                <h4 className="tw-font-medium tw-text-ink">
                                                     {achievement.title}
                                                 </h4>
                                                 <p className="tw-text-sm tw-text-secondary">
@@ -672,10 +672,10 @@ const Profile: PageWithLayout = ({ user }) => {
                                     <div className="tw-mx-auto tw-mb-4 tw-flex tw-h-16 tw-w-16 tw-items-center tw-justify-center tw-rounded-full tw-bg-primary tw-text-white">
                                         <i className="fas fa-code tw-text-2xl" />
                                     </div>
-                                    <h3 className="tw-mb-2 tw-text-2xl tw-font-bold tw-text-gray-900">
+                                    <h3 className="tw-mb-2 tw-text-2xl tw-font-bold tw-text-ink">
                                         Coding Skill Assessment
                                     </h3>
-                                    <p className="tw-text-gray-600">
+                                    <p className="tw-text-gray-300">
                                         Take our comprehensive assessment to determine your current skill level
                                     </p>
                                 </div>
@@ -683,52 +683,52 @@ const Profile: PageWithLayout = ({ user }) => {
                                 <div className="tw-mb-6 tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-3">
                                     <div className="tw-rounded-lg tw-bg-white tw-p-4 tw-text-center">
                                         <div className="tw-mb-1 tw-text-2xl tw-font-bold tw-text-primary">10</div>
-                                        <div className="tw-text-sm tw-text-gray-600">Questions</div>
+                                        <div className="tw-text-sm tw-text-gray-300">Questions</div>
                                     </div>
                                     <div className="tw-rounded-lg tw-bg-white tw-p-4 tw-text-center">
                                         <div className="tw-mb-1 tw-text-2xl tw-font-bold tw-text-primary">~30</div>
-                                        <div className="tw-text-sm tw-text-gray-600">Minutes</div>
+                                        <div className="tw-text-sm tw-text-gray-300">Minutes</div>
                                     </div>
                                     <div className="tw-rounded-lg tw-bg-white tw-p-4 tw-text-center">
                                         <div className="tw-mb-1 tw-text-2xl tw-font-bold tw-text-primary">5</div>
-                                        <div className="tw-text-sm tw-text-gray-600">Skill Levels</div>
+                                        <div className="tw-text-sm tw-text-gray-300">Skill Levels</div>
                                     </div>
                                 </div>
 
                                 <div className="tw-mb-6 tw-rounded-lg tw-bg-white tw-p-6">
-                                    <h4 className="tw-mb-4 tw-font-semibold tw-text-gray-900">What You&apos;ll Be Tested On:</h4>
+                                    <h4 className="tw-mb-4 tw-font-semibold tw-text-ink">What You&apos;ll Be Tested On:</h4>
                                     <div className="tw-grid tw-grid-cols-1 tw-gap-3 md:tw-grid-cols-2">
                                         <div className="tw-flex tw-items-center tw-space-x-2">
                                             <i className="fas fa-check-circle tw-text-success" />
-                                            <span className="tw-text-sm tw-text-gray-700">Basic Syntax & Variables</span>
+                                            <span className="tw-text-sm tw-text-gray-200">Basic Syntax & Variables</span>
                                         </div>
                                         <div className="tw-flex tw-items-center tw-space-x-2">
                                             <i className="fas fa-check-circle tw-text-success" />
-                                            <span className="tw-text-sm tw-text-gray-700">Functions & Conditionals</span>
+                                            <span className="tw-text-sm tw-text-gray-200">Functions & Conditionals</span>
                                         </div>
                                         <div className="tw-flex tw-items-center tw-space-x-2">
                                             <i className="fas fa-check-circle tw-text-success" />
-                                            <span className="tw-text-sm tw-text-gray-700">Arrays & Loops</span>
+                                            <span className="tw-text-sm tw-text-gray-200">Arrays & Loops</span>
                                         </div>
                                         <div className="tw-flex tw-items-center tw-space-x-2">
                                             <i className="fas fa-check-circle tw-text-success" />
-                                            <span className="tw-text-sm tw-text-gray-700">String Manipulation</span>
+                                            <span className="tw-text-sm tw-text-gray-200">String Manipulation</span>
                                         </div>
                                         <div className="tw-flex tw-items-center tw-space-x-2">
                                             <i className="fas fa-check-circle tw-text-success" />
-                                            <span className="tw-text-sm tw-text-gray-700">Problem Solving</span>
+                                            <span className="tw-text-sm tw-text-gray-200">Problem Solving</span>
                                         </div>
                                         <div className="tw-flex tw-items-center tw-space-x-2">
                                             <i className="fas fa-check-circle tw-text-success" />
-                                            <span className="tw-text-sm tw-text-gray-700">Algorithms</span>
+                                            <span className="tw-text-sm tw-text-gray-200">Algorithms</span>
                                         </div>
                                     </div>
                                 </div>
 
-                                <div className="tw-mb-6 tw-rounded-lg tw-border-l-4 tw-border-primary tw-bg-blue-50 tw-p-4">
+                                <div className="tw-mb-6 tw-rounded-lg tw-border-l-4 tw-border-primary tw-bg-navy-sky/20 tw-p-4">
                                     <div className="tw-flex tw-items-start tw-space-x-3">
                                         <i className="fas fa-info-circle tw-mt-1 tw-text-primary" />
-                                        <div className="tw-text-sm tw-text-gray-700">
+                                        <div className="tw-text-sm tw-text-gray-200">
                                             <strong>Note:</strong> This assessment uses our built-in code editor. You&apos;ll write actual JavaScript code to solve programming challenges. Your skill level will be determined based on your performance: Newbie, Beginner, Junior, Mid, or Senior.
                                         </div>
                                     </div>
@@ -751,12 +751,12 @@ const Profile: PageWithLayout = ({ user }) => {
                     {activeTab === "settings" && (
                         <div className="tw-col-span-1 tw-space-y-6 lg:tw-col-span-3">
                             <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
-                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-gray-900">
+                                <h3 className="tw-mb-4 tw-text-lg tw-font-semibold tw-text-ink">
                                     Account Settings
                                 </h3>
                                 <div className="tw-space-y-6">
                                     <div>
-                                        <h4 className="tw-mb-2 tw-font-medium tw-text-gray-900">
+                                        <h4 className="tw-mb-2 tw-font-medium tw-text-ink">
                                             Notifications
                                         </h4>
                                         <div className="tw-space-y-2">
@@ -783,7 +783,7 @@ const Profile: PageWithLayout = ({ user }) => {
                                         </div>
                                     </div>
                                     <div>
-                                        <h4 className="tw-mb-2 tw-font-medium tw-text-gray-900">
+                                        <h4 className="tw-mb-2 tw-font-medium tw-text-ink">
                                             Privacy
                                         </h4>
                                         <div className="tw-space-y-2">

--- a/src/pages/programs.tsx
+++ b/src/pages/programs.tsx
@@ -48,7 +48,7 @@ const ProgramsPage: PageWithLayout = ({ allPrograms, page }) => {
             <HeroArea data={heroData} />
             <main className="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
                 <div className="tw-mx-auto tw-mb-12 tw-mt-16 tw-max-w-4xl">
-                    <p className="tw-text-center tw-text-lg tw-text-gray-700">
+                    <p className="tw-text-center tw-text-lg tw-text-gray-200">
                         Our programs are designed to empower veterans with real-world skills,
                         mentorship, and a supportive community—helping you transition, grow, and
                         lead in tech.

--- a/src/pages/resume-translator.tsx
+++ b/src/pages/resume-translator.tsx
@@ -44,7 +44,7 @@ const ResumeTranslatorPage: PageWithLayout = ({ user }) => {
                 {/* Header with User Menu */}
                 <div className="tw-mb-8 tw-flex tw-items-center tw-justify-end">
                     <div className="tw-flex tw-items-center tw-space-x-4">
-                        <div className="tw-flex tw-items-center tw-space-x-2 tw-text-sm tw-text-gray-600">
+                        <div className="tw-flex tw-items-center tw-space-x-2 tw-text-sm tw-text-gray-300">
                             {user.image && (
                                 <img
                                     src={user.image}
@@ -59,7 +59,7 @@ const ResumeTranslatorPage: PageWithLayout = ({ user }) => {
                         <div className="tw-flex tw-space-x-2">
                             <Link
                                 href="/profile"
-                                className="tw-rounded-md tw-bg-gray-100 tw-px-3 tw-py-2 tw-text-sm tw-text-gray-700 tw-transition-colors hover:tw-bg-gray-200"
+                                className="tw-rounded-md tw-bg-gray-100 tw-px-3 tw-py-2 tw-text-sm tw-text-gray-200 tw-transition-colors hover:tw-bg-gray-50"
                                 title="View Profile"
                             >
                                 <i className="fas fa-user tw-mr-1" />
@@ -84,7 +84,7 @@ const ResumeTranslatorPage: PageWithLayout = ({ user }) => {
                                     <i className="fas fa-check-circle tw-text-success tw-mr-2" />
                                     Do:
                                 </h3>
-                                <ul className="tw-space-y-2 tw-text-gray-700">
+                                <ul className="tw-space-y-2 tw-text-gray-200">
                                     <li className="tw-flex tw-items-start">
                                         <span className="tw-mr-2">•</span>
                                         <span>Use action verbs to start each bullet point</span>
@@ -108,7 +108,7 @@ const ResumeTranslatorPage: PageWithLayout = ({ user }) => {
                                     <i className="fas fa-times-circle tw-text-danger tw-mr-2" />
                                     Don&apos;t:
                                 </h3>
-                                <ul className="tw-space-y-2 tw-text-gray-700">
+                                <ul className="tw-space-y-2 tw-text-gray-200">
                                     <li className="tw-flex tw-items-start">
                                         <span className="tw-mr-2">•</span>
                                         <span>Use military acronyms without explanation</span>

--- a/src/pages/store/index.tsx
+++ b/src/pages/store/index.tsx
@@ -25,7 +25,7 @@ const StorePage: React.FC<StorePageProps> = ({ products, isConfigured }) => {
                         <h1 className="tw-text-4xl tw-font-bold tw-text-secondary tw-mb-4">
                             Store Configuration Required
                         </h1>
-                        <p className="tw-text-lg tw-text-gray-600">
+                        <p className="tw-text-lg tw-text-gray-300">
                             The Shopify store is not configured yet. Please add your Shopify
                             credentials to the environment variables.
                         </p>
@@ -49,7 +49,7 @@ const StorePage: React.FC<StorePageProps> = ({ products, isConfigured }) => {
                         <h1 className="tw-text-5xl tw-font-bold tw-mb-4 tw-text-primary">
                             Vets Who Code Store
                         </h1>
-                        <p className="tw-text-xl tw-text-gray-700">
+                        <p className="tw-text-xl tw-text-gray-200">
                             Shop official merchandise and support our mission
                         </p>
                     </div>
@@ -89,7 +89,7 @@ const StorePage: React.FC<StorePageProps> = ({ products, isConfigured }) => {
                     <h2 className="tw-text-3xl tw-font-bold tw-text-secondary tw-mb-2">
                         All Products
                     </h2>
-                    <p className="tw-text-gray-600">
+                    <p className="tw-text-gray-300">
                         {products.length} {products.length === 1 ? "product" : "products"}{" "}
                         available
                     </p>
@@ -100,7 +100,7 @@ const StorePage: React.FC<StorePageProps> = ({ products, isConfigured }) => {
                     <ProductGrid products={products} columns={3} />
                 ) : (
                     <div className="tw-text-center tw-py-20">
-                        <p className="tw-text-xl tw-text-gray-600">
+                        <p className="tw-text-xl tw-text-gray-300">
                             No products available at the moment.
                         </p>
                     </div>

--- a/src/pages/store/products/[handle].tsx
+++ b/src/pages/store/products/[handle].tsx
@@ -35,7 +35,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
         return (
             <Layout>
                 <div className="tw-container tw-mx-auto tw-px-4 tw-py-20 tw-text-center">
-                    <p className="tw-text-xl tw-text-gray-600">Loading product...</p>
+                    <p className="tw-text-xl tw-text-gray-300">Loading product...</p>
                 </div>
             </Layout>
         );
@@ -50,7 +50,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                     <h1 className="tw-text-4xl tw-font-bold tw-text-secondary tw-mb-4">
                         Product Not Found
                     </h1>
-                    <p className="tw-text-xl tw-text-gray-600 tw-mb-8">
+                    <p className="tw-text-xl tw-text-gray-300 tw-mb-8">
                         The product you're looking for doesn't exist.
                     </p>
                     <button
@@ -119,14 +119,14 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                     <nav className="tw-flex tw-items-center tw-gap-2 tw-text-sm">
                         <button
                             onClick={() => router.push("/")}
-                            className="tw-text-gray-600 hover:tw-text-primary"
+                            className="tw-text-gray-300 hover:tw-text-primary"
                         >
                             Home
                         </button>
                         <span className="tw-text-gray-400">/</span>
                         <button
                             onClick={() => router.push("/store")}
-                            className="tw-text-gray-600 hover:tw-text-primary"
+                            className="tw-text-gray-300 hover:tw-text-primary"
                         >
                             Store
                         </button>
@@ -215,7 +215,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                     <div>
                         {/* Vendor */}
                         {product.vendor && (
-                            <p className="tw-text-sm tw-font-medium tw-text-gray-600 tw-mb-2 tw-uppercase tw-tracking-wide">
+                            <p className="tw-text-sm tw-font-medium tw-text-gray-300 tw-mb-2 tw-uppercase tw-tracking-wide">
                                 {product.vendor}
                             </p>
                         )}
@@ -240,7 +240,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                         {/* Availability */}
                         <div className="tw-mb-6">
                             {product.availableForSale ? (
-                                <span className="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-bg-green-100 tw-text-green-800 tw-rounded-full tw-font-medium">
+                                <span className="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-bg-gold-light/30 tw-text-gold-deep tw-rounded-full tw-font-medium">
                                     <svg className="tw-w-5 tw-h-5" fill="currentColor" viewBox="0 0 20 20">
                                         <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                                     </svg>
@@ -256,7 +256,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                         {/* Description */}
                         {product.description && (
                             <div className="tw-mb-8">
-                                <p className="tw-text-gray-700 tw-leading-relaxed">
+                                <p className="tw-text-gray-200 tw-leading-relaxed">
                                     {product.description}
                                 </p>
                             </div>
@@ -277,7 +277,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                                                 "tw-px-6 tw-py-3 tw-border-2 tw-rounded-lg tw-font-medium tw-transition-all",
                                                 selectedOptions[option.name] === value
                                                     ? "tw-border-primary tw-bg-primary tw-text-white"
-                                                    : "tw-border-gray-300 tw-bg-white tw-text-gray-700 hover:tw-border-gray-400"
+                                                    : "tw-border-gray-300 tw-bg-white tw-text-gray-200 hover:tw-border-gray-400"
                                             )}
                                         >
                                             {value}
@@ -295,7 +295,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                             <div className="tw-flex tw-items-center tw-gap-4">
                                 <button
                                     onClick={() => setQuantity(Math.max(1, quantity - 1))}
-                                    className="tw-w-12 tw-h-12 tw-flex tw-items-center tw-justify-center tw-bg-gray-100 tw-border tw-border-gray-300 tw-rounded-lg tw-text-gray-700 hover:tw-bg-gray-200 tw-font-bold tw-text-xl"
+                                    className="tw-w-12 tw-h-12 tw-flex tw-items-center tw-justify-center tw-bg-gray-100 tw-border tw-border-gray-300 tw-rounded-lg tw-text-gray-200 hover:tw-bg-gray-50 tw-font-bold tw-text-xl"
                                 >
                                     -
                                 </button>
@@ -304,7 +304,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                                 </span>
                                 <button
                                     onClick={() => setQuantity(quantity + 1)}
-                                    className="tw-w-12 tw-h-12 tw-flex tw-items-center tw-justify-center tw-bg-gray-100 tw-border tw-border-gray-300 tw-rounded-lg tw-text-gray-700 hover:tw-bg-gray-200 tw-font-bold tw-text-xl"
+                                    className="tw-w-12 tw-h-12 tw-flex tw-items-center tw-justify-center tw-bg-gray-100 tw-border tw-border-gray-300 tw-rounded-lg tw-text-gray-200 hover:tw-bg-gray-50 tw-font-bold tw-text-xl"
                                 >
                                     +
                                 </button>
@@ -319,7 +319,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                                 "tw-w-full tw-py-4 tw-rounded-lg tw-font-bold tw-text-lg tw-transition-all tw-duration-300",
                                 product.availableForSale
                                     ? "tw-bg-primary tw-text-white hover:tw-bg-primary-dark hover:tw-shadow-xl disabled:tw-opacity-50 disabled:tw-cursor-not-allowed"
-                                    : "tw-bg-gray-300 tw-text-gray-600 tw-cursor-not-allowed"
+                                    : "tw-bg-gray-300 tw-text-gray-300 tw-cursor-not-allowed"
                             )}
                         >
                             {isAdding
@@ -333,7 +333,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                         {(product.productType || product.tags.length > 0) && (
                             <div className="tw-mt-8 tw-pt-8 tw-border-t tw-border-gray-200">
                                 {product.productType && (
-                                    <p className="tw-text-sm tw-text-gray-600 tw-mb-2">
+                                    <p className="tw-text-sm tw-text-gray-300 tw-mb-2">
                                         <span className="tw-font-semibold">Category:</span>{" "}
                                         {product.productType}
                                     </p>
@@ -343,7 +343,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                                         {product.tags.map((tag) => (
                                             <span
                                                 key={tag}
-                                                className="tw-px-3 tw-py-1 tw-bg-gray-100 tw-text-gray-700 tw-rounded-full tw-text-sm"
+                                                className="tw-px-3 tw-py-1 tw-bg-gray-100 tw-text-gray-200 tw-rounded-full tw-text-sm"
                                             >
                                                 {tag}
                                             </span>

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -25,7 +25,7 @@ const Team: PageWithLayout = ({ data }) => {
             <h1 className="tw-sr-only">Our Team</h1>
 
             {/* Custom Hero Area with original size */}
-            <div className="tw-relative tw-z-1 tw-overflow-hidden tw-bg-pearl">
+            <div className="tw-relative tw-z-1 tw-overflow-hidden tw-bg-cream">
                 <div className="tw-relative tw-z-1 tw-flex tw-h-[450px] tw-w-full tw-items-end md:tw-h-[500px] lg:tw-h-[600px] xl:tw-h-[700px]">
                     <div className="tw-absolute tw-inset-0 tw-object-cover">
                         <img

--- a/src/pages/theory-of-change.tsx
+++ b/src/pages/theory-of-change.tsx
@@ -76,7 +76,7 @@ const TheoryOfChange: PageWithLayout = ({ data }) => {
                                         {heading.content}
                                     </h3>
                                 ))}
-                                <div className="tw-text-base tw-text-gray-700">
+                                <div className="tw-text-base tw-text-gray-200">
                                     {item.texts?.map((text, index) => {
                                         if (item.texts && item.texts.length > 1 && index === 0) {
                                             return (

--- a/src/pages/url-preview-demo.tsx
+++ b/src/pages/url-preview-demo.tsx
@@ -19,14 +19,14 @@ const URLPreviewDemo = () => {
   return (
     <div className="tw-min-h-screen tw-bg-gray-50 tw-py-12 tw-px-4">
       <div className="tw-max-w-4xl tw-mx-auto">
-        <h1 className="tw-text-4xl tw-font-bold tw-text-gray-900 tw-mb-8 tw-text-center">
+        <h1 className="tw-text-4xl tw-font-bold tw-text-ink tw-mb-8 tw-text-center">
           URL Preview Card Demo
         </h1>
 
         <div className="tw-bg-white tw-rounded-lg tw-shadow-md tw-p-6 tw-mb-8">
           <form onSubmit={handleSubmit} className="tw-space-y-4">
             <div>
-              <label htmlFor="url" className="tw-block tw-text-sm tw-font-medium tw-text-gray-700 tw-mb-2">
+              <label htmlFor="url" className="tw-block tw-text-sm tw-font-medium tw-text-gray-200 tw-mb-2">
                 Enter a URL to preview
               </label>
               <div className="tw-flex tw-gap-2">
@@ -41,7 +41,7 @@ const URLPreviewDemo = () => {
                 />
                 <button
                   type="submit"
-                  className="tw-px-6 tw-py-2 tw-bg-blue-600 tw-text-white tw-rounded-md hover:tw-bg-blue-700 tw-transition-colors"
+                  className="tw-px-6 tw-py-2 tw-bg-navy-royal tw-text-white tw-rounded-md hover:tw-bg-navy tw-transition-colors"
                 >
                   Preview
                 </button>
@@ -50,7 +50,7 @@ const URLPreviewDemo = () => {
           </form>
 
           <div className="tw-mt-4">
-            <p className="tw-text-sm tw-text-gray-600 tw-mb-2">Try these examples:</p>
+            <p className="tw-text-sm tw-text-gray-300 tw-mb-2">Try these examples:</p>
             <div className="tw-flex tw-flex-wrap tw-gap-2">
               {exampleUrls.map((exampleUrl) => (
                 <button
@@ -60,7 +60,7 @@ const URLPreviewDemo = () => {
                     setUrl(exampleUrl);
                     setSubmittedUrl(exampleUrl);
                   }}
-                  className="tw-px-3 tw-py-1 tw-text-sm tw-bg-gray-100 tw-text-gray-700 tw-rounded-md hover:tw-bg-gray-200 tw-transition-colors"
+                  className="tw-px-3 tw-py-1 tw-text-sm tw-bg-gray-100 tw-text-gray-200 tw-rounded-md hover:tw-bg-gray-50 tw-transition-colors"
                 >
                   {new URL(exampleUrl).hostname}
                 </button>
@@ -72,17 +72,17 @@ const URLPreviewDemo = () => {
         {submittedUrl && (
           <div className="tw-space-y-8">
             <div>
-              <h2 className="tw-text-2xl tw-font-semibold tw-text-gray-900 tw-mb-4">
+              <h2 className="tw-text-2xl tw-font-semibold tw-text-ink tw-mb-4">
                 Preview Card
               </h2>
               <URLPreviewCard url={submittedUrl} />
             </div>
 
             <div>
-              <h2 className="tw-text-2xl tw-font-semibold tw-text-gray-900 tw-mb-4">
+              <h2 className="tw-text-2xl tw-font-semibold tw-text-ink tw-mb-4">
                 Usage Example
               </h2>
-              <div className="tw-bg-gray-900 tw-rounded-lg tw-p-6 tw-overflow-x-auto">
+              <div className="tw-bg-ink tw-rounded-lg tw-p-6 tw-overflow-x-auto">
                 <pre className="tw-text-sm tw-text-gray-100">
                   <code>{`import URLPreviewCard from '@/components/url-preview-card';
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -75,122 +75,113 @@ module.exports = {
             colors: {
                 transparent: "transparent",
                 current: "currentColor",
-                primary: {
-                    DEFAULT: "#c5203e", // hashflag red
-                    50: "#fef2f4",
-                    100: "#fde6ea",
-                    200: "#fbd0d9",
-                    300: "#f7a6b9",
-                    400: "#f27293",
-                    500: "#e8446f",
-                    600: "#c5203e",
-                    700: "#b11a36",
-                    800: "#931733",
-                    900: "#7d1630",
-                    light: "#8fd6ca",
+
+                // ===== PRIMARY BRAND COLORS =====
+                // Based on VetsWhoCode Brand Style Guide
+
+                // Navy Blue (Pantone 282 C) - Primary Brand Color
+                navy: {
+                    DEFAULT: "#091f40",
+                    midnight: "#061A40",    // Alternative to primary navy
+                    deep: "#003559",        // Dark accents, hover states
+                    royal: "#0353A4",       // Secondary buttons
+                    ocean: "#006DAA",       // Links, interactive elements
+                    sky: "#B9D6F2",         // Light backgrounds, info boxes
                 },
-                secondary: {
-                    DEFAULT: "#091f40", // hashflag blue
-                    50: "#f3f6fc",
-                    100: "#e6edf8",
-                    200: "#c8d9ef",
-                    300: "#97bbe1",
-                    400: "#5f97ce",
-                    500: "#3b79b8",
-                    600: "#2a609c",
-                    700: "#224d7f",
-                    800: "#1f436a",
-                    900: "#091f40",
-                    light: "#8C89A2",
-                },
-                body: "#696969",
-                heading: "#333333",
-                success: {
-                    DEFAULT: "#4CAF50",
-                    100: "#7ed321",
-                },
-                warning: {
-                    DEFAULT: "#FFC107",
-                    100: "#fdb494",
-                },
-                danger: {
-                    DEFAULT: "#F44336",
-                    100: "#d85554",
-                },
-                info: {
-                    DEFAULT: "#17A2B8",
-                },
-                light: {
-                    DEFAULT: "#F8F9FA",
-                    50: "#f8f9fd",
-                    100: "#f8f8f8",
-                },
-                dark: {
-                    DEFAULT: "#333333",
-                    50: "#111111",
-                    100: "#171621",
-                },
-                white: {
-                    DEFAULT: "#FFFFFF",
-                    inverse: "#f6f2ed",
-                    catskill: "#f5f7fa",
-                },
-                orange: {
-                    DEFAULT: "#ef6f31",
-                    light: "rgba(239,111,49,0.1)",
-                    100: "#ff4c24",
-                    200: "#ff4d24",
-                    300: "#fa7d61",
-                },
-                yellow: {
-                    DEFAULT: "#f6b500",
-                    100: "#ffbb00",
-                },
-                gray: {
-                    100: "#faf8f6",
-                    200: "#f5f5f5",
-                    300: "#7e7e7e",
-                    350: "#e0e0e0",
-                    400: "#ababab",
-                    450: "#F3F3F3",
-                    500: "#EEEEEE",
-                    550: "#ededed",
-                    600: "#4b5563",
-                    650: "#e7e7e7",
-                    700: "#9b9b9b",
-                    750: "#F1F1F1",
-                    800: "#b6b7d2",
-                    850: "#666666",
-                },
-                blue: {
-                    100: "#7288e8",
-                },
-                spring: "#F5F1ED",
-                desert: {
+
+                // Red (Pantone 193 C) - Primary Accent, CTAs
+                red: {
                     DEFAULT: "#c5203e",
-                    100: "#e6dcd2",
+                    signal: "#C52233",      // Near primary, alternative
+                    crimson: "#A51C30",     // Hover/pressed states
+                    dark: "#74121D",        // Error borders, deep accents
+                    maroon: "#580C1F",      // Darkest gradients
                 },
-                pearl: "#EAE1D6",
-                putty: "#e5c791",
-                brunt: "#ee7455",
-                jagged: "#BCE6DF",
-                azure: "#00adff",
-                alto: "#dedede",
-                teracotta: {
-                    DEFAULT: "#dd7d5a",
-                    light: "#f4ebe7",
+
+                // Amber Gold - Highlights, Success States
+                gold: {
+                    DEFAULT: "#FDB330",
+                    light: "#FFE169",       // Highlight backgrounds
+                    bright: "#FAD643",      // Badges, success indicators
+                    rich: "#DBB42C",        // Hover state for gold
+                    deep: "#C9A227",        // Darker gold accents
                 },
-                scooter: {
-                    DEFAULT: "#2dbbc4",
-                    light: "#e3f1f2",
+
+                // Cream White - Backgrounds
+                cream: "#EEEDE9",
+
+                // Ink Black - Body Text
+                ink: "#1A1823",
+
+                // ===== UI GRAYS (Light Mode) =====
+                gray: {
+                    DEFAULT: "#6C757D",     // Slate - secondary text
+                    50: "#F8F9FA",          // Off White - light cards
+                    100: "#DEE2E6",         // Silver - borders, dividers
+                    200: "#6C757D",         // Slate - secondary text, captions
+                    300: "#495057",         // Charcoal - muted labels
+                    400: "#343A40",         // Dark Gray - softer text blocks
                 },
-                ebb: "#e9e6e3",
-                pampas: "#ece8e4",
-                gore: "#1f1f52",
-                porsche: "#ebb860",
-                mandy: "#df5b6c",
-                tan: "#d2a98e",
-                mishcka: "#e2e2e8",
+
+                // ===== SEMANTIC COLORS (Mapped to Brand Colors) =====
+                primary: {
+                    DEFAULT: "#c5203e",     // Brand Red
+                    light: "#C52233",       // Signal Red
+                    dark: "#A51C30",        // Crimson
+                },
+
+                secondary: {
+                    DEFAULT: "#091f40",     // Navy Blue
+                    light: "#0353A4",       // Royal Blue
+                    dark: "#061A40",        // Midnight
+                },
+
+                success: {
+                    DEFAULT: "#FDB330",     // Amber Gold
+                    light: "#FFE169",       // Light Gold
+                    dark: "#DBB42C",        // Rich Gold
+                },
+
+                warning: {
+                    DEFAULT: "#FAD643",     // Bright Gold
+                    light: "#FFE169",       // Light Gold
+                    dark: "#C9A227",        // Deep Gold
+                },
+
+                danger: {
+                    DEFAULT: "#c5203e",     // Brand Red
+                    light: "#C52233",       // Signal Red
+                    dark: "#74121D",        // Dark Red
+                },
+
+                info: {
+                    DEFAULT: "#006DAA",     // Ocean Blue
+                    light: "#B9D6F2",       // Sky Blue
+                    dark: "#0353A4",        // Royal Blue
+                },
+
+                // ===== DARK MODE COLORS =====
+                dark: {
+                    DEFAULT: "#1A1823",     // Ink Black - primary dark background
+                    surface: "#212529",     // Charcoal - elevated surfaces
+                    elevated: "#343A40",    // Dark Gray - tertiary surfaces
+                    text: "#F8F9FA",        // Off White - primary text
+                    "text-muted": "#DEE2E6", // Silver - secondary text
+                    "text-disabled": "#6C757D", // Slate - disabled text
+                    accent: "#84C1FF",      // Light Blue - links, interactive
+                    "accent-hover": "#B9D6F2", // Sky Blue - hover state
+                    error: "#F38375",       // Coral - errors
+                    success: "#FFE169",     // Light Gold - success
+                    badge: "#FAD643",       // Bright Gold - badges
+                },
+
+                // ===== UTILITY COLORS =====
+                white: "#FFFFFF",
+                black: "#000000",
+
+                // ===== LEGACY MAPPINGS (for prose/typography) =====
+                body: "#1A1823",           // Ink Black for body text
+                heading: "#091f40",        // Navy for headings
             },
             typography: ({ theme }) => ({
                 DEFAULT: {


### PR DESCRIPTION
Complete overhaul of color system to align with official brand guidelines:

COLORS UPDATED:
- Removed all non-brand colors (orange, yellow, spring, desert, pearl, etc.)
- Implemented official VetsWhoCode color palette: • Navy Blue (#091f40) with 6-shade scale • Red (#c5203e) with 5-shade scale • Amber Gold (#FDB330) with 5-shade scale • Cream White (#EEEDE9) for backgrounds • Ink Black (#1A1823) for body text • UI Grays (5 neutral shades)

COMPONENT UPDATES (95+ files):
- Replaced deprecated custom colors with brand colors
- Updated gray-900 → ink (Ink Black) for headings
- Fixed gray-200 backgrounds → gray-50 (text-only color)
- Updated testimonial section with Navy background and Cream cards
- Updated blog section with Navy background and Cream cards
- Fixed hero buttons using removed colors
- Updated event cards from gray to Cream backgrounds
- Fixed purple gradients (Navy→Red) to Navy→Midnight
- Updated footer dark mode with brand dark colors

IMPROVEMENTS:
- Better contrast and readability throughout
- Consistent brand identity across all pages
- Semantic color mappings (success, warning, danger, info)
- Dark mode color support
- Created migration scripts and documentation