### PR TITLE
fix: Use Next.js Image for profile avatar

### DIFF
--- a/src/components/profile/ProfileHeader.tsx
+++ b/src/components/profile/ProfileHeader.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { motion } from "framer-motion";
 import type { ProfileUser, ProfileFormData, GitHubData } from "@/types/profile";
 
@@ -45,13 +46,17 @@ const ProfileHeader = ({
                 {/* Avatar */}
                 <div className="tw-relative tw-flex-shrink-0">
                     {avatarUrl ? (
-                        <img
+                        <Image
                             src={avatarUrl}
                             alt={user.name || "User"}
-                            className="tw-h-28 tw-w-28 tw-rounded-full tw-border-4 tw-border-gold/40 tw-shadow-lg tw-shadow-gold/10"
+                            width={112}
+                            height={112}
+                            priority
+                            className="tw-rounded-full tw-border-4 tw-border-gold/40 tw-shadow-lg tw-shadow-gold/10"
+                            style={{ width: 112, height: 112, objectFit: "cover" }}
                         />
                     ) : (
-                        <div className="tw-flex tw-h-28 tw-w-28 tw-items-center tw-justify-center tw-rounded-full tw-bg-white/10 tw-text-3xl tw-border-4 tw-border-gold/40">
+                        <div className="tw-flex tw-items-center tw-justify-center tw-rounded-full tw-bg-white/10 tw-text-3xl tw-border-4 tw-border-gold/40" style={{ width: 112, height: 112 }}>
                             <i className="fas fa-user" />
                         </div>
                     )}


### PR DESCRIPTION
This pull request updates the avatar rendering in the `ProfileHeader` component to use Next.js's optimized `Image` component instead of a standard `<img>` tag, improving performance and consistency. It also ensures avatar sizing is handled explicitly for both image and fallback icon cases.

Avatar rendering improvements:

* Replaced the standard `<img>` tag with Next.js's `<Image>` component for displaying user avatars, specifying explicit width, height, and priority for better performance and layout stability. (`src/components/profile/ProfileHeader.tsx`) [[1]](diffhunk://#diff-7df959804bc99bebffb780b88aa8129fc1dd438b5535fc85c127442f18177fbbR1) [[2]](diffhunk://#diff-7df959804bc99bebffb780b88aa8129fc1dd438b5535fc85c127442f18177fbbL48-R59)
* Updated fallback avatar icon styling to use inline styles for width and height, matching the dimensions of the image avatar for consistency. (`src/components/profile/ProfileHeader.tsx`)Replace plain img tag with next/image Image component with priority loading. Ensures avatar renders immediately and reliably via Next.js image optimization pipeline.