### PR TITLE
fix: Replace misleading 'Sign In to Enroll' with application CTA

### DIFF
--- a/src/containers/course-details/enrollment-sidebar.tsx
+++ b/src/containers/course-details/enrollment-sidebar.tsx
@@ -133,13 +133,13 @@ const EnrollmentSidebar = ({ course }: TProps) => {
                         ) : (
                             <div>
                                 <Link
-                                    href="/login"
+                                    href="/apply"
                                     className="hover:tw-bg-primary-dark tw-mb-4 tw-block tw-w-full tw-rounded-md tw-bg-primary tw-px-6 tw-py-3 tw-text-center tw-font-semibold tw-text-white tw-transition-colors"
                                 >
-                                    Sign In to Enroll
+                                    Apply to Vets Who Code
                                 </Link>
                                 <p className="tw-text-center tw-text-sm tw-text-gray-300">
-                                    Join the learning platform for hands-on experience
+                                    Course access is available after acceptance into the program
                                 </p>
                             </div>
                         )}


### PR DESCRIPTION
This pull request updates the enrollment sidebar to clarify the application process for prospective students. The most important changes focus on improving user guidance and updating the call-to-action.

User experience improvements:

* Changed the enrollment button link from `/login` to `/apply`, making it clear that users need to apply rather than simply sign in.
* Updated the button text from "Sign In to Enroll" to "Apply to Vets Who Code" to better reflect the process.
* Revised the descriptive text to clarify that course access is granted after acceptance into the program, rather than immediate access upon joining.Unauthenticated users saw 'Sign In to Enroll' which implied they could bypass the application process. Now directs them to /apply with copy that clarifies program acceptance is required for course access.