### PR TITLE
feat: add media highlights section to homepage (#573)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -63,7 +63,7 @@ const nextConfig = {
                             "default-src 'self'",
                             "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.clarity.ms https://va.vercel-scripts.com https://www.googletagmanager.com https://maps.googleapis.com https://pro.fontawesome.com",
                             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://pro.fontawesome.com",
-                            "img-src 'self' data: blob: https://res.cloudinary.com https://avatars.githubusercontent.com https://cdn.shopify.com https://widgets.guidestar.org https://maps.googleapis.com https://maps.gstatic.com https://*.googleapis.com",
+                            "img-src 'self' data: blob: https://res.cloudinary.com https://avatars.githubusercontent.com https://cdn.shopify.com https://widgets.guidestar.org https://maps.googleapis.com https://maps.gstatic.com https://*.googleapis.com https://images.huffingtonpost.com https://images.ctfassets.net https://www.hackerrank.com https://*.businessinsider.com https://i.insider.com https://cdn.sstatic.net https://i.stack.imgur.com https://stackoverflow.blog https://cdn.stackoverflow.co",
                             "font-src 'self' data: https://fonts.gstatic.com https://pro.fontawesome.com",
                             "connect-src 'self' https://www.clarity.ms https://vitals.vercel-insights.com https://github.com https://api.github.com https://hashflagswag.myshopify.com https://res.cloudinary.com https://widgets.guidestar.org https://www.google-analytics.com https://maps.googleapis.com",
                             "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://donorbox.org",

--- a/src/containers/media/layout-01/index.tsx
+++ b/src/containers/media/layout-01/index.tsx
@@ -1,0 +1,65 @@
+import { motion } from "motion/react";
+import Section from "@components/ui/engagement-modal";
+import SectionTitle from "@components/section-title";
+import MottoText from "@components/ui/motto-text";
+import MediaCard from "@components/media-card";
+import { scrollUpVariants } from "@utils/variants";
+import { IMedia, MottoType, SectionTitleType, TSection } from "@utils/types";
+
+const AnimatedSectionTitle = motion(SectionTitle);
+const AnimatedMediaCard = motion(MediaCard);
+const AnimatedMottoText = motion(MottoText);
+
+type TProps = TSection & {
+    data: {
+        section_title?: SectionTitleType;
+        motto?: MottoType;
+        media: IMedia[];
+    };
+};
+
+const MediaArea = ({ data: { section_title, motto, media }, space, bg, titleSize }: TProps) => {
+    return (
+        <Section className="media-area" space={space} bg={bg}>
+            <div className="tw-container tw-relative">
+                {section_title && (
+                    <AnimatedSectionTitle
+                        {...section_title}
+                        titleSize={titleSize}
+                        className="tw-mb-7.5 md:tw-mb-15"
+                        initial="offscreen"
+                        whileInView="onscreen"
+                        viewport={{ once: true, amount: 0.4 }}
+                        variants={scrollUpVariants}
+                    />
+                )}
+
+                <div className="tw-grid tw-grid-cols-1 tw-gap-7.5 md:tw-grid-cols-2 lg:tw-grid-cols-3">
+                    {media?.map((item) => (
+                        <AnimatedMediaCard
+                            key={item.slug}
+                            {...item}
+                            initial="offscreen"
+                            whileInView="onscreen"
+                            viewport={{ once: true, amount: 0.4 }}
+                            variants={scrollUpVariants}
+                        />
+                    ))}
+                </div>
+
+                {motto && (
+                    <AnimatedMottoText
+                        {...motto}
+                        className="tw-mx-auto tw-mt-10 tw-text-center lg:tw-w-7/12"
+                        initial="offscreen"
+                        whileInView="onscreen"
+                        viewport={{ once: true, amount: 0.4 }}
+                        variants={scrollUpVariants}
+                    />
+                )}
+            </div>
+        </Section>
+    );
+};
+
+export default MediaArea;

--- a/src/data/homepages/index.json
+++ b/src/data/homepages/index.json
@@ -217,6 +217,18 @@
             }
         },
         {
+            "section": "media-area",
+            "section_title": {
+                "title": "Featured in <span>Media</span>",
+                "subtitle": "Vets Who Code in the spotlight"
+            },
+            "motto": {
+                "text": "See our impact and recognition in the media.​",
+                "path": "/media",
+                "pathText": "View all media"
+            }
+        },
+        {
             "section": "blog-area",
             "section_title": {
                 "title": "Trending on <span>Our Blogs</span>",

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,18 +10,20 @@ import VideoArea from "@containers/video/layout-04";
 import CourseArea from "@containers/course/layout-05";
 import TestimonialArea from "@containers/testimonial/layout-04";
 import EventArea from "@containers/event/layout-02";
+import MediaArea from "@containers/media/layout-01";
 import BlogArea from "@containers/blog/layout-03";
 import BrandArea from "@containers/brand/layout-01";
 import NewsletterArea from "@containers/newsletter/layout-02";
 import { EngagementModal } from "@components/ui/engagement-modal/EngagementModal";
 
 import { normalizedData } from "@utils/methods";
-import { IBlog, ICourse, IEvent } from "@utils/types";
+import { IBlog, ICourse, IEvent, IMedia } from "@utils/types";
 
 import { getPageData } from "../lib/page";
 import { getAllBlogs } from "../lib/blog";
 import { getallCourses } from "../lib/course";
 import { getallEvents } from "../lib/event";
+import { getAllMediaPosts } from "../lib/mdx-pages";
 
 interface PageContent {
     section: string;
@@ -34,6 +36,7 @@ interface PageData {
     };
     courses: ICourse[];
     events: IEvent[];
+    media: IMedia[];
     blogs: IBlog[];
 }
 
@@ -66,6 +69,10 @@ const Home: PageProps = ({ data }) => {
                 data={{ ...content?.["event-area"], events: data.events }}
                 titleSize="large"
             />
+            <MediaArea
+                data={{ ...content?.["media-area"], media: data.media }}
+                titleSize="large"
+            />
             <BlogArea data={{ ...content?.["blog-area"], blogs: data.blogs }} titleSize="large" />
             <BrandArea data={content?.["brand-area"]} />
             <NewsletterArea data={content?.["newsletter-area"]} />
@@ -86,6 +93,14 @@ export const getStaticProps: GetStaticProps = () => {
     const page = getPageData("home", "index");
     const courses = getallCourses(["title", "thumbnail"], 0, 6);
     const events = getallEvents(["title", "thumbnail", "start_date", "location"], 0, 6);
+    const allMedia = getAllMediaPosts<IMedia>(
+        ["slug", "title", "mediaType", "url", "publication", "date", "image", "description"],
+        "media"
+    );
+    // Sort by date (most recent first) and take the first 3
+    const media = allMedia
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+        .slice(0, 3);
     const { blogs } = getAllBlogs(["title", "image", "category", "postedAt"], 0, 3);
     return {
         props: {
@@ -93,6 +108,7 @@ export const getStaticProps: GetStaticProps = () => {
                 page,
                 courses,
                 events,
+                media,
                 blogs,
             },
             layout: {


### PR DESCRIPTION
Implemented a new media highlights section on the homepage that displays the 3 most recent media mentions and features. The section follows the same grid layout pattern as the blog and events sections for consistency.

Changes:
- Created MediaArea container component (src/containers/media/layout-01)
- Added media-area section to homepage JSON configuration
- Updated homepage to fetch and display media highlights
- Extended CSP img-src to allow external media images:
  - HuffPost, Contentful CDN, HackerRank
  - Business Insider, Stack Overflow
  - Stack Exchange CDN

Features:
- Displays 3 most recent media items sorted by date
- Responsive grid layout (1/2/3 columns)
- Individual card animations on scroll
- Links to full media page
- Matches existing blog/events section design patterns

Resolves #573