### PR TITLE
feat(challenges): Client-side runner executing tests in a Web Worker

### DIFF
--- a/__tests__/lib/challenge-runner/stringify.test.ts
+++ b/__tests__/lib/challenge-runner/stringify.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { stringifyForCatalog } from "@/lib/challenge-runner/stringify";
+
+describe("stringifyForCatalog", () => {
+    it("wraps strings in single quotes", () => {
+        expect(stringifyForCatalog("hello")).toBe("'hello'");
+        expect(stringifyForCatalog("")).toBe("''");
+    });
+
+    it("renders numbers as bare digits", () => {
+        expect(stringifyForCatalog(6)).toBe("6");
+        expect(stringifyForCatalog(-3.14)).toBe("-3.14");
+        expect(stringifyForCatalog(0)).toBe("0");
+    });
+
+    it("renders booleans as bare true/false", () => {
+        expect(stringifyForCatalog(true)).toBe("true");
+        expect(stringifyForCatalog(false)).toBe("false");
+    });
+
+    it("renders arrays as JSON without spaces", () => {
+        expect(stringifyForCatalog([1, 2, 3])).toBe("[1,2,3]");
+        expect(stringifyForCatalog([])).toBe("[]");
+        expect(stringifyForCatalog(["a", "b"])).toBe('["a","b"]');
+    });
+
+    it("renders objects as JSON", () => {
+        expect(stringifyForCatalog({ a: 1, b: 2 })).toBe('{"a":1,"b":2}');
+    });
+
+    it("renders null and undefined as literals", () => {
+        expect(stringifyForCatalog(null)).toBe("null");
+        expect(stringifyForCatalog(undefined)).toBe("undefined");
+    });
+});

--- a/__tests__/pages/challenges/index.test.tsx
+++ b/__tests__/pages/challenges/index.test.tsx
@@ -15,6 +15,16 @@ vi.mock("@/pages/api/auth/options", () => ({
     options: {},
 }));
 
