### PR TITLE
replace any[] with module's type for better type safety

### DIFF
--- a/src/components/ui/swiper/index.tsx
+++ b/src/components/ui/swiper/index.tsx
@@ -3,7 +3,7 @@ import cn from "clsx";
 import SwiperCore, { Navigation, Pagination, Autoplay, A11y } from "swiper";
 // eslint-disable-next-line import/no-unresolved
 import { Swiper, SwiperSlide } from "swiper/react";
-import { SwiperModule } from "swiper/types";
+import type { SwiperModule } from "swiper/types";
 
 type TOptions = {
     modules?: SwiperModule[];


### PR DESCRIPTION
This PR addresses issue #880 by improving the type safety of the Swiper component.

**Changes:** 
**from:**  modules?: any[]
**to:** SwiperModule[] = [Navigation, Pagination, A11y, Autoplay]
**Goal:**  To ensure type safety by restricting the modules array to only accept valid Swiper modules (Navigation, Pagination, A11y, Autoplay)

Closes #880