### PR TITLE
feat: Add multi-user profile support with /profile/[id]

### DIFF
--- a/src/components/profile/ProfileHeader.tsx
+++ b/src/components/profile/ProfileHeader.tsx
@@ -7,6 +7,7 @@ interface ProfileHeaderProps {
     formData: ProfileFormData;
     github: GitHubData | null;
     isEditing: boolean;
+    isOwner?: boolean;
     onToggleEdit: () => void;
     onLogout: () => void;
 }
@@ -16,6 +17,7 @@ const ProfileHeader = ({
     formData,
     github,
     isEditing,
+    isOwner = true,
     onToggleEdit,
     onLogout,
 }: ProfileHeaderProps) => {
@@ -147,25 +149,27 @@ const ProfileHeader = ({
                     </div>
                 </div>
 
-                {/* Actions */}
-                <div className="tw-flex tw-flex-shrink-0 tw-space-x-3">
-                    <button
-                        type="button"
-                        onClick={onToggleEdit}
-                        className="tw-rounded-lg tw-border tw-border-gold/30 tw-bg-gold/10 tw-px-4 tw-py-2 tw-font-mono tw-text-sm tw-font-semibold tw-text-gold tw-transition-all hover:tw-bg-gold/20"
-                    >
-                        <i className={`fas ${isEditing ? "fa-times" : "fa-edit"} tw-mr-2`} />
-                        {isEditing ? "Cancel" : "Edit Profile"}
-                    </button>
-                    <button
-                        type="button"
-                        onClick={onLogout}
-                        className="tw-rounded-lg tw-bg-red/80 tw-px-4 tw-py-2 tw-font-mono tw-text-sm tw-font-semibold tw-text-white tw-transition-all hover:tw-bg-red"
-                    >
-                        <i className="fas fa-sign-out-alt tw-mr-2" />
-                        Logout
-                    </button>
-                </div>
+                {/* Actions — only visible to profile owner */}
+                {isOwner && (
+                    <div className="tw-flex tw-flex-shrink-0 tw-space-x-3">
+                        <button
+                            type="button"
+                            onClick={onToggleEdit}
+                            className="tw-rounded-lg tw-border tw-border-gold/30 tw-bg-gold/10 tw-px-4 tw-py-2 tw-font-mono tw-text-sm tw-font-semibold tw-text-gold tw-transition-all hover:tw-bg-gold/20"
+                        >
+                            <i className={`fas ${isEditing ? "fa-times" : "fa-edit"} tw-mr-2`} />
+                            {isEditing ? "Cancel" : "Edit Profile"}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onLogout}
+                            className="tw-rounded-lg tw-bg-red/80 tw-px-4 tw-py-2 tw-font-mono tw-text-sm tw-font-semibold tw-text-white tw-transition-all hover:tw-bg-red"
+                        >
+                            <i className="fas fa-sign-out-alt tw-mr-2" />
+                            Logout
+                        </button>
+                    </div>
+                )}
             </div>
         </motion.div>
     );

--- a/src/components/profile/ProfileNav.tsx
+++ b/src/components/profile/ProfileNav.tsx
@@ -4,12 +4,20 @@ import { PROFILE_TABS } from "@/types/profile";
 interface ProfileNavProps {
     activeTab: ProfileTab;
     onTabChange: (tab: ProfileTab) => void;
+    isOwner?: boolean;
 }
 
-const ProfileNav = ({ activeTab, onTabChange }: ProfileNavProps) => (
+const OWNER_ONLY_TABS: ProfileTab[] = ["settings"];
+
+const ProfileNav = ({ activeTab, onTabChange, isOwner = true }: ProfileNavProps) => {
+    const visibleTabs = isOwner
+        ? PROFILE_TABS
+        : PROFILE_TABS.filter((tab) => !OWNER_ONLY_TABS.includes(tab.id));
+
+    return (
     <div className="tw-mb-8">
         <nav className="tw-flex tw-gap-1 tw-overflow-x-auto tw-border-b tw-border-navy/10 tw-pb-px">
-            {PROFILE_TABS.map((tab) => (
+            {visibleTabs.map((tab) => (
                 <button
                     key={tab.id}
                     type="button"
@@ -26,6 +34,7 @@ const ProfileNav = ({ activeTab, onTabChange }: ProfileNavProps) => (
             ))}
         </nav>
     </div>
-);
+    );
+};
 
 export default ProfileNav;

--- a/src/hooks/use-github-profile.ts
+++ b/src/hooks/use-github-profile.ts
@@ -7,7 +7,7 @@ interface UseGitHubProfileReturn {
     error: string | null;
 }
 
-export default function useGitHubProfile(): UseGitHubProfileReturn {
+export default function useGitHubProfile(userId?: string): UseGitHubProfileReturn {
     const [data, setData] = useState<GitHubData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -17,7 +17,10 @@ export default function useGitHubProfile(): UseGitHubProfileReturn {
 
         async function fetchGitHub() {
             try {
-                const res = await fetch("/api/user/github");
+                const url = userId
+                    ? `/api/user/github?userId=${encodeURIComponent(userId)}`
+                    : "/api/user/github";
+                const res = await fetch(url);
                 if (!res.ok) {
                     const body = await res.json().catch(() => ({}));
                     throw new Error(body.error || `HTTP ${res.status}`);
@@ -33,7 +36,7 @@ export default function useGitHubProfile(): UseGitHubProfileReturn {
 
         fetchGitHub();
         return () => { cancelled = true; };
-    }, []);
+    }, [userId]);
 
     return { data, isLoading, error };
 }

--- a/src/hooks/use-learning-stats.ts
+++ b/src/hooks/use-learning-stats.ts
@@ -7,7 +7,7 @@ interface UseLearningStatsReturn {
     error: string | null;
 }
 
-export default function useLearningStats(): UseLearningStatsReturn {
+export default function useLearningStats(userId?: string): UseLearningStatsReturn {
     const [data, setData] = useState<LearningStatsData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -17,7 +17,10 @@ export default function useLearningStats(): UseLearningStatsReturn {
 
         async function fetchStats() {
             try {
-                const res = await fetch("/api/user/learning-stats");
+                const url = userId
+                    ? `/api/user/learning-stats?userId=${encodeURIComponent(userId)}`
+                    : "/api/user/learning-stats";
+                const res = await fetch(url);
                 if (!res.ok) {
                     const body = await res.json().catch(() => ({}));
                     throw new Error(body.error || `HTTP ${res.status}`);
@@ -33,7 +36,7 @@ export default function useLearningStats(): UseLearningStatsReturn {
 
         fetchStats();
         return () => { cancelled = true; };
-    }, []);
+    }, [userId]);
 
     return { data, isLoading, error };
 }

--- a/src/hooks/use-profile-form.ts
+++ b/src/hooks/use-profile-form.ts
@@ -54,7 +54,10 @@ export default function useProfileForm(user: ProfileUser): UseProfileFormReturn 
         async function fetchProfile() {
             if (!session?.user) return;
             try {
-                const response = await fetch("/api/user/profile");
+                const url = user.id && user.id !== session.user.id
+                    ? `/api/user/profile?userId=${encodeURIComponent(user.id)}`
+                    : "/api/user/profile";
+                const response = await fetch(url);
                 if (response.ok) {
                     const userData = await response.json();
                     const profileData: ProfileFormData = {

--- a/src/pages/api/user/github.ts
+++ b/src/pages/api/user/github.ts
@@ -56,11 +56,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(401).json({ error: "Unauthorized" });
     }
 
+    // Allow viewing another member's GitHub data via ?userId=
+    const targetUserId = (req.query.userId as string) || session.user.id;
+
     try {
-        // Get the user's GitHub access token from the Account table
+        // Get the target user's GitHub access token from the Account table
         const account = await prisma.account.findFirst({
             where: {
-                userId: session.user.id,
+                userId: targetUserId,
                 provider: "github",
             },
             select: { access_token: true },

--- a/src/pages/api/user/learning-stats.ts
+++ b/src/pages/api/user/learning-stats.ts
@@ -15,7 +15,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(401).json({ error: "Unauthorized" });
     }
 
-    const userId = session.user.id;
+    // Allow viewing another member's learning stats via ?userId=
+    const userId = (req.query.userId as string) || session.user.id;
 
     try {
         const [enrollments, progressAgg, certificates, recentProgress] = await Promise.all([

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -102,10 +102,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const userId = session.user.id;
 
     if (req.method === "GET") {
-        return handleGetProfile(userId, res);
+        // Allow viewing another member's profile via ?userId=
+        const targetUserId = (req.query.userId as string) || userId;
+        return handleGetProfile(targetUserId, res);
     }
 
     if (req.method === "PUT") {
+        // Only the owner can update their own profile
         return handleUpdateProfile(userId, req.body, res);
     }
 

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,188 +1,12 @@
-import Breadcrumb from "@components/breadcrumb";
-import SEO from "@components/seo/page-seo";
-import { useMount } from "@hooks";
-import Layout01 from "@layout/layout-01";
-import Spinner from "@ui/spinner";
-import type { GetServerSideProps, NextPage } from "next";
-import { useRouter } from "next/router";
+import type { GetServerSideProps } from "next";
 import { getServerSession } from "next-auth/next";
-import { signOut } from "next-auth/react";
-import { useState } from "react";
 import { options } from "@/pages/api/auth/options";
-import prisma from "@/lib/prisma";
-import useGitHubProfile from "@/hooks/use-github-profile";
-import useLearningStats from "@/hooks/use-learning-stats";
-import useProfileForm from "@/hooks/use-profile-form";
-import type { ProfileUser, ProfileTab } from "@/types/profile";
-import {
-    NotificationToast,
-    ProfileHeader,
-    ProfileNav,
-    GitHubStatsGrid,
-    RepositoryShowcase,
-    LanguageBreakdown,
-    ActivityFeed,
-    ServiceRecord,
-    LearningProgress,
-    ProfileSettings,
-    GitHubReadme,
-} from "@/components/profile";
 
-type PageProps = {
-    user: ProfileUser;
-    layout?: {
-        headerShadow: boolean;
-        headerFluid: boolean;
-        footerMode: string;
-    };
-};
-
-type PageWithLayout = NextPage<PageProps> & {
-    Layout?: typeof Layout01;
-};
-
-const Profile: PageWithLayout = ({ user }) => {
-    const mounted = useMount();
-    const router = useRouter();
-    const [activeTab, setActiveTab] = useState<ProfileTab>("command-center");
-
-    const github = useGitHubProfile();
-    const learning = useLearningStats();
-    const form = useProfileForm(user);
-
-    if (!mounted) {
-        return (
-            <div className="tw-fixed tw-top-0 tw-z-50 tw-flex tw-h-screen tw-w-screen tw-items-center tw-justify-center tw-bg-white">
-                <Spinner />
-            </div>
-        );
-    }
-
-    const handleLogout = async () => {
-        try {
-            await signOut({ redirect: false });
-            await router.replace("/login");
-        } catch {
-            // logout error handled silently
-        }
-    };
-
-    return (
-        <>
-            <SEO title="Profile" />
-            <Breadcrumb
-                pages={[{ path: "/", label: "home" }]}
-                currentPage="Profile"
-                showTitle={false}
-            />
-
-            {form.notification && (
-                <NotificationToast
-                    type={form.notification.type}
-                    message={form.notification.message}
-                    onDismiss={form.dismissNotification}
-                />
-            )}
-
-            <div className="tw-container tw-py-8">
-                <ProfileHeader
-                    user={user}
-                    formData={form.formData}
-                    github={github.data}
-                    isEditing={form.isEditing}
-                    onToggleEdit={() =>
-                        form.isEditing ? form.handleCancel() : form.setIsEditing(true)
-                    }
-                    onLogout={handleLogout}
-                />
-
-                <ProfileNav activeTab={activeTab} onTabChange={setActiveTab} />
-
-                {/* Command Center — GitHub overview */}
-                {activeTab === "command-center" && (
-                    <div className="tw-space-y-8">
-                        {github.error && !github.isLoading && (
-                            <div className="tw-rounded-lg tw-border tw-border-red/20 tw-bg-red/5 tw-p-6 tw-text-center">
-                                <i className="fas fa-exclamation-triangle tw-text-red tw-text-2xl tw-mb-2" />
-                                <p className="tw-font-mono tw-text-sm tw-text-red/80">
-                                    Unable to load GitHub data: {github.error}
-                                </p>
-                                <p className="tw-font-mono tw-text-xs tw-text-gray-300 tw-mt-1">
-                                    Try logging out and back in to refresh your GitHub token.
-                                </p>
-                            </div>
-                        )}
-                        <GitHubStatsGrid
-                            github={github.data}
-                            isLoading={github.isLoading}
-                        />
-                        <LanguageBreakdown
-                            languages={github.data?.languages || []}
-                            isLoading={github.isLoading}
-                        />
-                        <GitHubReadme
-                            content={github.data?.readme || null}
-                            login={github.data?.profile.login || ""}
-                            isLoading={github.isLoading}
-                        />
-                    </div>
-                )}
-
-                {/* Arsenal — Repositories */}
-                {activeTab === "arsenal" && (
-                    <RepositoryShowcase
-                        repos={github.data?.repos || []}
-                        isLoading={github.isLoading}
-                    />
-                )}
-
-                {/* Ops Log — GitHub activity feed */}
-                {activeTab === "ops-log" && (
-                    <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
-                        <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
-                            Operations Log
-                        </h3>
-                        <ActivityFeed
-                            events={github.data?.events || []}
-                            isLoading={github.isLoading}
-                        />
-                    </div>
-                )}
-
-                {/* Service Record — Military background + profile edit */}
-                {activeTab === "service-record" && (
-                    <ServiceRecord
-                        formData={form.formData}
-                        isEditing={form.isEditing}
-                        isSaving={form.isSaving}
-                        onInputChange={form.handleInputChange}
-                        onSave={form.handleSave}
-                        onCancel={form.handleCancel}
-                    />
-                )}
-
-                {/* Training — Learning progress */}
-                {activeTab === "training" && (
-                    <LearningProgress
-                        data={learning.data}
-                        isLoading={learning.isLoading}
-                        error={learning.error}
-                    />
-                )}
-
-                {/* Settings */}
-                {activeTab === "settings" && <ProfileSettings />}
-            </div>
-        </>
-    );
-};
-
-Profile.Layout = Layout01;
-
-export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+// Redirect /profile to /profile/[currentUserId]
+export const getServerSideProps: GetServerSideProps = async (context) => {
     const session = await getServerSession(context.req, context.res, options);
 
-    if (!session?.user) {
+    if (!session?.user?.id) {
         return {
             redirect: {
                 destination: "/login?callbackUrl=/profile",
@@ -191,37 +15,15 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (context)
         };
     }
 
-    // If session image is missing, try to get GitHub avatar from the Account table
-    let image = session.user.image || null;
-    if (!image) {
-        try {
-            const account = await prisma.account.findFirst({
-                where: { userId: session.user.id, provider: "github" },
-                select: { providerAccountId: true },
-            });
-            if (account?.providerAccountId) {
-                image = `https://avatars.githubusercontent.com/u/${account.providerAccountId}?v=4`;
-            }
-        } catch {
-            // non-critical, fall through
-        }
-    }
-
     return {
-        props: {
-            user: {
-                id: session.user.id,
-                name: session.user.name || null,
-                email: session.user.email || "",
-                image,
-            },
-            layout: {
-                headerShadow: true,
-                headerFluid: false,
-                footerMode: "light",
-            },
+        redirect: {
+            destination: `/profile/${session.user.id}`,
+            permanent: false,
         },
     };
 };
 
-export default Profile;
+// This page never renders — it always redirects
+export default function ProfileRedirect() {
+    return null;
+}

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -1,0 +1,246 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import { useMount } from "@hooks";
+import Layout01 from "@layout/layout-01";
+import Spinner from "@ui/spinner";
+import type { GetServerSideProps, NextPage } from "next";
+import { useRouter } from "next/router";
+import { getServerSession } from "next-auth/next";
+import { signOut } from "next-auth/react";
+import { useState } from "react";
+import { options } from "@/pages/api/auth/options";
+import prisma from "@/lib/prisma";
+import useGitHubProfile from "@/hooks/use-github-profile";
+import useLearningStats from "@/hooks/use-learning-stats";
+import useProfileForm from "@/hooks/use-profile-form";
+import type { ProfileUser, ProfileTab } from "@/types/profile";
+import {
+    NotificationToast,
+    ProfileHeader,
+    ProfileNav,
+    GitHubStatsGrid,
+    RepositoryShowcase,
+    LanguageBreakdown,
+    ActivityFeed,
+    ServiceRecord,
+    LearningProgress,
+    ProfileSettings,
+    GitHubReadme,
+} from "@/components/profile";
+
+type PageProps = {
+    user: ProfileUser;
+    isOwner: boolean;
+    layout?: {
+        headerShadow: boolean;
+        headerFluid: boolean;
+        footerMode: string;
+    };
+};
+
+type PageWithLayout = NextPage<PageProps> & {
+    Layout?: typeof Layout01;
+};
+
+const MemberProfile: PageWithLayout = ({ user, isOwner }) => {
+    const mounted = useMount();
+    const router = useRouter();
+    const [activeTab, setActiveTab] = useState<ProfileTab>("command-center");
+
+    // Pass the target user's ID to hooks so they fetch that member's data
+    const targetId = isOwner ? undefined : user.id;
+    const github = useGitHubProfile(targetId);
+    const learning = useLearningStats(targetId);
+    const form = useProfileForm(user);
+
+    if (!mounted) {
+        return (
+            <div className="tw-fixed tw-top-0 tw-z-50 tw-flex tw-h-screen tw-w-screen tw-items-center tw-justify-center tw-bg-white">
+                <Spinner />
+            </div>
+        );
+    }
+
+    const handleLogout = async () => {
+        try {
+            await signOut({ redirect: false });
+            await router.replace("/login");
+        } catch {
+            // logout error handled silently
+        }
+    };
+
+    return (
+        <>
+            <SEO title={isOwner ? "Profile" : `${user.name || "Member"}'s Profile`} />
+            <Breadcrumb
+                pages={[{ path: "/", label: "home" }]}
+                currentPage={isOwner ? "Profile" : user.name || "Member"}
+                showTitle={false}
+            />
+
+            {isOwner && form.notification && (
+                <NotificationToast
+                    type={form.notification.type}
+                    message={form.notification.message}
+                    onDismiss={form.dismissNotification}
+                />
+            )}
+
+            <div className="tw-container tw-py-8">
+                <ProfileHeader
+                    user={user}
+                    formData={form.formData}
+                    github={github.data}
+                    isEditing={isOwner ? form.isEditing : false}
+                    isOwner={isOwner}
+                    onToggleEdit={() =>
+                        form.isEditing ? form.handleCancel() : form.setIsEditing(true)
+                    }
+                    onLogout={handleLogout}
+                />
+
+                <ProfileNav
+                    activeTab={activeTab}
+                    onTabChange={setActiveTab}
+                    isOwner={isOwner}
+                />
+
+                {/* Command Center — GitHub overview */}
+                {activeTab === "command-center" && (
+                    <div className="tw-space-y-8">
+                        {github.error && !github.isLoading && (
+                            <div className="tw-rounded-lg tw-border tw-border-red/20 tw-bg-red/5 tw-p-6 tw-text-center">
+                                <i className="fas fa-exclamation-triangle tw-text-red tw-text-2xl tw-mb-2" />
+                                <p className="tw-font-mono tw-text-sm tw-text-red/80">
+                                    Unable to load GitHub data: {github.error}
+                                </p>
+                            </div>
+                        )}
+                        <GitHubStatsGrid
+                            github={github.data}
+                            isLoading={github.isLoading}
+                        />
+                        <LanguageBreakdown
+                            languages={github.data?.languages || []}
+                            isLoading={github.isLoading}
+                        />
+                        <GitHubReadme
+                            content={github.data?.readme || null}
+                            login={github.data?.profile.login || ""}
+                            isLoading={github.isLoading}
+                        />
+                    </div>
+                )}
+
+                {/* Arsenal — Repositories */}
+                {activeTab === "arsenal" && (
+                    <RepositoryShowcase
+                        repos={github.data?.repos || []}
+                        isLoading={github.isLoading}
+                    />
+                )}
+
+                {/* Ops Log — GitHub activity feed */}
+                {activeTab === "ops-log" && (
+                    <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
+                        <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                            Operations Log
+                        </h3>
+                        <ActivityFeed
+                            events={github.data?.events || []}
+                            isLoading={github.isLoading}
+                        />
+                    </div>
+                )}
+
+                {/* Service Record — Military background (read-only for non-owners) */}
+                {activeTab === "service-record" && (
+                    <ServiceRecord
+                        formData={form.formData}
+                        isEditing={isOwner ? form.isEditing : false}
+                        isSaving={form.isSaving}
+                        onInputChange={form.handleInputChange}
+                        onSave={form.handleSave}
+                        onCancel={form.handleCancel}
+                    />
+                )}
+
+                {/* Training — Learning progress */}
+                {activeTab === "training" && (
+                    <LearningProgress
+                        data={learning.data}
+                        isLoading={learning.isLoading}
+                        error={learning.error}
+                    />
+                )}
+
+                {/* Settings — only for owner */}
+                {activeTab === "settings" && isOwner && <ProfileSettings />}
+            </div>
+        </>
+    );
+};
+
+MemberProfile.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const session = await getServerSession(context.req, context.res, options);
+
+    if (!session?.user) {
+        return {
+            redirect: {
+                destination: "/login?callbackUrl=/profile",
+                permanent: false,
+            },
+        };
+    }
+
+    const targetId = context.params?.id as string;
+    const isOwner = session.user.id === targetId;
+
+    // Look up the target user
+    const targetUser = await prisma.user.findUnique({
+        where: { id: targetId },
+        select: { id: true, name: true, email: true, image: true },
+    });
+
+    if (!targetUser) {
+        return { notFound: true };
+    }
+
+    // If image is missing, try GitHub avatar fallback
+    let image = targetUser.image || null;
+    if (!image) {
+        try {
+            const account = await prisma.account.findFirst({
+                where: { userId: targetId, provider: "github" },
+                select: { providerAccountId: true },
+            });
+            if (account?.providerAccountId) {
+                image = `https://avatars.githubusercontent.com/u/${account.providerAccountId}?v=4`;
+            }
+        } catch {
+            // non-critical
+        }
+    }
+
+    return {
+        props: {
+            user: {
+                id: targetUser.id,
+                name: targetUser.name || null,
+                email: isOwner ? targetUser.email || "" : "",
+                image,
+            },
+            isOwner,
+            layout: {
+                headerShadow: true,
+                headerFluid: false,
+                footerMode: "light",
+            },
+        },
+    };
+};
+
+export default MemberProfile;


### PR DESCRIPTION
This pull request introduces support for viewing other users' profiles, GitHub data, and learning stats by user ID, and ensures that profile actions and tabs are only accessible to the profile owner. It refactors hooks and API routes to accept an optional `userId` parameter, updates UI components to conditionally show owner-only features, and changes the `/profile` route to redirect to `/profile/[userId]`.

**Profile viewing and API enhancements:**

* Refactored hooks (`useGitHubProfile`, `useLearningStats`, `useProfileForm`) and API endpoints (`/api/user/profile`, `/api/user/github`, `/api/user/learning-stats`) to accept an optional `userId` parameter, enabling retrieval of data for any user, not just the current session user. [[1]](diffhunk://#diff-fae83cbfa84c7a280d0e0db1ef81a94d1083219b53e507c531ed56809a3456b0L10-R10) [[2]](diffhunk://#diff-fae83cbfa84c7a280d0e0db1ef81a94d1083219b53e507c531ed56809a3456b0L20-R23) [[3]](diffhunk://#diff-fae83cbfa84c7a280d0e0db1ef81a94d1083219b53e507c531ed56809a3456b0L36-R39) [[4]](diffhunk://#diff-8b9fe1ce3268bf81270c55839997bad56fa550b14432663c604c2907b16d1cb4L10-R10) [[5]](diffhunk://#diff-8b9fe1ce3268bf81270c55839997bad56fa550b14432663c604c2907b16d1cb4L20-R23) [[6]](diffhunk://#diff-8b9fe1ce3268bf81270c55839997bad56fa550b14432663c604c2907b16d1cb4L36-R39) [[7]](diffhunk://#diff-645adb3bb08b2b354956b21a7f8398135d861d7f1b2288643bf8fb99a09c7d32L57-R60) [[8]](diffhunk://#diff-1b5f4c93385c64af2950e7c7141af05f8730824b0552ecc4db7db9076d6b9337R59-R66) [[9]](diffhunk://#diff-eb23f5b59f5117205a1ce5c8c5967179af61e30cfab6cfea01d9b7fca30dc2aeL18-R19) [[10]](diffhunk://#diff-2d76bed54b90abbae53515451ed6b01a1c490c2a4113b98bbf83eb17fbf4f01dL105-R111)

**Owner-only actions and UI controls:**

* Added `isOwner` prop to `ProfileHeader` and `ProfileNav` components, and updated their logic to conditionally render edit/logout actions and owner-only tabs (like "settings") only for the profile owner. [[1]](diffhunk://#diff-7df959804bc99bebffb780b88aa8129fc1dd438b5535fc85c127442f18177fbbR10) [[2]](diffhunk://#diff-7df959804bc99bebffb780b88aa8129fc1dd438b5535fc85c127442f18177fbbR20) [[3]](diffhunk://#diff-7df959804bc99bebffb780b88aa8129fc1dd438b5535fc85c127442f18177fbbL150-R153) [[4]](diffhunk://#diff-7df959804bc99bebffb780b88aa8129fc1dd438b5535fc85c127442f18177fbbR172) [[5]](diffhunk://#diff-83d28ad4fb177ba09ab16aece7d3584732b61d4e11d6a7ca6b5ea5c6b25c65e5R7-R20) [[6]](diffhunk://#diff-83d28ad4fb177ba09ab16aece7d3584732b61d4e11d6a7ca6b5ea5c6b25c65e5R38)

**Routing changes:**

* Changed `/profile` page to always redirect to `/profile/[currentUserId]`, ensuring direct navigation to a user's profile by their ID. The original `/profile` page now only performs the redirect and does not render any content. [[1]](diffhunk://#diff-27493a45525c74e39bd9dad7aa2a186f2a21f507c892506369450d3d965f42c2L1-R9) [[2]](diffhunk://#diff-27493a45525c74e39bd9dad7aa2a186f2a21f507c892506369450d3d965f42c2L194-R29)

These changes collectively enable viewing and interacting with other users' profiles in a secure and user-friendly manner, while preserving owner-only features.- Create dynamic /profile/[id] page with owner detection
- Redirect /profile to /profile/[currentUserId]
- Hide edit/logout buttons for non-owners in ProfileHeader
- Hide Settings tab for non-owners in ProfileNav
- Update API routes to accept ?userId= for viewing others
- Update hooks to pass optional userId parameter