### PR TITLE
fix: Update Amanda Casari board member image

### DIFF
--- a/src/data/board-members.json
+++ b/src/data/board-members.json
@@ -320,9 +320,9 @@
         "path": "/team/amanda-casari",
         "url": "",
         "image": {
-            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1771203109/team/amanda-casari.jpg",
-            "width": 259,
-            "height": 194,
+            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1771212402/team/amanda-casari.png",
+            "width": 1024,
+            "height": 768,
             "alt": "Board Member"
         },
         "designation": "Board Member",


### PR DESCRIPTION
This pull request updates the image for Amanda Casari in the board members data. The new image has a higher resolution and uses a `.png` format instead of `.jpg`. 

- Updated Amanda Casari's profile image in `src/data/board-members.json` to a higher resolution `.png` file, changing the `src`, `width`, and `height` fields.