### PR TITLE
fix: Update portfolio checklist edition year to 2026

### DIFF
--- a/src/pages/portfolio-checklist.tsx
+++ b/src/pages/portfolio-checklist.tsx
@@ -525,7 +525,7 @@ const PortfolioChecklist: PageProps = () => {
                         it&rsquo;s noise. Build accordingly.
                     </p>
                     <p className="tw-text-sm tw-text-white/70 print:tw-text-gray-200">
-                        2025 Edition &middot; {totalItems} items across 7 sections
+                        2026 Edition &middot; {totalItems} items across 7 sections
                     </p>
                 </div>
             </section>


### PR DESCRIPTION
This pull request makes a minor update to the `PortfolioChecklist` page, updating the edition year displayed in the UI from 2025 to 2026.