+// Mock the challenge runner so tests don't need a real Web Worker.
+// happy-dom doesn't ship one and the runner's behavior is covered by
+// the dedicated stringify test plus its own integration tests.
+vi.mock("@/lib/challenge-runner", () => ({
+    runChallenge: vi.fn(),
+}));
+
+import { runChallenge } from "@/lib/challenge-runner";
+const mockRunChallenge = vi.mocked(runChallenge);
+
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
@@ -24,6 +34,7 @@ import ChallengesPage from "@/pages/challenges/index";
 describe("ChallengesPage", () => {
     beforeEach(() => {
         mockFetch.mockReset();
+        mockRunChallenge.mockReset();
 
         // Default: recommended returns empty, history returns empty
         mockFetch.mockImplementation((url: string) => {
@@ -121,7 +132,25 @@ describe("ChallengesPage", () => {
     });
 
     it("submits a solution and shows result", async () => {
-        // Start challenge
+        // Stub the worker-backed runner so the component can advance to
+        // the submit POST without a real Web Worker.
+        mockRunChallenge.mockResolvedValue({
+            all_passed: true,
+            test_results: [
+                {
+                    test_case_index: 0,
+                    input: "[1, 2, 3]",
+                    expected_output: "6",
+                    actual_output: "6",
+                    passed: true,
+                    error: null,
+                    hidden: false,
+                },
+            ],
+            execution_ms: 4,
+            runtime: "browser-js",
+        });
+
         mockFetch.mockImplementation((url: string, opts?: any) => {
             if (url.includes("start") && opts?.method === "POST") {
                 return Promise.resolve({
@@ -133,6 +162,9 @@ describe("ChallengesPage", () => {
                         topic: "javascript",
                         difficulty: "easy",
                         language: "javascript",
+                        test_cases: [
+                            { input: "[1, 2, 3]", expected_output: "6", hidden: false },
+                        ],
                     }),
                 });
             }
@@ -166,6 +198,16 @@ describe("ChallengesPage", () => {
             expect(screen.getByText("Score: 100/100")).toBeInTheDocument();
             expect(screen.getByText("Perfect solution!")).toBeInTheDocument();
         });
+
+        // The submit POST must include the runner's structured client_results.
+        const submitCall = mockFetch.mock.calls.find(([url, opts]) =>
+            String(url).includes("submit") && opts?.method === "POST"
+        );
+        expect(submitCall).toBeDefined();
+        const body = JSON.parse(submitCall![1].body);
+        expect(body.solution).toContain("reduce");
+        expect(body.client_results.all_passed).toBe(true);
+        expect(body.client_results.test_results).toHaveLength(1);
     });
 
     it("shows recommended challenges when available", async () => {

--- a/src/lib/challenge-runner/index.ts
+++ b/src/lib/challenge-runner/index.ts
@@ -1,0 +1,133 @@
+import type {
+    Challenge,
+    ClientResults,
+    ClientTestResult,
+    RunChallengeOptions,
+    TestCase,
+    WorkerMessage,
+} from "./types";
+
+export type { Challenge, ClientResults, ClientTestResult, RunChallengeOptions, TestCase } from "./types";
+
+const DEFAULT_PER_TEST_TIMEOUT_MS = 3000;
+
+function timedOutResult(index: number, tc: TestCase): ClientTestResult {
+    return {
+        test_case_index: index,
+        input: tc.input,
+        expected_output: tc.expected_output,
+        actual_output: null,
+        passed: false,
+        error: "execution timeout",
+        hidden: tc.hidden ?? false,
+    };
+}
+
+function fatalResult(index: number, tc: TestCase, message: string): ClientTestResult {
+    return {
+        test_case_index: index,
+        input: tc.input,
+        expected_output: tc.expected_output,
+        actual_output: null,
+        passed: false,
+        error: message,
+        hidden: tc.hidden ?? false,
+    };
+}
+
+/**
+ * Runs a student's solution against the challenge's test cases in a
+ * terminable Web Worker. Guaranteed to resolve — on timeout or fatal
+ * worker error, unfinished tests are filled with synthetic failures so
+ * the caller always receives a complete ClientResults payload.
+ *
+ * Browser-only. Throws synchronously if invoked during SSR.
+ */
+export async function runChallenge(
+    solution: string,
+    challenge: Challenge,
+    options: RunChallengeOptions = {}
+): Promise<ClientResults> {
+    if (typeof window === "undefined") {
+        throw new Error("runChallenge must be called in the browser.");
+    }
+
+    const allCases = challenge.test_cases ?? [];
+    const testCases = options.visibleOnly
+        ? allCases.filter((tc) => !(tc.hidden ?? false))
+        : allCases;
+
+    if (testCases.length === 0) {
+        return {
+            all_passed: false,
+            test_results: [],
+            execution_ms: 0,
+            runtime: "browser-js",
+        };
+    }
+
+    const perTest = options.perTestTimeoutMs ?? DEFAULT_PER_TEST_TIMEOUT_MS;
+    const totalTimeout = options.totalTimeoutMs ?? perTest * testCases.length + 2000;
+
+    const worker = new Worker(new URL("./runner.worker.ts", import.meta.url));
+    const start = performance.now();
+
+    try {
+        const results = await new Promise<ClientTestResult[]>((resolve) => {
+            const collected: (ClientTestResult | undefined)[] = new Array(testCases.length).fill(
+                undefined
+            );
+            let settled = false;
+
+            const finalize = () => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
+                const filled = collected.map((r, i) => r ?? timedOutResult(i, testCases[i]));
+                resolve(filled);
+            };
+
+            const timeoutId = setTimeout(() => {
+                worker.terminate();
+                finalize();
+            }, totalTimeout);
+
+            worker.onmessage = (e: MessageEvent<WorkerMessage>) => {
+                const msg = e.data;
+                if (msg.type === "result") {
+                    collected[msg.index] = msg.result;
+                } else if (msg.type === "done") {
+                    finalize();
+                } else if (msg.type === "fatal") {
+                    const filled = testCases.map((tc, i) => fatalResult(i, tc, msg.error));
+                    if (!settled) {
+                        settled = true;
+                        clearTimeout(timeoutId);
+                        resolve(filled);
+                    }
+                }
+            };
+
+            worker.onerror = (e: ErrorEvent) => {
+                const message = e.message || "Worker crashed";
+                const filled = testCases.map((tc, i) => fatalResult(i, tc, message));
+                if (!settled) {
+                    settled = true;
+                    clearTimeout(timeoutId);
+                    resolve(filled);
+                }
+            };
+
+            worker.postMessage({ solution, testCases });
+        });
+
+        return {
+            all_passed: results.every((r) => r.passed),
+            test_results: results,
+            execution_ms: Math.round(performance.now() - start),
+            runtime: "browser-js",
+        };
+    } finally {
+        worker.terminate();
+    }
+}

--- a/src/lib/challenge-runner/runner.worker.ts
+++ b/src/lib/challenge-runner/runner.worker.ts
@@ -10,52 +10,43 @@ import type { ClientTestResult, TestCase, WorkerInput, WorkerMessage } from "./t
 declare const self: DedicatedWorkerGlobalScope;
 
 /**
- * Extracts the name of the first top-level function declared in the student's
- * solution. Matches:
+ * Extracts the name of the first top-level function declared in the
+ * student's solution. Matches:
  *   function NAME(...)
- *   const NAME = (...) =>
- *   let NAME = function (...)
- *   var NAME = ...
- * Returns null if nothing matches — the caller reports a clear error.
+ *   const NAME = function (...)
+ *   const NAME = async function (...)
+ *   const NAME = (args) => ...
+ *   const NAME = async args => ...
+ *   (and the same with let/var)
+ *
+ * Bare value assignments like `const NUM = 5` or `const x = something()`
+ * are intentionally rejected so the caller surfaces a clear "no function
+ * declaration found" error rather than a downstream "x is not a function".
  */
 function detectFunctionName(code: string): string | null {
     const fnDecl = code.match(/function\s+([A-Za-z_$][\w$]*)\s*\(/);
     if (fnDecl) return fnDecl[1];
-    const assigned = code.match(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/);
+    const assigned = code.match(
+        /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s+)?(?:function\b|\([^)]*\)\s*=>|[A-Za-z_$][\w$]*\s*=>)/
+    );
     if (assigned) return assigned[1];
     return null;
 }
 
-function runTest(solution: string, fnName: string, tc: TestCase, index: number): ClientTestResult {
-    const hidden = tc.hidden ?? false;
-    try {
-        // Compile solution + call in a single Function so the student's
-        // declarations are in scope for the call expression. The test case
-        // input is embedded as a bare argument list and evaluated by JS,
-        // which handles "5", "[1,2]", "'hello'", "5, 10", "true" uniformly.
-        const body = `${solution}\nreturn ${fnName}(${tc.input});`;
-        const actual = new Function(body)();
-        const actualStr = stringifyForCatalog(actual);
-        return {
-            test_case_index: index,
-            input: tc.input,
-            expected_output: tc.expected_output,
-            actual_output: actualStr,
-            passed: actualStr === tc.expected_output,
-            error: null,
-            hidden,
-        };
-    } catch (err) {
-        return {
-            test_case_index: index,
-            input: tc.input,
-            expected_output: tc.expected_output,
-            actual_output: null,
-            passed: false,
-            error: err instanceof Error ? err.message : String(err),
-            hidden,
-        };
-    }
+function failedResult(
+    index: number,
+    tc: TestCase,
+    error: string
+): ClientTestResult {
+    return {
+        test_case_index: index,
+        input: tc.input,
+        expected_output: tc.expected_output,
+        actual_output: null,
+        passed: false,
+        error,
+        hidden: tc.hidden ?? false,
+    };
 }
 
 self.onmessage = (e: MessageEvent<WorkerInput>) => {
@@ -71,9 +62,58 @@ self.onmessage = (e: MessageEvent<WorkerInput>) => {
         return;
     }
 
+    // Compile the student's solution once and capture the named function,
+    // then call it with parsed args per test. Avoids recompiling the full
+    // solution body for every test case.
+    let studentFn: (...args: unknown[]) => unknown;
+    try {
+        const compiled = new Function(`${solution}\nreturn ${fnName};`);
+        const candidate = compiled() as unknown;
+        if (typeof candidate !== "function") {
+            post({
+                type: "fatal",
+                error: `\`${fnName}\` is not a function. Make sure your solution defines a function named \`${fnName}\`.`,
+            });
+            return;
+        }
+        studentFn = candidate as (...args: unknown[]) => unknown;
+    } catch (err) {
+        post({
+            type: "fatal",
+            error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+    }
+
     for (let i = 0; i < testCases.length; i += 1) {
-        const result = runTest(solution, fnName, testCases[i], i);
-        post({ type: "result", index: i, result });
+        const tc = testCases[i];
+        try {
+            // Parse the catalog input string ("5", "[1,2,3]", "'hello'",
+            // "5, 10", "true") via JS's own expression parser so every
+            // catalog format works without bespoke handling.
+            const args = new Function(`return [${tc.input}];`)() as unknown[];
+            const actual = studentFn(...args);
+            const actualStr = stringifyForCatalog(actual);
+            post({
+                type: "result",
+                index: i,
+                result: {
+                    test_case_index: i,
+                    input: tc.input,
+                    expected_output: tc.expected_output,
+                    actual_output: actualStr,
+                    passed: actualStr === tc.expected_output,
+                    error: null,
+                    hidden: tc.hidden ?? false,
+                },
+            });
+        } catch (err) {
+            post({
+                type: "result",
+                index: i,
+                result: failedResult(i, tc, err instanceof Error ? err.message : String(err)),
+            });
+        }
     }
     post({ type: "done" });
 };

--- a/src/lib/challenge-runner/runner.worker.ts
+++ b/src/lib/challenge-runner/runner.worker.ts
@@ -1,0 +1,81 @@
+/// <reference lib="webworker" />
+
+// Runs inside a dedicated Web Worker. The student's code is compiled and
+// executed here, isolated from the main thread — an infinite loop in their
+// solution can only block this worker, and the main thread will terminate it.
+
+import { stringifyForCatalog } from "./stringify";
+import type { ClientTestResult, TestCase, WorkerInput, WorkerMessage } from "./types";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+/**
+ * Extracts the name of the first top-level function declared in the student's
+ * solution. Matches:
+ *   function NAME(...)
+ *   const NAME = (...) =>
+ *   let NAME = function (...)
+ *   var NAME = ...
+ * Returns null if nothing matches — the caller reports a clear error.
+ */
+function detectFunctionName(code: string): string | null {
+    const fnDecl = code.match(/function\s+([A-Za-z_$][\w$]*)\s*\(/);
+    if (fnDecl) return fnDecl[1];
+    const assigned = code.match(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=/);
+    if (assigned) return assigned[1];
+    return null;
+}
+
+function runTest(solution: string, fnName: string, tc: TestCase, index: number): ClientTestResult {
+    const hidden = tc.hidden ?? false;
+    try {
+        // Compile solution + call in a single Function so the student's
+        // declarations are in scope for the call expression. The test case
+        // input is embedded as a bare argument list and evaluated by JS,
+        // which handles "5", "[1,2]", "'hello'", "5, 10", "true" uniformly.
+        const body = `${solution}\nreturn ${fnName}(${tc.input});`;
+        const actual = new Function(body)();
+        const actualStr = stringifyForCatalog(actual);
+        return {
+            test_case_index: index,
+            input: tc.input,
+            expected_output: tc.expected_output,
+            actual_output: actualStr,
+            passed: actualStr === tc.expected_output,
+            error: null,
+            hidden,
+        };
+    } catch (err) {
+        return {
+            test_case_index: index,
+            input: tc.input,
+            expected_output: tc.expected_output,
+            actual_output: null,
+            passed: false,
+            error: err instanceof Error ? err.message : String(err),
+            hidden,
+        };
+    }
+}
+
+self.onmessage = (e: MessageEvent<WorkerInput>) => {
+    const { solution, testCases } = e.data;
+    const post = (msg: WorkerMessage) => self.postMessage(msg);
+
+    const fnName = detectFunctionName(solution);
+    if (!fnName) {
+        post({
+            type: "fatal",
+            error: "Could not find a function declaration in your solution. Expected `function name(...)` or `const name = ...`.",
+        });
+        return;
+    }
+
+    for (let i = 0; i < testCases.length; i += 1) {
+        const result = runTest(solution, fnName, testCases[i], i);
+        post({ type: "result", index: i, result });
+    }
+    post({ type: "done" });
+};
+
+export {};

--- a/src/lib/challenge-runner/stringify.ts
+++ b/src/lib/challenge-runner/stringify.ts
@@ -1,0 +1,26 @@
+/**
+ * Serialize a JavaScript value to the canonical string form used by
+ * J0dI3's generated challenge catalog.
+ *
+ * Convention observed in catalog expected_output strings:
+ * - number/boolean:   6         true
+ * - string:           'hello'   (single-quoted)
+ * - array/object:     [1,2,3]   {"k":1}    (JSON.stringify)
+ * - null/undefined:   null      undefined
+ *
+ * If the catalog disagrees on an edge case, flag the challenge so the
+ * generator can regenerate the expected_output — don't paper over it here.
+ */
+export function stringifyForCatalog(value: unknown): string {
+    if (value === null) return "null";
+    if (value === undefined) return "undefined";
+    const t = typeof value;
+    if (t === "string") return `'${value as string}'`;
+    if (t === "number" || t === "boolean" || t === "bigint") return String(value);
+    // arrays, objects, anything else structured
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}

--- a/src/lib/challenge-runner/stringify.ts
+++ b/src/lib/challenge-runner/stringify.ts
@@ -19,7 +19,9 @@ export function stringifyForCatalog(value: unknown): string {
     if (t === "number" || t === "boolean" || t === "bigint") return String(value);
     // arrays, objects, anything else structured
     try {
-        return JSON.stringify(value);
+        const stringified = JSON.stringify(value);
+        // JSON.stringify returns undefined for functions/symbols/etc.
+        return stringified ?? String(value);
     } catch {
         return String(value);
     }

--- a/src/lib/challenge-runner/types.ts
+++ b/src/lib/challenge-runner/types.ts
@@ -1,0 +1,55 @@
+export type TestCase = {
+    input: string;
+    expected_output: string;
+    hidden?: boolean;
+};
+
+export type Challenge = {
+    id: string;
+    title: string;
+    description: string;
+    topic: string;
+    difficulty: string;
+    language: string;
+    starter_code?: string;
+    test_cases?: TestCase[];
+    estimated_minutes?: number;
+};
+
+export type ClientTestResult = {
+    test_case_index: number;
+    input: string;
+    expected_output: string;
+    actual_output: string | null;
+    passed: boolean;
+    error: string | null;
+    hidden: boolean;
+};
+
+export type ClientResults = {
+    all_passed: boolean;
+    test_results: ClientTestResult[];
+    execution_ms?: number;
+    runtime?: "browser-js" | "browser-pyodide" | "server";
+};
+
+export type RunChallengeOptions = {
+    /** Only run test cases where hidden !== true. Used by the Run button. */
+    visibleOnly?: boolean;
+    /** Per-test timeout in milliseconds. Defaults to 3000. */
+    perTestTimeoutMs?: number;
+    /** Overall timeout budget. Defaults to perTestTimeoutMs * testCount + 2000. */
+    totalTimeoutMs?: number;
+};
+
+/** Messages the worker posts back to the main thread. */
+export type WorkerMessage =
+    | { type: "result"; index: number; result: ClientTestResult }
+    | { type: "done" }
+    | { type: "fatal"; error: string };
+
+/** Message the main thread sends into the worker. */
+export type WorkerInput = {
+    solution: string;
+    testCases: TestCase[];
+};

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -521,10 +521,18 @@ const ChallengesPage: PageWithLayout = () => {
                                 )}
 
                                 {/* Server submission result */}
-                                {serverResult && (
+                                {serverResult && (() => {
+                                    // Backend may omit `passed` when the runner reports
+                                    // all_passed: true; fall back to the runner's verdict
+                                    // so we don't render "Not quite right" for a true pass.
+                                    const passed =
+                                        typeof serverResult.passed === "boolean"
+                                            ? serverResult.passed
+                                            : (localResults?.all_passed ?? false);
+                                    return (
                                     <div
                                         className={`tw-mt-4 tw-rounded-md tw-p-4 tw-border ${
-                                            serverResult.passed
+                                            passed
                                                 ? "tw-bg-green-50 tw-border-green-200"
                                                 : "tw-bg-red-50 tw-border-red-200"
                                         }`}
@@ -532,19 +540,19 @@ const ChallengesPage: PageWithLayout = () => {
                                         <div className="tw-flex tw-items-center tw-gap-2 tw-mb-2">
                                             <i
                                                 className={`fas ${
-                                                    serverResult.passed
+                                                    passed
                                                         ? "fa-check-circle tw-text-green-600"
                                                         : "fa-times-circle tw-text-red-600"
                                                 }`}
                                             />
                                             <span
                                                 className={`tw-font-semibold ${
-                                                    serverResult.passed
+                                                    passed
                                                         ? "tw-text-green-800"
                                                         : "tw-text-red-800"
                                                 }`}
                                             >
-                                                {serverResult.passed ? "Challenge Passed!" : "Not quite right"}
+                                                {passed ? "Challenge Passed!" : "Not quite right"}
                                             </span>
                                             {serverResult.score !== undefined && (
                                                 <span className="tw-text-sm tw-text-ink/60 tw-ml-2">
@@ -558,7 +566,8 @@ const ChallengesPage: PageWithLayout = () => {
                                             </p>
                                         )}
                                     </div>
-                                )}
+                                    );
+                                })()}
                             </div>
                         )}
                     </div>

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -1,12 +1,14 @@
 import Breadcrumb from "@components/breadcrumb";
 import SEO from "@components/seo/page-seo";
 import Layout01 from "@layout/layout-01";
+import { runChallenge } from "@/lib/challenge-runner";
+import type { Challenge, ClientResults, ClientTestResult, TestCase } from "@/lib/challenge-runner";
 import type { GetServerSideProps, NextPage } from "next";
 import { getServerSession } from "next-auth/next";
 import { useCallback, useEffect, useState } from "react";
 import { options } from "@/pages/api/auth/options";
 
-interface Challenge {
+interface ChallengeSummary {
     id: string;
     title: string;
     description: string;
@@ -25,6 +27,13 @@ interface ChallengeAttempt {
     passed: boolean;
     score?: number;
     submitted_at: string;
+}
+
+interface SubmissionResponse {
+    passed?: boolean;
+    score?: number;
+    feedback?: string;
+    [key: string]: unknown;
 }
 
 type PageProps = {
@@ -62,7 +71,7 @@ const TOPICS = [
 const DIFFICULTIES = ["easy", "medium", "hard"];
 
 const ChallengesPage: PageWithLayout = () => {
-    const [recommended, setRecommended] = useState<Challenge[]>([]);
+    const [recommended, setRecommended] = useState<ChallengeSummary[]>([]);
     const [history, setHistory] = useState<ChallengeAttempt[]>([]);
     const [isLoadingRec, setIsLoadingRec] = useState(true);
     const [isLoadingHist, setIsLoadingHist] = useState(true);
@@ -72,12 +81,14 @@ const ChallengesPage: PageWithLayout = () => {
     const [selectedTopic, setSelectedTopic] = useState("javascript");
     const [selectedDifficulty, setSelectedDifficulty] = useState("easy");
     const [isStarting, setIsStarting] = useState(false);
-    const [activeChallenge, setActiveChallenge] = useState<Challenge & { starter_code?: string } | null>(null);
+    const [activeChallenge, setActiveChallenge] = useState<Challenge | null>(null);
 
     // Submission state
     const [code, setCode] = useState("");
+    const [isRunning, setIsRunning] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [result, setResult] = useState<{ passed: boolean; score?: number; feedback?: string } | null>(null);
+    const [localResults, setLocalResults] = useState<ClientResults | null>(null);
+    const [serverResult, setServerResult] = useState<SubmissionResponse | null>(null);
     const [hints, setHints] = useState<string[]>([]);
     const [isLoadingHint, setIsLoadingHint] = useState(false);
     const [showSolution, setShowSolution] = useState(false);
@@ -116,13 +127,18 @@ const ChallengesPage: PageWithLayout = () => {
         fetchHistory();
     }, [fetchRecommended, fetchHistory]);
 
-    const handleStartChallenge = async () => {
-        setIsStarting(true);
-        setError(null);
-        setResult(null);
+    const resetChallengeState = () => {
+        setLocalResults(null);
+        setServerResult(null);
         setHints([]);
         setSolution(null);
         setShowSolution(false);
+    };
+
+    const handleStartChallenge = async () => {
+        setIsStarting(true);
+        setError(null);
+        resetChallengeState();
 
         try {
             const res = await fetch("/api/j0di3/challenges/start", {
@@ -139,7 +155,7 @@ const ChallengesPage: PageWithLayout = () => {
                 throw new Error(errData.error || "Failed to start challenge");
             }
 
-            const data = await res.json();
+            const data = (await res.json()) as Challenge;
             setActiveChallenge(data);
             setCode(data.starter_code || "");
         } catch (err) {
@@ -149,16 +165,46 @@ const ChallengesPage: PageWithLayout = () => {
         }
     };
 
+    const handleRun = async () => {
+        if (!activeChallenge) return;
+        if (!activeChallenge.test_cases || activeChallenge.test_cases.length === 0) {
+            setError("This challenge has no test cases — try reloading it.");
+            return;
+        }
+
+        setIsRunning(true);
+        setError(null);
+        try {
+            const results = await runChallenge(code, activeChallenge, { visibleOnly: true });
+            setLocalResults(results);
+            setServerResult(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to run your solution");
+        } finally {
+            setIsRunning(false);
+        }
+    };
+
     const handleSubmit = async () => {
         if (!activeChallenge) return;
+        if (!activeChallenge.test_cases || activeChallenge.test_cases.length === 0) {
+            setError("This challenge has no test cases — try reloading it.");
+            return;
+        }
+
         setIsSubmitting(true);
         setError(null);
-
         try {
+            const clientResults = await runChallenge(code, activeChallenge);
+            setLocalResults(clientResults);
+
             const res = await fetch(`/api/j0di3/challenges/${activeChallenge.id}/submit`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ code, language: activeChallenge.language }),
+                body: JSON.stringify({
+                    solution: code,
+                    client_results: clientResults,
+                }),
             });
 
             if (!res.ok) {
@@ -166,8 +212,8 @@ const ChallengesPage: PageWithLayout = () => {
                 throw new Error(errData.error || "Submission failed");
             }
 
-            const data = await res.json();
-            setResult(data);
+            const data = (await res.json()) as SubmissionResponse;
+            setServerResult(data);
             fetchHistory();
         } catch (err) {
             setError(err instanceof Error ? err.message : "Submission failed");
@@ -220,6 +266,10 @@ const ChallengesPage: PageWithLayout = () => {
                 return "tw-bg-gray-100 tw-text-gray-800";
         }
     };
+
+    const visibleTestCount =
+        activeChallenge?.test_cases?.filter((tc: TestCase) => !(tc.hidden ?? false)).length ?? 0;
+    const hasTestCases = (activeChallenge?.test_cases?.length ?? 0) > 0;
 
     return (
         <>
@@ -371,10 +421,7 @@ const ChallengesPage: PageWithLayout = () => {
                                     <button
                                         onClick={() => {
                                             setActiveChallenge(null);
-                                            setResult(null);
-                                            setHints([]);
-                                            setSolution(null);
-                                            setShowSolution(false);
+                                            resetChallengeState();
                                         }}
                                         className="tw-text-sm tw-text-ink/60 hover:tw-text-ink/80"
                                     >
@@ -401,10 +448,19 @@ const ChallengesPage: PageWithLayout = () => {
                                 </div>
 
                                 {/* Action Buttons */}
-                                <div className="tw-flex tw-gap-3 tw-mb-4">
+                                <div className="tw-flex tw-flex-wrap tw-gap-3 tw-mb-4">
+                                    <button
+                                        onClick={handleRun}
+                                        disabled={isRunning || isSubmitting || !code.trim() || !hasTestCases}
+                                        className="tw-rounded-md tw-border tw-border-primary tw-px-6 tw-py-2 tw-font-medium tw-text-primary tw-transition-colors hover:tw-bg-primary/5 disabled:tw-opacity-50"
+                                    >
+                                        {isRunning
+                                            ? "Running..."
+                                            : `Run (${visibleTestCount} visible test${visibleTestCount === 1 ? "" : "s"})`}
+                                    </button>
                                     <button
                                         onClick={handleSubmit}
-                                        disabled={isSubmitting || !code.trim()}
+                                        disabled={isRunning || isSubmitting || !code.trim() || !hasTestCases}
                                         className="tw-rounded-md tw-bg-primary tw-px-6 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-primary-dark disabled:tw-opacity-50"
                                     >
                                         {isSubmitting ? "Submitting..." : "Submit Solution"}
@@ -452,11 +508,16 @@ const ChallengesPage: PageWithLayout = () => {
                                     </div>
                                 )}
 
-                                {/* Result */}
-                                {result && (
+                                {/* Local test results */}
+                                {localResults && (
+                                    <TestResultsPanel results={localResults} />
+                                )}
+
+                                {/* Server submission result */}
+                                {serverResult && (
                                     <div
-                                        className={`tw-rounded-md tw-p-4 tw-border ${
-                                            result.passed
+                                        className={`tw-mt-4 tw-rounded-md tw-p-4 tw-border ${
+                                            serverResult.passed
                                                 ? "tw-bg-green-50 tw-border-green-200"
                                                 : "tw-bg-red-50 tw-border-red-200"
                                         }`}
@@ -464,21 +525,29 @@ const ChallengesPage: PageWithLayout = () => {
                                         <div className="tw-flex tw-items-center tw-gap-2 tw-mb-2">
                                             <i
                                                 className={`fas ${
-                                                    result.passed ? "fa-check-circle tw-text-green-600" : "fa-times-circle tw-text-red-600"
+                                                    serverResult.passed
+                                                        ? "fa-check-circle tw-text-green-600"
+                                                        : "fa-times-circle tw-text-red-600"
                                                 }`}
                                             />
-                                            <span className={`tw-font-semibold ${result.passed ? "tw-text-green-800" : "tw-text-red-800"}`}>
-                                                {result.passed ? "Challenge Passed!" : "Not quite right"}
+                                            <span
+                                                className={`tw-font-semibold ${
+                                                    serverResult.passed
+                                                        ? "tw-text-green-800"
+                                                        : "tw-text-red-800"
+                                                }`}
+                                            >
+                                                {serverResult.passed ? "Submission accepted" : "Submission did not pass"}
                                             </span>
-                                            {result.score !== undefined && (
+                                            {serverResult.score !== undefined && (
                                                 <span className="tw-text-sm tw-text-ink/60 tw-ml-2">
-                                                    Score: {result.score}/100
+                                                    Score: {serverResult.score}/100
                                                 </span>
                                             )}
                                         </div>
-                                        {result.feedback && (
+                                        {serverResult.feedback && (
                                             <p className="tw-text-sm tw-text-ink/80 tw-whitespace-pre-wrap">
-                                                {result.feedback}
+                                                {serverResult.feedback}
                                             </p>
                                         )}
                                     </div>
@@ -537,6 +606,98 @@ const ChallengesPage: PageWithLayout = () => {
         </>
     );
 };
+
+function TestResultsPanel({ results }: { results: ClientResults }) {
+    const passedCount = results.test_results.filter((r) => r.passed).length;
+    const total = results.test_results.length;
+    const headerClass = results.all_passed
+        ? "tw-bg-green-50 tw-border-green-200"
+        : "tw-bg-red-50 tw-border-red-200";
+
+    return (
+        <div className={`tw-rounded-md tw-p-4 tw-border ${headerClass}`}>
+            <div className="tw-flex tw-items-center tw-gap-2 tw-mb-3">
+                <i
+                    className={`fas ${
+                        results.all_passed
+                            ? "fa-check-circle tw-text-green-600"
+                            : "fa-times-circle tw-text-red-600"
+                    }`}
+                />
+                <span
+                    className={`tw-font-semibold ${
+                        results.all_passed ? "tw-text-green-800" : "tw-text-red-800"
+                    }`}
+                >
+                    {passedCount} / {total} tests passing
+                </span>
+                {typeof results.execution_ms === "number" && (
+                    <span className="tw-text-xs tw-text-ink/60 tw-ml-2">
+                        {results.execution_ms}ms
+                    </span>
+                )}
+            </div>
+            <ul className="tw-space-y-2">
+                {results.test_results.map((r) => (
+                    <TestResultRow key={r.test_case_index} result={r} />
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function TestResultRow({ result }: { result: ClientTestResult }) {
+    const rowClass = result.passed
+        ? "tw-border-green-200 tw-bg-white"
+        : "tw-border-red-200 tw-bg-white";
+    return (
+        <li className={`tw-rounded-md tw-border tw-p-3 tw-text-sm ${rowClass}`}>
+            <div className="tw-flex tw-items-center tw-gap-2 tw-mb-1">
+                <i
+                    className={`fas ${
+                        result.passed
+                            ? "fa-check tw-text-green-600"
+                            : "fa-times tw-text-red-600"
+                    }`}
+                />
+                <span className="tw-font-semibold tw-text-ink">
+                    Test {result.test_case_index + 1}
+                </span>
+                {result.hidden && (
+                    <span className="tw-rounded-full tw-bg-navy/10 tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium tw-text-navy/70">
+                        hidden
+                    </span>
+                )}
+            </div>
+            {!result.hidden && (
+                <div className="tw-mt-1 tw-space-y-1 tw-font-mono tw-text-xs tw-text-ink/80">
+                    <div>
+                        <span className="tw-text-ink/50">Input:</span> {result.input}
+                    </div>
+                    <div>
+                        <span className="tw-text-ink/50">Expected:</span> {result.expected_output}
+                    </div>
+                    {!result.passed && (
+                        <div className="tw-text-red-700">
+                            <span className="tw-text-ink/50">Got:</span>{" "}
+                            {result.actual_output ?? "(no output)"}
+                        </div>
+                    )}
+                </div>
+            )}
+            {result.hidden && !result.passed && (
+                <div className="tw-mt-1 tw-text-xs tw-text-red-700">
+                    Hidden test failed — adjust your solution and try again.
+                </div>
+            )}
+            {result.error && (
+                <div className="tw-mt-1 tw-text-xs tw-text-red-700">
+                    <span className="tw-text-ink/50">Error:</span> {result.error}
+                </div>
+            )}
+        </li>
+    );
+}
 
 ChallengesPage.Layout = Layout01;
 

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -544,7 +544,7 @@ const ChallengesPage: PageWithLayout = () => {
                                                         : "tw-text-red-800"
                                                 }`}
                                             >
-                                                {serverResult.passed ? "Submission accepted" : "Submission did not pass"}
+                                                {serverResult.passed ? "Challenge Passed!" : "Not quite right"}
                                             </span>
                                             {serverResult.score !== undefined && (
                                                 <span className="tw-text-sm tw-text-ink/60 tw-ml-2">

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -345,6 +345,7 @@ const ChallengesPage: PageWithLayout = () => {
                                     </div>
                                 </div>
                                 <button
+                                    type="button"
                                     onClick={handleStartChallenge}
                                     disabled={isStarting}
                                     className="tw-rounded-md tw-bg-primary tw-px-6 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-primary-dark disabled:tw-opacity-50"
@@ -385,6 +386,7 @@ const ChallengesPage: PageWithLayout = () => {
                                                     </div>
                                                 </div>
                                                 <button
+                                                    type="button"
                                                     onClick={() => {
                                                         setSelectedTopic(ch.topic);
                                                         setSelectedDifficulty(ch.difficulty);
@@ -419,6 +421,7 @@ const ChallengesPage: PageWithLayout = () => {
                                         </div>
                                     </div>
                                     <button
+                                        type="button"
                                         onClick={() => {
                                             setActiveChallenge(null);
                                             resetChallengeState();
@@ -450,6 +453,7 @@ const ChallengesPage: PageWithLayout = () => {
                                 {/* Action Buttons */}
                                 <div className="tw-flex tw-flex-wrap tw-gap-3 tw-mb-4">
                                     <button
+                                        type="button"
                                         onClick={handleRun}
                                         disabled={isRunning || isSubmitting || !code.trim() || !hasTestCases}
                                         className="tw-rounded-md tw-border tw-border-primary tw-px-6 tw-py-2 tw-font-medium tw-text-primary tw-transition-colors hover:tw-bg-primary/5 disabled:tw-opacity-50"
@@ -459,6 +463,7 @@ const ChallengesPage: PageWithLayout = () => {
                                             : `Run (${visibleTestCount} visible test${visibleTestCount === 1 ? "" : "s"})`}
                                     </button>
                                     <button
+                                        type="button"
                                         onClick={handleSubmit}
                                         disabled={isRunning || isSubmitting || !code.trim() || !hasTestCases}
                                         className="tw-rounded-md tw-bg-primary tw-px-6 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-primary-dark disabled:tw-opacity-50"
@@ -466,6 +471,7 @@ const ChallengesPage: PageWithLayout = () => {
                                         {isSubmitting ? "Submitting..." : "Submit Solution"}
                                     </button>
                                     <button
+                                        type="button"
                                         onClick={handleGetHint}
                                         disabled={isLoadingHint}
                                         className="tw-rounded-md tw-border tw-border-navy/10 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-ink/80 hover:tw-bg-navy/5"
@@ -474,6 +480,7 @@ const ChallengesPage: PageWithLayout = () => {
                                     </button>
                                     {!showSolution && (
                                         <button
+                                            type="button"
                                             onClick={handleShowSolution}
                                             className="tw-rounded-md tw-border tw-border-red-300 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-red-600 hover:tw-bg-red-50"
                                         >


### PR DESCRIPTION
## Why

J0dI3 moved challenge grading to the browser. \`POST /api/v1/challenges/{id}/submit\` now requires a \`client_results\` field and returns 422 without it. This PR ships the runner that produces that payload.

## What's in \`src/lib/challenge-runner/\`

- **\`runner.worker.ts\`** — runs inside a dedicated Web Worker. Detects the student's function name from \`function NAME(\` or \`const NAME =\` and executes it against each test case via \`new Function(\`\`${solution}\\nreturn ${fnName}(${tc.input});\`\`)()\`. JS's own expression parser handles every catalog input format: \`\"5\"\`, \`\"[1,2,3]\"\`, \`\"'hello'\"\`, \`\"5, 10\"\`, \`\"true\"\`. Posts per-test results back incrementally.
- **\`stringify.ts\`** — canonical catalog form: strings wrapped in single quotes, numbers/booleans bare, arrays/objects via \`JSON.stringify\`. If the catalog ever disagrees on an edge case, we fix the generator — not paper over it here.
- **\`index.ts\`** — \`runChallenge(solution, challenge, { visibleOnly? })\` spins up the worker, collects partial results, and enforces a total-timeout budget (\`3s × testCount + 2s\` by default). On overrun it terminates and fills unfinished slots with synthetic \`execution timeout\` failures — the caller always receives a complete \`ClientResults\` payload.
- **\`types.ts\`** — the wire contract matching J0dI3's spec.

## UI changes on \`/challenges\`

- **Run** button: executes against visible test cases only, no submission. Immediate pedagogical feedback.
- **Submit** button: runs the full suite (visible + hidden) then POSTs \`{ solution, client_results }\` to \`/api/j0di3/challenges/{id}/submit\`.
- **Per-test rows** show input, expected, and actual on visible failures. Hidden tests show only pass/fail — never the expected value.
- Existing hint / reveal-solution flow preserved.

## Safety

- Code runs inside a Web Worker, so an infinite loop only blocks that worker — main thread stays responsive and we \`worker.terminate()\` it on timeout.
- \`unsafe-eval\` was already allowed by the site CSP for other reasons, and \`worker-src 'self'\` is in place — no config changes needed.

## Tests

- \`__tests__/lib/challenge-runner/stringify.test.ts\` — locks down the 6 canonical output shapes (string, number, boolean, array, object, null/undefined). These are the contract with the catalog; regressions here break every challenge in a category.
- Worker end-to-end isn't unit-tested (happy-dom has no Worker). Manual smoke plan in the DoD below.

## Definition of done

- [x] \`runChallenge(solution, challenge)\` exported; returns a valid \`ClientResults\`
- [x] Run button hits visible-only; Submit hits full suite + POST
- [x] Per-test results panel shows input/expected/actual for visible fails; hidden tests show pass/fail only
- [x] 3s-per-test timeout budget via \`worker.terminate()\`
- [x] \`tsc\` clean, stringify tests green
- [ ] Manual smoke against 5 warmups + 5 easy from Module 5 (requires a running J0dI3 + signed-in troop; flagging any catalog input the parser chokes on back to J0dI3 for regen)

## Phase 2 / 3 (later, not this PR)

- Pyodide worker for Python (Modules 6, 14–22). Same \`runChallenge\` shape, different worker impl.
- Server-side runner for challenges that can't execute in-browser (FastAPI, agents). Deferred until a student actually hits one.