### PR TITLE
fix(auth): Harden sign-in and centralize admin route guards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,15 @@ GITHUB_PAT="your-github-personal-access-token"
 GITHUB_TOKEN="your-github-token"
 GITHUB_ORG="Vets-Who-Code"
 
+# Admin allowlist — comma-separated GitHub usernames that bypass org-membership
+# check on sign-in. Keep this list minimal (founders/external admins only).
+ADMIN_GITHUB_LOGINS=""
+
+# Dev-only escape hatch. Set to "true" ONLY when running locally with
+# NODE_ENV=development to allow any GitHub user to sign in. NEVER set in
+# production or preview deployments.
+ALLOW_ANY_GITHUB_USER="false"
+
 # Google Maps API (for location features)
 NEXT_PUBLIC_GOOGLE_MAPS_KEY="your-google-maps-api-key"
 

--- a/__tests__/lib/auth-guards.test.ts
+++ b/__tests__/lib/auth-guards.test.ts
@@ -1,0 +1,149 @@
+import type { GetServerSidePropsContext } from "next";
+import type { Session } from "next-auth";
+import { getServerSession } from "next-auth/next";
+
+// Mock next-auth so we don't hit real session logic.
+vi.mock("next-auth/next", () => ({
+    getServerSession: vi.fn(),
+}));
+
+// Stub the auth options import chain — the real module pulls in prisma and
+// ensure-troop, neither of which we need for pure guard logic.
+vi.mock("@/pages/api/auth/options", () => ({
+    options: {},
+}));
+
+import { requireAdminSSR, requireAuthSSR } from "@/lib/auth-guards";
+
+const mockGetServerSession = getServerSession as unknown as ReturnType<typeof vi.fn>;
+
+function buildContext(resolvedUrl: string): GetServerSidePropsContext {
+    return {
+        req: {} as GetServerSidePropsContext["req"],
+        res: {} as GetServerSidePropsContext["res"],
+        resolvedUrl,
+        query: {},
+        params: undefined,
+    } as GetServerSidePropsContext;
+}
+
+function buildSession(overrides: Partial<Session["user"]> = {}): Session {
+    return {
+        expires: "2099-01-01T00:00:00.000Z",
+        user: {
+            id: "user-123",
+            name: "Test Troop",
+            email: "troop@example.com",
+            image: null,
+            role: "STUDENT",
+            ...overrides,
+        },
+    };
+}
+
+describe("auth-guards", () => {
+    beforeEach(() => {
+        mockGetServerSession.mockReset();
+    });
+
+    describe("requireAuthSSR", () => {
+        it("redirects to /login with URI-encoded resolvedUrl when unauthenticated", async () => {
+            mockGetServerSession.mockResolvedValueOnce(null);
+            const context = buildContext("/admin/courses?page=2&sort=new");
+
+            const result = await requireAuthSSR(context);
+
+            expect(result.ok).toBe(false);
+            if (result.ok) return; // type narrow
+            expect(result.result).toEqual({
+                redirect: {
+                    destination:
+                        "/login?callbackUrl=%2Fadmin%2Fcourses%3Fpage%3D2%26sort%3Dnew",
+                    permanent: false,
+                },
+            });
+        });
+
+        it("redirects to /login when session exists but has no user", async () => {
+            mockGetServerSession.mockResolvedValueOnce({
+                expires: "2099-01-01T00:00:00.000Z",
+            } as Session);
+            const context = buildContext("/profile");
+
+            const result = await requireAuthSSR(context);
+
+            expect(result.ok).toBe(false);
+            if (result.ok) return;
+            expect(result.result).toEqual({
+                redirect: {
+                    destination: "/login?callbackUrl=%2Fprofile",
+                    permanent: false,
+                },
+            });
+        });
+
+        it("returns ok:true with the session when authenticated", async () => {
+            const session = buildSession({ role: "STUDENT" });
+            mockGetServerSession.mockResolvedValueOnce(session);
+
+            const result = await requireAuthSSR(buildContext("/profile"));
+
+            expect(result.ok).toBe(true);
+            if (!result.ok) return;
+            expect(result.session).toBe(session);
+        });
+    });
+
+    describe("requireAdminSSR", () => {
+        it("redirects unauthenticated requests to /login (delegates to requireAuthSSR)", async () => {
+            mockGetServerSession.mockResolvedValueOnce(null);
+
+            const result = await requireAdminSSR(buildContext("/admin"));
+
+            expect(result.ok).toBe(false);
+            if (result.ok) return;
+            expect(result.result).toEqual({
+                redirect: {
+                    destination: "/login?callbackUrl=%2Fadmin",
+                    permanent: false,
+                },
+            });
+        });
+
+        it("redirects authenticated non-admins to /", async () => {
+            mockGetServerSession.mockResolvedValueOnce(buildSession({ role: "STUDENT" }));
+
+            const result = await requireAdminSSR(buildContext("/admin/users"));
+
+            expect(result.ok).toBe(false);
+            if (result.ok) return;
+            expect(result.result).toEqual({
+                redirect: { destination: "/", permanent: false },
+            });
+        });
+
+        it("redirects authenticated users with undefined role to / (defensive)", async () => {
+            mockGetServerSession.mockResolvedValueOnce(buildSession({ role: undefined }));
+
+            const result = await requireAdminSSR(buildContext("/admin"));
+
+            expect(result.ok).toBe(false);
+            if (result.ok) return;
+            expect(result.result).toEqual({
+                redirect: { destination: "/", permanent: false },
+            });
+        });
+
+        it("returns ok:true with the session when the user is ADMIN", async () => {
+            const session = buildSession({ role: "ADMIN" });
+            mockGetServerSession.mockResolvedValueOnce(session);
+
+            const result = await requireAdminSSR(buildContext("/admin"));
+
+            expect(result.ok).toBe(true);
+            if (!result.ok) return;
+            expect(result.session).toBe(session);
+            expect(result.session.user.role).toBe("ADMIN");
+        });
+    });
+});

