### PR TITLE
fix: Update Paul Ford board member image

### DIFF
--- a/src/data/board-members.json
+++ b/src/data/board-members.json
@@ -261,9 +261,9 @@
         "path": "/team/paul-ford",
         "url": "",
         "image": {
-            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1771208155/team/paul-ford.png",
-            "width": 460,
-            "height": 460,
+            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1771213002/team/paul-ford.jpg",
+            "width": 500,
+            "height": 500,
             "alt": "Board Member"
         },
         "designation": "Board Member",


### PR DESCRIPTION
This pull request makes a minor update to the board member data. The change updates Paul Ford's profile image with a new source, width, and height.

* Updated Paul Ford's profile image in `src/data/board-members.json` with a new `.jpg` file, increased width and height, and updated the image path.