### PR TITLE
feat: Add Amanda Casari to board members

### DIFF
--- a/src/data/board-members.json
+++ b/src/data/board-members.json
@@ -312,5 +312,27 @@
                 "url": "https://kyleshevlin.com/"
             }
         ]
+    },
+    {
+        "id": 15,
+        "name": "Amanda Casari",
+        "slug": "amanda-casari",
+        "path": "/team/amanda-casari",
+        "url": "",
+        "image": {
+            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1771203109/team/amanda-casari.jpg",
+            "width": 259,
+            "height": 194,
+            "alt": "Board Member"
+        },
+        "designation": "Board Member",
+        "bio": "Amanda Casari is a researcher and engineer in the Google Open Source Programs Office co-leading research and open data projects to better understand risk and resilience in open source ecosystems. For over 18 years, she has worked in a breadth of cross-functional roles and engineering disciplines, including developer relations, data science, complexity science, and robotics. Amanda co-authored an O'Reilly book, Feature Engineering for Machine Learning: Principles and Techniques for Data Scientists. She was named an External Faculty member of the Vermont Complex Systems Center in 2021. She is persistently fascinated by the difference between the systems we aim to create and the ones that emerge, and pie.",
+        "socials": [
+            {
+                "label": "LinkedIn",
+                "icon": "fab fa-linkedin",
+                "url": "https://www.linkedin.com/in/amcasari/"
+            }
+        ]
     }
 ]


### PR DESCRIPTION
This pull request adds a new board member, Amanda Casari, to the `board-members.json` data file. The update includes all relevant details such as her bio, image, and social media information.

Team member data update:

* Added Amanda Casari as a new board member in `src/data/board-members.json`, including her name, bio, image, and LinkedIn profile.