--- a/src/lib/auth-guards.ts
+++ b/src/lib/auth-guards.ts
@@ -1,0 +1,48 @@
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
+import type { Session } from "next-auth";
+import { getServerSession } from "next-auth/next";
+import { options } from "@/pages/api/auth/options";
+
+type GuardOk = { ok: true; session: Session };
+type GuardRedirect = { ok: false; result: GetServerSidePropsResult<never> };
+export type GuardResult = GuardOk | GuardRedirect;
+
+export async function requireAuthSSR(
+    context: GetServerSidePropsContext
+): Promise<GuardResult> {
+    const session = await getServerSession(context.req, context.res, options);
+
+    if (!session?.user) {
+        return {
+            ok: false,
+            result: {
+                redirect: {
+                    destination: `/login?callbackUrl=${encodeURIComponent(
+                        context.resolvedUrl
+                    )}`,
+                    permanent: false,
+                },
+            },
+        };
+    }
+
+    return { ok: true, session };
+}
+
+export async function requireAdminSSR(
+    context: GetServerSidePropsContext
+): Promise<GuardResult> {
+    const auth = await requireAuthSSR(context);
+    if (!auth.ok) return auth;
+
+    if (auth.session.user.role !== "ADMIN") {
+        return {
+            ok: false,
+            result: {
+                redirect: { destination: "/", permanent: false },
+            },
+        };
+    }
+
+    return auth;
+}

--- a/src/pages/admin/blog-images.tsx
+++ b/src/pages/admin/blog-images.tsx
@@ -5,8 +5,8 @@
  */
 
 import type { GetServerSideProps } from "next";
