### PR TITLE
Blog/vwc 2026 application guide

### DIFF
--- a/src/data/blogs/vwc-2026-what-to-know-before-you-apply.md
+++ b/src/data/blogs/vwc-2026-what-to-know-before-you-apply.md
@@ -7,6 +7,7 @@ image:
     {
         src: "v1769461512/2026-cohort-accelerator-program_mtzxei.jpg",
     }
+audioUrl: "https://res.cloudinary.com/vetswhocode/video/upload/v1769462295/blog-audio/vwc-2026-what-to-know-before-you-apply.wav"
 category: "Program Updates"
 tags:
     - Vets Who Code


### PR DESCRIPTION
This pull request adds a new blog post for the Vets Who Code 2026 cohort, providing key information for prospective applicants. The post details the program's complete rebuild, updated curriculum, structure, and application requirements.

New blog post addition:

- Added a comprehensive blog post (`vwc-2026-what-to-know-before-you-apply.md`) that covers:
  - Major changes to the Vets Who Code program for 2026, including a rebuilt curriculum focused on AI engineering, smaller cohorts, and real production work.
  - Detailed breakdown of the four program phases, skills taught, and technologies used.
  - Clear expectations for time commitment, structure, and applicant fit.
  - Application process and requirements, including pre-work and documentation.
  - Program context, goals, and rationale for changes, authored by Jerome Hardaway.