### PR TITLE
test(e2e): Skip shopify image cache test when shopify is unconfigured

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -70,6 +70,16 @@ export default defineConfig({
         timeout: process.env.CI ? 30000 : 120000,
         env: {
             NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || "test-secret-for-playwright",
+            // Forward Shopify creds when present so /store can render real
+            // products for e2e tests that depend on them. When unset (most CI
+            // runs), the Shopify-dependent specs skip themselves at runtime.
+            ...(process.env.SHOPIFY_STORE_DOMAIN && {
+                SHOPIFY_STORE_DOMAIN: process.env.SHOPIFY_STORE_DOMAIN,
+            }),
+            ...(process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN && {
+                SHOPIFY_STOREFRONT_ACCESS_TOKEN:
+                    process.env.SHOPIFY_STOREFRONT_ACCESS_TOKEN,
+            }),
         },
     },
 });

--- a/tests/e2e/shopify-image-cache.spec.ts
+++ b/tests/e2e/shopify-image-cache.spec.ts
@@ -15,6 +15,19 @@ test.describe("Shopify Image Caching", () => {
     // Wait for the page to be fully loaded
     await page.waitForLoadState("networkidle");
 
+    // When SHOPIFY_STORE_DOMAIN / SHOPIFY_STOREFRONT_ACCESS_TOKEN aren't set,
+    // /store renders a "Store Configuration Required" fallback with no
+    // products. Skip the test at runtime rather than fail — this test
+    // requires a live Shopify connection to be meaningful.
+    const storeUnconfigured = await page
+      .getByText("Store Configuration Required")
+      .isVisible()
+      .catch(() => false);
+    test.skip(
+      storeUnconfigured,
+      "Shopify not configured — set SHOPIFY_STORE_DOMAIN + SHOPIFY_STOREFRONT_ACCESS_TOKEN to run this test"
+    );
+
     // Find the first product image from Shopify
     const productImage = page.locator('img[src*="cdn.shopify.com"]').first();
     await expect(productImage).toBeVisible();


### PR DESCRIPTION
## Summary
- Runtime-skip the `shopify-image-cache` e2e when `/store` renders the "Store Configuration Required" fallback, so CI no longer fails when `SHOPIFY_STORE_DOMAIN` / `SHOPIFY_STOREFRONT_ACCESS_TOKEN` are unset.
- Forward those two env vars from the parent process to the spawned Playwright web server when present, so local runs (and any future CI with secrets set) exercise the real Shopify path.

## Why
CI run failure:
```
Error: Timed out 5000ms waiting for expect(locator).toBeVisible()
Locator: locator('img[src*="cdn.shopify.com"]').first()
```
Root cause: CI doesn't have Shopify creds → store page renders the config-required fallback → no `cdn.shopify.com` images ever appear → locator times out. The test's intent is to verify the service worker caches Shopify CDN images for offline display — a no-op without real products, so skipping is the correct behaviour.

## What changed
- `tests/e2e/shopify-image-cache.spec.ts` — runtime `test.skip` after the initial `goto` when the fallback panel is visible, with a descriptive message.
- `playwright.config.ts` — conditionally forward `SHOPIFY_STORE_DOMAIN` and `SHOPIFY_STOREFRONT_ACCESS_TOKEN` into `webServer.env` when set on the parent process.

## Known follow-up (not in this PR)
When Shopify **is** configured, the test still has a separate pre-existing race condition: `page.reload()` after `setOffline(true)` returns `ERR_INTERNET_DISCONNECTED` because the service worker has not finished caching the page HTML at that point. Filed as a separate issue — deliberately out of scope here to keep this PR tight.

## Test plan
- [x] CI-mode failure path verified (store page renders fallback → test skips, not fails).
- [x] Type-check clean on changed files.
- [ ] CI green on this branch.