-import { getServerSession } from "next-auth/next";
 import React, { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
 import BlogImageManager from "@/components/blog-image-manager";
 import {
     BlogImageInfo,
@@ -14,7 +14,6 @@ import {
     getBlogImageStats,
     getBlogsWithoutCloudinaryImages,
 } from "@/lib/blog-images";
-import { options } from "@/pages/api/auth/options";
 
 const BlogImagesAdminPage: React.FC = () => {
     const [stats, setStats] = useState<ReturnType<typeof getBlogImageStats> | null>(null);
@@ -325,28 +324,8 @@ const BlogImagesAdminPage: React.FC = () => {
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-    // Check authentication
-    const session = await getServerSession(context.req, context.res, options);
-
-    // Redirect if not authenticated
-    if (!session?.user) {
-        return {
-            redirect: {
-                destination: "/login?callbackUrl=/admin/blog-images",
-                permanent: false,
-            },
-        };
-    }
-
-    // Check for ADMIN role
-    if (session.user.role !== "ADMIN") {
-        return {
-            redirect: {
-                destination: "/",
-                permanent: false,
-            },
-        };
-    }
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
 
     return {
         props: {},

--- a/src/pages/admin/courses.tsx
+++ b/src/pages/admin/courses.tsx
@@ -3,10 +3,9 @@ import SEO from "@components/seo/page-seo";
 import Layout01 from "@layout/layout-01";
 import type { GetServerSideProps, NextPage } from "next";
 import Link from "next/link";
-import { getServerSession } from "next-auth/next";
 import React, { useState } from "react";
 import prisma from "@/lib/prisma";
-import { options } from "@/pages/api/auth/options";
+import { requireAdminSSR } from "@/lib/auth-guards";
 
 type Course = {
     id: string;
@@ -291,28 +290,8 @@ const AdminCoursesPage: PageWithLayout = ({ courses: initialCourses }) => {
 AdminCoursesPage.Layout = Layout01;
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
-    // Check authentication
-    const session = await getServerSession(context.req, context.res, options);
-
-    // Redirect if not authenticated
-    if (!session?.user) {
-        return {
-            redirect: {
-                destination: "/login?callbackUrl=/admin/courses",
-                permanent: false,
-            },
-        };
-    }
-
-    // Check for ADMIN role
-    if (session.user.role !== "ADMIN") {
-        return {
-            redirect: {
-                destination: "/",
-                permanent: false,
-            },
-        };
-    }
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
 
     // Fetch all courses with module and enrollment counts
     const coursesWithCounts = await prisma.course.findMany({

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -3,9 +3,8 @@ import SEO from "@components/seo/page-seo";
 import Layout01 from "@layout/layout-01";
 import type { GetServerSideProps, NextPage } from "next";
 import Link from "next/link";
-import { getServerSession } from "next-auth/next";
 import React from "react";
-import { options } from "@/pages/api/auth/options";
+import { requireAdminSSR } from "@/lib/auth-guards";
 
 type DashboardStats = {
     totalStudents: number;
@@ -157,30 +156,9 @@ const AdminDashboard: PageWithLayout = ({ stats, userName }) => {
 AdminDashboard.Layout = Layout01;
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
-    // Check authentication
-    const session = await getServerSession(context.req, context.res, options);
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
 
-    // Redirect if not authenticated
-    if (!session?.user) {
-        return {
-            redirect: {
-                destination: "/login?callbackUrl=/admin",
-                permanent: false,
-            },
-        };
-    }
-
-    // Check for ADMIN role
-    if (session.user.role !== "ADMIN") {
-        return {
-            redirect: {
-                destination: "/",
-                permanent: false,
-            },
-        };
-    }
-
-    // Import prisma here to avoid issues
     const { default: prisma } = await import("@/lib/prisma");
 
     // Fetch real statistics from database
@@ -219,7 +197,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async (context)
     return {
         props: {
             stats,
-            userName: session.user.name || "User",
+            userName: guard.session.user.name || "User",
             layout: {
                 headerShadow: true,
                 headerFluid: false,

--- a/src/pages/admin/users.tsx
+++ b/src/pages/admin/users.tsx
@@ -3,10 +3,9 @@ import SEO from "@components/seo/page-seo";
 import Layout01 from "@layout/layout-01";
 import type { GetServerSideProps, NextPage } from "next";
 import Link from "next/link";
-import { getServerSession } from "next-auth/next";
 import React, { useState } from "react";
 import prisma from "@/lib/prisma";
-import { options } from "@/pages/api/auth/options";
+import { requireAdminSSR } from "@/lib/auth-guards";
 
 type User = {
     id: string;
@@ -330,28 +329,8 @@ const AdminUsersPage: PageWithLayout = ({ users: initialUsers }) => {
 AdminUsersPage.Layout = Layout01;
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
-    // Check authentication
-    const session = await getServerSession(context.req, context.res, options);
-
-    // Redirect if not authenticated
-    if (!session?.user) {
-        return {
-            redirect: {
-                destination: "/login?callbackUrl=/admin/users",
-                permanent: false,
-            },
-        };
-    }
-
-    // Check for ADMIN role
-    if (session.user.role !== "ADMIN") {
-        return {
-            redirect: {
-                destination: "/",
-                permanent: false,
-            },
-        };
-    }
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
 
     // Fetch all users with enrollment counts
     const usersWithEnrollments = await prisma.user.findMany({

--- a/src/pages/api/auth/options.ts
+++ b/src/pages/api/auth/options.ts
@@ -48,17 +48,27 @@ export const options: NextAuthOptions = {
                     return false;
                 }
 
-                // For development, allow any GitHub user to sign in
-                if (process.env.NODE_ENV === "development") {
+                // Dev-only escape hatch. Requires BOTH NODE_ENV=development AND
+                // explicit ALLOW_ANY_GITHUB_USER=true. Never set the flag in
+                // production or on preview deployments.
+                if (
+                    process.env.NODE_ENV === "development" &&
+                    process.env.ALLOW_ANY_GITHUB_USER === "true"
+                ) {
                     return true;
                 }
 
-                // Allow jeromehardaway to login as admin
-                if (githubProfile.login === "jeromehardaway") {
+                // Configured admin allowlist bypasses org-membership check.
+                // Used for founders/external admins not on the org roster.
+                const adminLogins = (process.env.ADMIN_GITHUB_LOGINS || "")
+                    .split(",")
+                    .map((s) => s.trim().toLowerCase())
+                    .filter(Boolean);
+                if (adminLogins.includes(githubProfile.login.toLowerCase())) {
                     return true;
                 }
 
-                // For other users in production, check organization membership
+                // For all other users, check organization membership
                 const githubOrg = process.env.GITHUB_ORG;
                 if (!githubOrg) {
                     console.error("[Auth] GITHUB_ORG env var is not set");

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -4,7 +4,6 @@ import { useMount } from "@hooks";
 import Layout01 from "@layout/layout-01";
 import Spinner from "@ui/spinner";
 import type { GetServerSideProps, NextPage } from "next";
-import { useRouter } from "next/router";
 import { getServerSession } from "next-auth/next";
 import { signOut } from "next-auth/react";
 import { useState } from "react";
@@ -45,7 +44,6 @@ type PageWithLayout = NextPage<PageProps> & {
 
 const MemberProfile: PageWithLayout = ({ user, isOwner }) => {
     const mounted = useMount();
-    const router = useRouter();
     const [activeTab, setActiveTab] = useState<ProfileTab>("command-center");
 
     // Pass the target user's ID to hooks so they fetch that member's data
@@ -64,10 +62,12 @@ const MemberProfile: PageWithLayout = ({ user, isOwner }) => {
 
     const handleLogout = async () => {
         try {
-            await signOut({ redirect: false });
-            await router.replace("/login");
-        } catch {
-            // logout error handled silently
+            await signOut({ callbackUrl: "/login" });
+        } catch (error) {
+            console.error("[Profile] signOut failed:", error);
+            window.alert(
+                "Logout failed. Please try again, or clear your browser cookies for this site."
+            );
         }
     };
 


### PR DESCRIPTION
- Remove hardcoded jeromehardaway login bypass in NextAuth signIn callback. Replace with ADMIN_GITHUB_LOGINS env allowlist (case-insensitive, comma-separated).
- Require explicit ALLOW_ANY_GITHUB_USER=true alongside NODE_ENV=development to enable the dev-mode "any GitHub user signs in" escape hatch. Prevents accidental exposure on non-production deploys where NODE_ENV may not be "production".
- Add src/lib/auth-guards.ts exporting requireAuthSSR / requireAdminSSR. Refactor all four /admin pages (index, blog-images, courses, users) to use the shared helper so every admin route checks session + role consistently.
- Fix silent catch block in profile logout — surface signOut failures via alert and console.error instead of swallowing them; use signOut callbackUrl to let NextAuth handle the redirect.
- Document new env vars (ADMIN_GITHUB_LOGINS, ALLOW_ANY_GITHUB_USER) in .env.example.