### PR TITLE
feat(j0di3): Reps tray, catalog browse, deep links, progress, job matches

### DIFF
--- a/src/components/jobs/JobMatch.tsx
+++ b/src/components/jobs/JobMatch.tsx
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface MatchedJob {
+    title: string;
+    company: string;
+    fit_pct: number;
+    matched_skills: string[];
+    gap_skills: string[];
+    url: string;
+}
+
+interface MatchResponse {
+    matched_jobs?: MatchedJob[];
+    [key: string]: unknown;
+}
+
+export default function JobMatch() {
+    const [jobs, setJobs] = useState<MatchedJob[] | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchMatches = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/j0di3/jobs/match", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            });
+            if (!res.ok) {
+                const errData = await res.json().catch(() => ({}));
+                throw new Error(errData.error || "Failed to load matches");
+            }
+            const body = (await res.json()) as MatchResponse;
+            const list = Array.isArray(body.matched_jobs) ? body.matched_jobs : [];
+            // Backend returns descending by fit_pct, but sort defensively
+            // in case ordering ever changes upstream.
+            const sorted = [...list].sort((a, b) => (b.fit_pct ?? 0) - (a.fit_pct ?? 0));
+            setJobs(sorted);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load matches");
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchMatches();
+    }, [fetchMatches]);
+
+    return (
+        <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-sm">
+            <div className="tw-flex tw-items-center tw-justify-between tw-mb-4">
+                <div>
+                    <h2 className="tw-text-xl tw-font-bold tw-text-ink">Your Matches</h2>
+                    <p className="tw-text-sm tw-text-navy/60">
+                        Roles ranked by fit against the skills on your resume.
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={fetchMatches}
+                    disabled={isLoading}
+                    className="tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-1.5 tw-text-sm tw-font-medium tw-text-ink/80 hover:tw-bg-navy/5 disabled:tw-opacity-50"
+                >
+                    <i className="fas fa-sync tw-mr-2" />
+                    {isLoading ? "Refreshing..." : "Refresh"}
+                </button>
+            </div>
+
+            {error && (
+                <div className="tw-mb-4 tw-rounded-md tw-border tw-border-red-200 tw-bg-red-50 tw-p-3 tw-text-sm tw-text-red-700">
+                    {error}
+                </div>
+            )}
+
+            {isLoading && jobs === null && (
+                <div className="tw-rounded-md tw-border tw-border-navy/10 tw-p-8 tw-text-center tw-text-navy/60">
+                    Scoring matches...
+                </div>
+            )}
+
+            {jobs !== null && jobs.length === 0 && !isLoading && (
+                <div className="tw-rounded-md tw-border tw-border-navy/10 tw-p-8 tw-text-center tw-text-navy/60">
+                    No matches yet. Update your resume from the Resume Scorer tab and try again.
+                </div>
+            )}
+
+            {jobs !== null && jobs.length > 0 && (
+                <ul className="tw-space-y-4">
+                    {jobs.map((job, idx) => (
+                        <JobMatchCard key={`${job.url}-${idx}`} job={job} />
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+function JobMatchCard({ job }: { job: MatchedJob }) {
+    const fitColor = (pct: number) => {
+        if (pct >= 80) return "tw-bg-green-100 tw-text-green-800";
+        if (pct >= 60) return "tw-bg-yellow-100 tw-text-yellow-800";
+        return "tw-bg-red-100 tw-text-red-800";
+    };
+    return (
+        <li className="tw-rounded-md tw-border tw-border-navy/10 tw-p-4 tw-transition-shadow hover:tw-shadow-sm">
+            <div className="tw-flex tw-items-start tw-justify-between tw-gap-3 tw-mb-3">
+                <div className="tw-min-w-0">
+                    <a
+                        href={job.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="tw-text-base tw-font-semibold tw-text-ink hover:tw-text-primary"
+                    >
+                        {job.title}
+                    </a>
+                    <p className="tw-text-sm tw-text-ink/60 tw-mt-0.5">{job.company}</p>
+                </div>
+                <span
+                    className={`tw-shrink-0 tw-rounded-full tw-px-3 tw-py-1 tw-text-xs tw-font-bold ${fitColor(
+                        job.fit_pct
+                    )}`}
+                >
+                    {Math.round(job.fit_pct)}% fit
+                </span>
+            </div>
+
+            {job.matched_skills.length > 0 && (
+                <div className="tw-mb-2">
+                    <div className="tw-text-[10px] tw-font-mono tw-uppercase tw-tracking-widest tw-text-navy/50 tw-mb-1">
+                        Matched skills
+                    </div>
+                    <div className="tw-flex tw-flex-wrap tw-gap-1.5">
+                        {job.matched_skills.map((s) => (
+                            <span
+                                key={`m-${s}`}
+                                className="tw-rounded-full tw-bg-green-100 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-text-green-800"
+                            >
+                                {s}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {job.gap_skills.length > 0 && (
+                <div>
+                    <div className="tw-text-[10px] tw-font-mono tw-uppercase tw-tracking-widest tw-text-navy/50 tw-mb-1">
+                        Skill gaps
+                    </div>
+                    <div className="tw-flex tw-flex-wrap tw-gap-1.5">
+                        {job.gap_skills.map((s) => (
+                            <span
+                                key={`g-${s}`}
+                                className="tw-rounded-full tw-bg-amber-100 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-text-amber-800"
+                            >
+                                {s}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <div className="tw-mt-3">
+                <a
+                    href={job.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="tw-inline-flex tw-items-center tw-gap-1 tw-text-sm tw-text-primary hover:tw-underline"
+                >
+                    View posting
+                    <i className="fas fa-external-link-alt tw-text-[10px]" />
+                </a>
+            </div>
+        </li>
+    );
+}

--- a/src/components/profile/TroopDashboard.tsx
+++ b/src/components/profile/TroopDashboard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 
 interface DashboardData {
@@ -27,9 +28,37 @@ interface DashboardData {
     }[];
 }
 
+interface WarmupChallenge {
+    id?: string;
+    challenge_id?: string;
+    title: string;
+    topic: string;
+    difficulty: string;
+}
+
+interface ModuleProgress {
+    curriculum_module: number;
+    total: number;
+    attempted: number;
+    completed: number;
+}
+
+interface ProgressData {
+    troop_id: string;
+    current_module: number;
+    current_module_progress: ModuleProgress | null;
+    by_module: ModuleProgress[];
+    overall_completed: number;
+    overall_total: number;
+}
+
 export default function TroopDashboard() {
     const [data, setData] = useState<DashboardData | null>(null);
+    const [warmups, setWarmups] = useState<WarmupChallenge[]>([]);
+    const [progress, setProgress] = useState<ProgressData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
+    const [isLoadingWarmups, setIsLoadingWarmups] = useState(true);
+    const [isLoadingProgress, setIsLoadingProgress] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [isUpdatingModule, setIsUpdatingModule] = useState(false);
 
@@ -71,9 +100,38 @@ export default function TroopDashboard() {
         }
     }, []);
 
+    const fetchWarmups = useCallback(async () => {
+        try {
+            const res = await fetch("/api/j0di3/challenges/recommended-warmups?count=5");
+            if (res.ok) {
+                const body = await res.json();
+                setWarmups(Array.isArray(body) ? body : (body.challenges ?? []));
+            }
+        } catch {
+            // non-critical — tray just stays hidden
+        } finally {
+            setIsLoadingWarmups(false);
+        }
+    }, []);
+
+    const fetchProgress = useCallback(async () => {
+        try {
+            const res = await fetch("/api/j0di3/troops/progress");
+            if (res.ok) {
+                setProgress(await res.json());
+            }
+        } catch {
+            // non-critical
+        } finally {
+            setIsLoadingProgress(false);
+        }
+    }, []);
+
     useEffect(() => {
         fetchDashboard();
-    }, [fetchDashboard]);
+        fetchWarmups();
+        fetchProgress();
+    }, [fetchDashboard, fetchWarmups, fetchProgress]);
 
     if (isLoading) {
         return (
@@ -102,6 +160,9 @@ export default function TroopDashboard() {
 
     return (
         <div className="tw-space-y-6">
+            {/* Reps tray — confidence loop entry point */}
+            <RepsTray warmups={warmups} loading={isLoadingWarmups} />
+
             {/* Stats Grid */}
             <div className="tw-grid tw-grid-cols-2 md:tw-grid-cols-4 tw-gap-4">
                 {[
@@ -248,6 +309,9 @@ export default function TroopDashboard() {
                 </div>
             )}
 
+            {/* Module progress bars */}
+            <ModuleProgressPanel progress={progress} loading={isLoadingProgress} />
+
             {/* Recent Conversations */}
             {data?.recent_conversations && data.recent_conversations.length > 0 && (
                 <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
@@ -280,6 +344,133 @@ export default function TroopDashboard() {
                     </div>
                 </div>
             )}
+        </div>
+    );
+}
+
+function RepsTray({
+    warmups,
+    loading,
+}: {
+    warmups: WarmupChallenge[];
+    loading: boolean;
+}) {
+    if (loading) {
+        return null;
+    }
+    if (warmups.length === 0) {
+        return null;
+    }
+    return (
+        <div className="tw-rounded-lg tw-border tw-border-primary/20 tw-bg-white tw-p-6 tw-shadow-sm">
+            <div className="tw-flex tw-items-center tw-justify-between tw-mb-4">
+                <div>
+                    <h3 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-primary tw-mb-1">
+                        Reps
+                    </h3>
+                    <p className="tw-text-sm tw-text-ink/70">
+                        Knock one out — most take 30 seconds.
+                    </p>
+                </div>
+            </div>
+            <ul className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-5 tw-gap-3">
+                {warmups.map((w) => {
+                    const id = w.id ?? w.challenge_id ?? "";
+                    return (
+                        <li key={id || w.title}>
+                            <Link
+                                href={`/challenges/${id}`}
+                                className="tw-block tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-3 tw-transition-shadow hover:tw-shadow-md hover:tw-border-primary"
+                            >
+                                <div className="tw-text-sm tw-font-semibold tw-text-ink tw-line-clamp-2 tw-mb-2">
+                                    {w.title}
+                                </div>
+                                <div className="tw-flex tw-flex-wrap tw-gap-1">
+                                    <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-blue-800">
+                                        {w.topic}
+                                    </span>
+                                    <span className="tw-rounded-full tw-bg-green-100 tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-green-800">
+                                        warmup
+                                    </span>
+                                </div>
+                            </Link>
+                        </li>
+                    );
+                })}
+            </ul>
+        </div>
+    );
+}
+
+function ModuleProgressPanel({
+    progress,
+    loading,
+}: {
+    progress: ProgressData | null;
+    loading: boolean;
+}) {
+    if (loading) {
+        return (
+            <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm tw-text-center">
+                <p className="tw-text-gray-300 tw-text-sm">Loading progress...</p>
+            </div>
+        );
+    }
+    if (!progress || !Array.isArray(progress.by_module) || progress.by_module.length === 0) {
+        return null;
+    }
+    const overallPct =
+        progress.overall_total > 0
+            ? Math.round((progress.overall_completed / progress.overall_total) * 100)
+            : 0;
+    return (
+        <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
+            <div className="tw-flex tw-items-center tw-justify-between tw-mb-4">
+                <h3 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                    Module Progress
+                </h3>
+                <span className="tw-text-xs tw-text-ink/60">
+                    {progress.overall_completed} / {progress.overall_total} overall ({overallPct}%)
+                </span>
+            </div>
+            <ul className="tw-space-y-2">
+                {progress.by_module
+                    .slice()
+                    .sort((a, b) => a.curriculum_module - b.curriculum_module)
+                    .map((m) => {
+                        const pct = m.total > 0 ? Math.round((m.completed / m.total) * 100) : 0;
+                        const isCurrent = m.curriculum_module === progress.current_module;
+                        return (
+                            <li key={m.curriculum_module} className="tw-text-sm">
+                                <div className="tw-flex tw-items-center tw-justify-between tw-mb-1">
+                                    <span
+                                        className={`tw-font-medium ${
+                                            isCurrent ? "tw-text-primary" : "tw-text-ink/80"
+                                        }`}
+                                    >
+                                        Module {m.curriculum_module}
+                                        {isCurrent && (
+                                            <span className="tw-ml-2 tw-rounded-full tw-bg-primary/10 tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-semibold tw-text-primary tw-uppercase">
+                                                Current
+                                            </span>
+                                        )}
+                                    </span>
+                                    <span className="tw-text-xs tw-text-ink/60">
+                                        {m.completed} / {m.total}
+                                    </span>
+                                </div>
+                                <div className="tw-h-2 tw-w-full tw-rounded-full tw-bg-navy/5 tw-overflow-hidden">
+                                    <div
+                                        className={`tw-h-full ${
+                                            isCurrent ? "tw-bg-primary" : "tw-bg-navy/30"
+                                        }`}
+                                        style={{ width: `${pct}%` }}
+                                    />
+                                </div>
+                            </li>
+                        );
+                    })}
+            </ul>
         </div>
     );
 }

--- a/src/pages/api/j0di3/challenges/[id]/index.ts
+++ b/src/pages/api/j0di3/challenges/[id]/index.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", (req) => `/api/v1/challenges/${req.query.id}`);

--- a/src/pages/api/j0di3/challenges/list.ts
+++ b/src/pages/api/j0di3/challenges/list.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", "/api/v1/challenges/list");

--- a/src/pages/api/j0di3/challenges/recommended-warmups.ts
+++ b/src/pages/api/j0di3/challenges/recommended-warmups.ts
@@ -1,0 +1,8 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) =>
+        `/api/v1/challenges/recommended-warmups/${(req as AuthenticatedRequest).user!.troopId}`
+);

--- a/src/pages/api/j0di3/challenges/topics.ts
+++ b/src/pages/api/j0di3/challenges/topics.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", "/api/v1/challenges/topics");

--- a/src/pages/api/j0di3/troops/progress.ts
+++ b/src/pages/api/j0di3/troops/progress.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/progress`
+);

--- a/src/pages/challenges/[id].tsx
+++ b/src/pages/challenges/[id].tsx
@@ -1,0 +1,493 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import { runChallenge } from "@/lib/challenge-runner";
+import type { Challenge, ClientResults, ClientTestResult, TestCase } from "@/lib/challenge-runner";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { getServerSession } from "next-auth/next";
+import { useCallback, useEffect, useState } from "react";
+import { options } from "@/pages/api/auth/options";
+
+interface SubmissionResponse {
+    passed?: boolean;
+    score?: number;
+    feedback?: string;
+    [key: string]: unknown;
+}
+
+type PageProps = {
+    layout?: {
+        headerShadow: boolean;
+        headerFluid: boolean;
+        footerMode: string;
+    };
+};
+
+type PageWithLayout = NextPage<PageProps> & {
+    Layout?: typeof Layout01;
+};
+
+const ChallengeDetailPage: PageWithLayout = () => {
+    const router = useRouter();
+    const idParam = router.query.id;
+    const id = typeof idParam === "string" ? idParam : undefined;
+
+    const [challenge, setChallenge] = useState<Challenge | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [loadError, setLoadError] = useState<string | null>(null);
+
+    const [code, setCode] = useState("");
+    const [isRunning, setIsRunning] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [localResults, setLocalResults] = useState<ClientResults | null>(null);
+    const [serverResult, setServerResult] = useState<SubmissionResponse | null>(null);
+    const [hints, setHints] = useState<string[]>([]);
+    const [isLoadingHint, setIsLoadingHint] = useState(false);
+    const [solutionText, setSolutionText] = useState<string | null>(null);
+    const [showSolution, setShowSolution] = useState(false);
+
+    const fetchChallenge = useCallback(async () => {
+        if (!id) return;
+        setIsLoading(true);
+        setLoadError(null);
+        try {
+            const res = await fetch(`/api/j0di3/challenges/${id}`);
+            if (!res.ok) {
+                const errData = await res.json().catch(() => ({}));
+                throw new Error(errData.error || "Failed to load challenge");
+            }
+            const data = (await res.json()) as Challenge;
+            setChallenge(data);
+            setCode(data.starter_code || "");
+        } catch (err) {
+            setLoadError(err instanceof Error ? err.message : "Failed to load challenge");
+        } finally {
+            setIsLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        if (router.isReady && id) {
+            fetchChallenge();
+        }
+    }, [router.isReady, id, fetchChallenge]);
+
+    const handleRun = async () => {
+        if (!challenge) return;
+        if (!challenge.test_cases || challenge.test_cases.length === 0) {
+            setError("This challenge has no test cases — try reloading it.");
+            return;
+        }
+        setIsRunning(true);
+        setError(null);
+        try {
+            const results = await runChallenge(code, challenge, { visibleOnly: true });
+            setLocalResults(results);
+            setServerResult(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to run your solution");
+        } finally {
+            setIsRunning(false);
+        }
+    };
+
+    const handleSubmit = async () => {
+        if (!challenge) return;
+        if (!challenge.test_cases || challenge.test_cases.length === 0) {
+            setError("This challenge has no test cases — try reloading it.");
+            return;
+        }
+        setIsSubmitting(true);
+        setError(null);
+        try {
+            const clientResults = await runChallenge(code, challenge);
+            setLocalResults(clientResults);
+
+            const res = await fetch(`/api/j0di3/challenges/${challenge.id}/submit`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ solution: code, client_results: clientResults }),
+            });
+
+            if (!res.ok) {
+                const errData = await res.json();
+                throw new Error(errData.error || "Submission failed");
+            }
+            setServerResult((await res.json()) as SubmissionResponse);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Submission failed");
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleGetHint = async () => {
+        if (!challenge) return;
+        setIsLoadingHint(true);
+        try {
+            const res = await fetch(`/api/j0di3/challenges/${challenge.id}/hint`);
+            if (res.ok) {
+                const body = await res.json();
+                setHints((prev) => [...prev, body.hint || body.message || "No more hints available."]);
+            }
+        } catch {
+            // non-critical
+        } finally {
+            setIsLoadingHint(false);
+        }
+    };
+
+    const handleShowSolution = async () => {
+        if (!challenge) return;
+        try {
+            const res = await fetch(`/api/j0di3/challenges/${challenge.id}/solution`);
+            if (res.ok) {
+                const body = await res.json();
+                setSolutionText(body.solution || body.code || "Solution not available.");
+                setShowSolution(true);
+            }
+        } catch {
+            // non-critical
+        }
+    };
+
+    const difficultyColor = (d: string) => {
+        switch (d.toLowerCase()) {
+            case "warmup":
+                return "tw-bg-emerald-100 tw-text-emerald-800";
+            case "easy":
+                return "tw-bg-green-100 tw-text-green-800";
+            case "medium":
+                return "tw-bg-yellow-100 tw-text-yellow-800";
+            case "hard":
+                return "tw-bg-red-100 tw-text-red-800";
+            default:
+                return "tw-bg-gray-100 tw-text-gray-800";
+        }
+    };
+
+    const visibleTestCount =
+        challenge?.test_cases?.filter((tc: TestCase) => !(tc.hidden ?? false)).length ?? 0;
+    const hasTestCases = (challenge?.test_cases?.length ?? 0) > 0;
+
+    return (
+        <>
+            <SEO title={challenge?.title ? `${challenge.title} — Challenge` : "Challenge"} />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/challenges", label: "challenges" },
+                ]}
+                currentPage={challenge?.title ?? "Challenge"}
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12">
+                {isLoading && (
+                    <div className="tw-rounded-lg tw-bg-white tw-p-8 tw-text-center tw-shadow-sm">
+                        <p className="tw-text-navy/60">Loading challenge...</p>
+                    </div>
+                )}
+
+                {loadError && !isLoading && (
+                    <div className="tw-rounded-lg tw-border tw-border-red-200 tw-bg-red-50 tw-p-6 tw-text-center">
+                        <p className="tw-text-red-700 tw-mb-3">{loadError}</p>
+                        <Link
+                            href="/challenges"
+                            className="tw-text-sm tw-text-primary hover:tw-underline"
+                        >
+                            ← Back to challenges
+                        </Link>
+                    </div>
+                )}
+
+                {challenge && !isLoading && !loadError && (
+                    <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-sm">
+                        <div className="tw-flex tw-items-start tw-justify-between tw-mb-4">
+                            <div>
+                                <h1 className="tw-text-2xl tw-font-bold tw-text-ink">
+                                    {challenge.title}
+                                </h1>
+                                <div className="tw-flex tw-gap-2 tw-mt-2">
+                                    <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium tw-text-blue-800">
+                                        {challenge.topic}
+                                    </span>
+                                    <span
+                                        className={`tw-rounded-full tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium ${difficultyColor(
+                                            challenge.difficulty
+                                        )}`}
+                                    >
+                                        {challenge.difficulty}
+                                    </span>
+                                </div>
+                            </div>
+                            <Link
+                                href="/challenges"
+                                className="tw-text-sm tw-text-ink/60 hover:tw-text-ink/80"
+                            >
+                                ← All challenges
+                            </Link>
+                        </div>
+
+                        <p className="tw-mb-4 tw-text-ink/80">{challenge.description}</p>
+
+                        <div className="tw-mb-4">
+                            <label
+                                htmlFor="code-editor"
+                                className="tw-block tw-text-sm tw-font-medium tw-text-ink/80 tw-mb-2"
+                            >
+                                Your Solution ({challenge.language})
+                            </label>
+                            <textarea
+                                id="code-editor"
+                                value={code}
+                                onChange={(e) => setCode(e.target.value)}
+                                rows={15}
+                                className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-bg-navy/5 tw-px-4 tw-py-3 tw-font-mono tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                                placeholder="Write your solution here..."
+                                spellCheck={false}
+                            />
+                        </div>
+
+                        {error && (
+                            <div className="tw-mb-4 tw-rounded-md tw-border tw-border-red-200 tw-bg-red-50 tw-p-3 tw-text-sm tw-text-red-700">
+                                {error}
+                            </div>
+                        )}
+
+                        <div className="tw-flex tw-flex-wrap tw-gap-3 tw-mb-4">
+                            <button
+                                type="button"
+                                onClick={handleRun}
+                                disabled={isRunning || isSubmitting || !code.trim() || !hasTestCases}
+                                className="tw-rounded-md tw-border tw-border-primary tw-px-6 tw-py-2 tw-font-medium tw-text-primary tw-transition-colors hover:tw-bg-primary/5 disabled:tw-opacity-50"
+                            >
+                                {isRunning
+                                    ? "Running..."
+                                    : `Run (${visibleTestCount} visible test${visibleTestCount === 1 ? "" : "s"})`}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleSubmit}
+                                disabled={isRunning || isSubmitting || !code.trim() || !hasTestCases}
+                                className="tw-rounded-md tw-bg-primary tw-px-6 tw-py-2 tw-font-medium tw-text-white tw-transition-colors hover:tw-bg-primary-dark disabled:tw-opacity-50"
+                            >
+                                {isSubmitting ? "Submitting..." : "Submit Solution"}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={handleGetHint}
+                                disabled={isLoadingHint}
+                                className="tw-rounded-md tw-border tw-border-navy/10 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-ink/80 hover:tw-bg-navy/5"
+                            >
+                                {isLoadingHint ? "Loading..." : `Get Hint (${hints.length} used)`}
+                            </button>
+                            {!showSolution && (
+                                <button
+                                    type="button"
+                                    onClick={handleShowSolution}
+                                    className="tw-rounded-md tw-border tw-border-red-300 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-red-600 hover:tw-bg-red-50"
+                                >
+                                    Reveal Solution
+                                </button>
+                            )}
+                        </div>
+
+                        {hints.length > 0 && (
+                            <div className="tw-mb-4 tw-space-y-2">
+                                {hints.map((hint, i) => (
+                                    <div
+                                        key={i}
+                                        className="tw-rounded-md tw-bg-blue-50 tw-border tw-border-blue-200 tw-p-3"
+                                    >
+                                        <span className="tw-text-xs tw-font-semibold tw-text-blue-600 tw-uppercase">
+                                            Hint {i + 1}
+                                        </span>
+                                        <p className="tw-text-sm tw-text-blue-800 tw-mt-1">{hint}</p>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+
+                        {showSolution && solutionText && (
+                            <div className="tw-mb-4 tw-rounded-md tw-bg-amber-50 tw-border tw-border-amber-200 tw-p-4">
+                                <span className="tw-text-xs tw-font-semibold tw-text-amber-600 tw-uppercase">
+                                    Solution
+                                </span>
+                                <pre className="tw-mt-2 tw-text-sm tw-font-mono tw-text-amber-900 tw-whitespace-pre-wrap">
+                                    {solutionText}
+                                </pre>
+                            </div>
+                        )}
+
+                        {localResults && <TestResultsPanel results={localResults} />}
+
+                        {serverResult && (() => {
+                            const passed =
+                                typeof serverResult.passed === "boolean"
+                                    ? serverResult.passed
+                                    : (localResults?.all_passed ?? false);
+                            return (
+                                <div
+                                    className={`tw-mt-4 tw-rounded-md tw-p-4 tw-border ${
+                                        passed
+                                            ? "tw-bg-green-50 tw-border-green-200"
+                                            : "tw-bg-red-50 tw-border-red-200"
+                                    }`}
+                                >
+                                    <div className="tw-flex tw-items-center tw-gap-2 tw-mb-2">
+                                        <i
+                                            className={`fas ${
+                                                passed
+                                                    ? "fa-check-circle tw-text-green-600"
+                                                    : "fa-times-circle tw-text-red-600"
+                                            }`}
+                                        />
+                                        <span
+                                            className={`tw-font-semibold ${
+                                                passed ? "tw-text-green-800" : "tw-text-red-800"
+                                            }`}
+                                        >
+                                            {passed ? "Challenge Passed!" : "Not quite right"}
+                                        </span>
+                                        {serverResult.score !== undefined && (
+                                            <span className="tw-text-sm tw-text-ink/60 tw-ml-2">
+                                                Score: {serverResult.score}/100
+                                            </span>
+                                        )}
+                                    </div>
+                                    {serverResult.feedback && (
+                                        <p className="tw-text-sm tw-text-ink/80 tw-whitespace-pre-wrap">
+                                            {serverResult.feedback}
+                                        </p>
+                                    )}
+                                </div>
+                            );
+                        })()}
+                    </div>
+                )}
+            </div>
+        </>
+    );
+};
+
+function TestResultsPanel({ results }: { results: ClientResults }) {
+    const passedCount = results.test_results.filter((r) => r.passed).length;
+    const total = results.test_results.length;
+    const headerClass = results.all_passed
+        ? "tw-bg-green-50 tw-border-green-200"
+        : "tw-bg-red-50 tw-border-red-200";
+
+    return (
+        <div className={`tw-rounded-md tw-p-4 tw-border ${headerClass}`}>
+            <div className="tw-flex tw-items-center tw-gap-2 tw-mb-3">
+                <i
+                    className={`fas ${
+                        results.all_passed
+                            ? "fa-check-circle tw-text-green-600"
+                            : "fa-times-circle tw-text-red-600"
+                    }`}
+                />
+                <span
+                    className={`tw-font-semibold ${
+                        results.all_passed ? "tw-text-green-800" : "tw-text-red-800"
+                    }`}
+                >
+                    {passedCount} / {total} tests passing
+                </span>
+                {typeof results.execution_ms === "number" && (
+                    <span className="tw-text-xs tw-text-ink/60 tw-ml-2">
+                        {results.execution_ms}ms
+                    </span>
+                )}
+            </div>
+            <ul className="tw-space-y-2">
+                {results.test_results.map((r) => (
+                    <TestResultRow key={r.test_case_index} result={r} />
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function TestResultRow({ result }: { result: ClientTestResult }) {
+    const rowClass = result.passed
+        ? "tw-border-green-200 tw-bg-white"
+        : "tw-border-red-200 tw-bg-white";
+    return (
+        <li className={`tw-rounded-md tw-border tw-p-3 tw-text-sm ${rowClass}`}>
+            <div className="tw-flex tw-items-center tw-gap-2 tw-mb-1">
+                <i
+                    className={`fas ${
+                        result.passed
+                            ? "fa-check tw-text-green-600"
+                            : "fa-times tw-text-red-600"
+                    }`}
+                />
+                <span className="tw-font-semibold tw-text-ink">
+                    Test {result.test_case_index + 1}
+                </span>
+                {result.hidden && (
+                    <span className="tw-rounded-full tw-bg-navy/10 tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium tw-text-navy/70">
+                        hidden
+                    </span>
+                )}
+            </div>
+            {!result.hidden && (
+                <div className="tw-mt-1 tw-space-y-1 tw-font-mono tw-text-xs tw-text-ink/80">
+                    <div>
+                        <span className="tw-text-ink/50">Input:</span> {result.input}
+                    </div>
+                    <div>
+                        <span className="tw-text-ink/50">Expected:</span> {result.expected_output}
+                    </div>
+                    {!result.passed && (
+                        <div className="tw-text-red-700">
+                            <span className="tw-text-ink/50">Got:</span>{" "}
+                            {result.actual_output ?? "(no output)"}
+                        </div>
+                    )}
+                </div>
+            )}
+            {result.hidden && !result.passed && (
+                <div className="tw-mt-1 tw-text-xs tw-text-red-700">
+                    Hidden test failed — adjust your solution and try again.
+                </div>
+            )}
+            {result.error && (
+                <div className="tw-mt-1 tw-text-xs tw-text-red-700">
+                    <span className="tw-text-ink/50">Error:</span> {result.error}
+                </div>
+            )}
+        </li>
+    );
+}
+
+ChallengeDetailPage.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const session = await getServerSession(context.req, context.res, options);
+    if (!session?.user) {
+        const id = context.params?.id ?? "";
+        return {
+            redirect: {
+                destination: `/login?callbackUrl=/challenges/${id}`,
+                permanent: false,
+            },
+        };
+    }
+    return {
+        props: {
+            layout: {
+                headerShadow: true,
+                headerFluid: false,
+                footerMode: "light",
+            },
+        },
+    };
+};
+
+export default ChallengeDetailPage;

--- a/src/pages/challenges/browse.tsx
+++ b/src/pages/challenges/browse.tsx
@@ -1,0 +1,368 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { getServerSession } from "next-auth/next";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { options } from "@/pages/api/auth/options";
+
+type Difficulty = "warmup" | "easy" | "medium" | "hard";
+type Language = "javascript" | "typescript" | "python";
+
+interface CatalogItem {
+    challenge_id: string;
+    title: string;
+    difficulty: Difficulty;
+    topic: string;
+    curriculum_module: number;
+    language: Language;
+}
+
+interface CatalogResponse {
+    items: CatalogItem[];
+    pagination: {
+        limit: number;
+        offset: number;
+        total: number;
+        next_offset: number | null;
+    };
+}
+
+interface TopicsResponse {
+    module: number | null;
+    topics: string[];
+}
+
+const DIFFICULTIES: Difficulty[] = ["warmup", "easy", "medium", "hard"];
+const PAGE_SIZE = 20;
+
+type PageProps = {
+    layout?: {
+        headerShadow: boolean;
+        headerFluid: boolean;
+        footerMode: string;
+    };
+};
+
+type PageWithLayout = NextPage<PageProps> & {
+    Layout?: typeof Layout01;
+};
+
+const BrowseChallengesPage: PageWithLayout = () => {
+    const [moduleFilter, setModuleFilter] = useState<number | "">("");
+    const [difficultyFilter, setDifficultyFilter] = useState<Difficulty | "">("");
+    const [topicFilter, setTopicFilter] = useState<string>("");
+    const [topics, setTopics] = useState<string[]>([]);
+    const [items, setItems] = useState<CatalogItem[]>([]);
+    const [pagination, setPagination] = useState<CatalogResponse["pagination"] | null>(null);
+    const [offset, setOffset] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const queryString = useMemo(() => {
+        const params = new URLSearchParams();
+        if (moduleFilter !== "") params.set("module", String(moduleFilter));
+        if (difficultyFilter) params.set("difficulty", difficultyFilter);
+        if (topicFilter) params.set("topic", topicFilter);
+        params.set("limit", String(PAGE_SIZE));
+        params.set("offset", String(offset));
+        return params.toString();
+    }, [moduleFilter, difficultyFilter, topicFilter, offset]);
+
+    const fetchTopics = useCallback(async (mod: number | "") => {
+        try {
+            const url =
+                mod !== ""
+                    ? `/api/j0di3/challenges/topics?module=${mod}`
+                    : "/api/j0di3/challenges/topics";
+            const res = await fetch(url);
+            if (res.ok) {
+                const body = (await res.json()) as TopicsResponse;
+                setTopics(body.topics ?? []);
+            }
+        } catch {
+            // non-critical — topic chip area just stays empty
+        }
+    }, []);
+
+    const fetchCatalog = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+        try {
+            const res = await fetch(`/api/j0di3/challenges/list?${queryString}`);
+            if (!res.ok) {
+                const errData = await res.json().catch(() => ({}));
+                throw new Error(errData.error || "Failed to load catalog");
+            }
+            const body = (await res.json()) as CatalogResponse;
+            setItems(body.items ?? []);
+            setPagination(body.pagination ?? null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "Failed to load catalog");
+        } finally {
+            setIsLoading(false);
+        }
+    }, [queryString]);
+
+    useEffect(() => {
+        fetchTopics(moduleFilter);
+        // changing the module clears the topic filter so we don't keep a
+        // topic that doesn't exist in the new module
+        setTopicFilter("");
+    }, [moduleFilter, fetchTopics]);
+
+    useEffect(() => {
+        fetchCatalog();
+    }, [fetchCatalog]);
+
+    const resetFilters = () => {
+        setModuleFilter("");
+        setDifficultyFilter("");
+        setTopicFilter("");
+        setOffset(0);
+    };
+
+    const difficultyColor = (d: Difficulty) => {
+        switch (d) {
+            case "warmup":
+                return "tw-bg-emerald-100 tw-text-emerald-800";
+            case "easy":
+                return "tw-bg-green-100 tw-text-green-800";
+            case "medium":
+                return "tw-bg-yellow-100 tw-text-yellow-800";
+            case "hard":
+                return "tw-bg-red-100 tw-text-red-800";
+        }
+    };
+
+    return (
+        <>
+            <SEO title="Browse Challenges" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/challenges", label: "challenges" },
+                ]}
+                currentPage="Browse"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12">
+                <div className="tw-mb-8">
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink tw-mb-2">
+                        Challenge Catalog
+                    </h1>
+                    <p className="tw-text-navy/60">
+                        Browse the full Hashflag Stack challenge library. Filter by module,
+                        difficulty, or topic.
+                    </p>
+                </div>
+
+                {/* Filters */}
+                <div className="tw-mb-6 tw-rounded-lg tw-bg-white tw-p-4 tw-shadow-sm tw-space-y-4">
+                    <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-3 tw-gap-3">
+                        <div>
+                            <label
+                                htmlFor="module"
+                                className="tw-block tw-text-xs tw-font-mono tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-1"
+                            >
+                                Module
+                            </label>
+                            <select
+                                id="module"
+                                value={moduleFilter}
+                                onChange={(e) => {
+                                    setOffset(0);
+                                    setModuleFilter(e.target.value === "" ? "" : Number(e.target.value));
+                                }}
+                                className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                            >
+                                <option value="">All modules</option>
+                                {Array.from({ length: 25 }, (_, i) => i + 1).map((m) => (
+                                    <option key={m} value={m}>
+                                        Module {m}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div>
+                            <label
+                                htmlFor="difficulty"
+                                className="tw-block tw-text-xs tw-font-mono tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-1"
+                            >
+                                Difficulty
+                            </label>
+                            <select
+                                id="difficulty"
+                                value={difficultyFilter}
+                                onChange={(e) => {
+                                    setOffset(0);
+                                    setDifficultyFilter(e.target.value as Difficulty | "");
+                                }}
+                                className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                            >
+                                <option value="">Any</option>
+                                {DIFFICULTIES.map((d) => (
+                                    <option key={d} value={d}>
+                                        {d.charAt(0).toUpperCase() + d.slice(1)}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                        <div className="tw-flex tw-items-end">
+                            <button
+                                type="button"
+                                onClick={resetFilters}
+                                className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm tw-font-medium tw-text-ink/80 hover:tw-bg-navy/5"
+                            >
+                                Reset filters
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Topic chips */}
+                    {topics.length > 0 && (
+                        <div>
+                            <div className="tw-block tw-text-xs tw-font-mono tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                                Topic
+                            </div>
+                            <div className="tw-flex tw-flex-wrap tw-gap-2">
+                                {topics.map((t) => {
+                                    const active = topicFilter === t;
+                                    return (
+                                        <button
+                                            key={t}
+                                            type="button"
+                                            onClick={() => {
+                                                setOffset(0);
+                                                setTopicFilter(active ? "" : t);
+                                            }}
+                                            className={`tw-rounded-full tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-transition-colors ${
+                                                active
+                                                    ? "tw-bg-primary tw-text-white"
+                                                    : "tw-bg-navy/5 tw-text-ink/80 hover:tw-bg-navy/10"
+                                            }`}
+                                        >
+                                            {t}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                {/* Results */}
+                {error && (
+                    <div className="tw-mb-4 tw-rounded-md tw-border tw-border-red-200 tw-bg-red-50 tw-p-3 tw-text-sm tw-text-red-700">
+                        {error}
+                    </div>
+                )}
+
+                {isLoading ? (
+                    <div className="tw-rounded-lg tw-bg-white tw-p-8 tw-text-center tw-shadow-sm">
+                        <p className="tw-text-navy/60">Loading challenges...</p>
+                    </div>
+                ) : items.length === 0 ? (
+                    <div className="tw-rounded-lg tw-bg-white tw-p-8 tw-text-center tw-shadow-sm">
+                        <p className="tw-text-navy/60">No challenges match these filters.</p>
+                    </div>
+                ) : (
+                    <ul className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4">
+                        {items.map((item) => (
+                            <li key={item.challenge_id}>
+                                <Link
+                                    href={`/challenges/${item.challenge_id}`}
+                                    className="tw-block tw-h-full tw-rounded-lg tw-bg-white tw-p-4 tw-shadow-sm tw-transition-shadow hover:tw-shadow-md hover:tw-border-primary tw-border tw-border-transparent"
+                                >
+                                    <div className="tw-flex tw-items-start tw-justify-between tw-gap-2 tw-mb-2">
+                                        <h3 className="tw-text-base tw-font-semibold tw-text-ink tw-line-clamp-2">
+                                            {item.title}
+                                        </h3>
+                                    </div>
+                                    <div className="tw-flex tw-flex-wrap tw-gap-1.5 tw-mb-2">
+                                        <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-blue-800">
+                                            {item.topic}
+                                        </span>
+                                        <span
+                                            className={`tw-rounded-full tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium ${difficultyColor(
+                                                item.difficulty
+                                            )}`}
+                                        >
+                                            {item.difficulty}
+                                        </span>
+                                        <span className="tw-rounded-full tw-bg-navy/5 tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-ink/70">
+                                            Module {item.curriculum_module}
+                                        </span>
+                                    </div>
+                                    <div className="tw-text-xs tw-text-ink/50 tw-font-mono">
+                                        {item.language}
+                                    </div>
+                                </Link>
+                            </li>
+                        ))}
+                    </ul>
+                )}
+
+                {/* Pagination */}
+                {pagination && (
+                    <div className="tw-mt-6 tw-flex tw-items-center tw-justify-between tw-text-sm">
+                        <div className="tw-text-ink/60">
+                            Showing {pagination.offset + 1}–
+                            {Math.min(pagination.offset + items.length, pagination.total)} of{" "}
+                            {pagination.total}
+                        </div>
+                        <div className="tw-flex tw-gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+                                disabled={offset === 0 || isLoading}
+                                className="tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-1.5 tw-font-medium tw-text-ink/80 hover:tw-bg-navy/5 disabled:tw-opacity-40"
+                            >
+                                ← Previous
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    if (pagination.next_offset !== null) {
+                                        setOffset(pagination.next_offset);
+                                    }
+                                }}
+                                disabled={pagination.next_offset === null || isLoading}
+                                className="tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-1.5 tw-font-medium tw-text-ink/80 hover:tw-bg-navy/5 disabled:tw-opacity-40"
+                            >
+                                Next →
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </div>
+        </>
+    );
+};
+
+BrowseChallengesPage.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const session = await getServerSession(context.req, context.res, options);
+    if (!session?.user) {
+        return {
+            redirect: {
+                destination: "/login?callbackUrl=/challenges/browse",
+                permanent: false,
+            },
+        };
+    }
+    return {
+        props: {
+            layout: {
+                headerShadow: true,
+                headerFluid: false,
+                footerMode: "light",
+            },
+        },
+    };
+};
+
+export default BrowseChallengesPage;

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -4,6 +4,7 @@ import Layout01 from "@layout/layout-01";
 import { runChallenge } from "@/lib/challenge-runner";
 import type { Challenge, ClientResults, ClientTestResult, TestCase } from "@/lib/challenge-runner";
 import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
 import { getServerSession } from "next-auth/next";
 import { useCallback, useEffect, useState } from "react";
 import { options } from "@/pages/api/auth/options";
@@ -284,13 +285,22 @@ const ChallengesPage: PageWithLayout = () => {
             />
 
             <div className="tw-container tw-py-16">
-                <div className="tw-mb-12">
-                    <h1 className="tw-text-4xl tw-font-bold tw-text-ink tw-mb-4">
-                        Code Challenges
-                    </h1>
-                    <p className="tw-text-xl tw-text-navy/60">
-                        AI-powered coding challenges that adapt to your skill level
-                    </p>
+                <div className="tw-mb-12 tw-flex tw-flex-wrap tw-items-end tw-justify-between tw-gap-4">
+                    <div>
+                        <h1 className="tw-text-4xl tw-font-bold tw-text-ink tw-mb-4">
+                            Code Challenges
+                        </h1>
+                        <p className="tw-text-xl tw-text-navy/60">
+                            AI-powered coding challenges that adapt to your skill level
+                        </p>
+                    </div>
+                    <Link
+                        href="/challenges/browse"
+                        className="tw-inline-flex tw-items-center tw-gap-2 tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-ink/80 hover:tw-border-primary hover:tw-text-primary"
+                    >
+                        <i className="fas fa-th-list" />
+                        Browse the full catalog
+                    </Link>
                 </div>
 
                 {error && (

--- a/src/pages/jobs/index.tsx
+++ b/src/pages/jobs/index.tsx
@@ -10,6 +10,7 @@ import React, { useMemo, useState } from "react";
 import { options } from "@/pages/api/auth/options";
 import ResumeScorer from "@/components/jobs/ResumeScorer";
 import MockInterview from "@/components/jobs/MockInterview";
+import JobMatch from "@/components/jobs/JobMatch";
 
 type PageProps = {
     jobs: Job[];
@@ -32,7 +33,7 @@ type PageWithLayout = NextPage<PageProps> & {
     Layout?: typeof Layout01;
 };
 
-type JobsTab = "board" | "resume" | "interview";
+type JobsTab = "board" | "matches" | "resume" | "interview";
 
 const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
     const [activeTab, setActiveTab] = useState<JobsTab>("board");
@@ -110,6 +111,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
                 <div className="tw-mb-8 tw-flex tw-gap-1 tw-rounded-lg tw-bg-navy/5 tw-p-1">
                     {([
                         { key: "board" as const, label: "Job Board", icon: "fa-briefcase" },
+                        { key: "matches" as const, label: "Matches", icon: "fa-bullseye" },
                         { key: "resume" as const, label: "Resume Scorer", icon: "fa-file-alt" },
                         { key: "interview" as const, label: "Mock Interview", icon: "fa-comments" },
                     ]).map((tab) => (
@@ -129,6 +131,8 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
                 </div>
 
                 {/* Resume Scorer Tab */}
+                {activeTab === "matches" && <JobMatch />}
+
                 {activeTab === "resume" && <ResumeScorer />}
 
                 {/* Mock Interview Tab */}


### PR DESCRIPTION
Implements the 2026-04-25 J0dI3 frontend handoff. Six DoD items, four commits.

## DoD checklist

- [x] **Dashboard renders \`current_module_topics\`** — already wired in TroopDashboard from the prior week→module rename. The field now has data; renders unchanged.
- [x] **Confidence (Reps) tray** pulls 5 unattempted warmups from \`/challenges/recommended-warmups\` and renders cards linking to \`/challenges/[id]\`. Framed as \"Knock one out — most take 30 seconds.\"
- [x] **Catalog browse page** at \`/challenges/browse\` — module/difficulty/topic filters, topic chips driven by \`/challenges/topics\`, 20-per-page pagination using \`next_offset\`, cards link to deep links.
- [x] **Single-challenge deep link** at \`/challenges/[id]\` — fetches via \`/challenges/{id}\` and renders the full Run / Submit / runner-results / hints / reveal-solution UX.
- [x] **Module progress component** on the dashboard, fed by \`/troops/progress\` — per-module bars sorted by module number with the current module highlighted, plus an overall completion summary.
- [x] **Job match tab** at \`/jobs\` — sorts by \`fit_pct\` (defensive client sort), color-tiers the fit chip, renders matched skills as green chips and gap skills as amber.

## API proxy routes added

- \`GET /api/j0di3/challenges/list\` → \`/api/v1/challenges/list\`
- \`GET /api/j0di3/challenges/topics\` → \`/api/v1/challenges/topics\`
- \`GET /api/j0di3/challenges/[id]\` → \`/api/v1/challenges/{id}\`
- \`GET /api/j0di3/challenges/recommended-warmups\` → \`/api/v1/challenges/recommended-warmups/{troop_id}\`
- \`GET /api/j0di3/troops/progress\` → \`/api/v1/troops/{id}/progress\`

All five use the existing \`j0di3Proxy\` helper, so they auth-gate and inject \`troop_id\` consistently with the rest of the J0dI3 surface.

## Out of scope (intentional)

- \`/admin/stats\` proxy — admin-scoped, no admin UI in this PR. Can be added when there's a place to render it.
- The 'topic strings normalized' note — no FE compares topic strings today, so nothing to update.
- Coding pillar RAG-grounding (\`/coding/*\`) — purely server-side, no FE change required.

## Test plan

- [x] \`tsc --noEmit\` clean on production sources
- [x] All affected vitest suites pass: \`__tests__/components/profile/TroopDashboard\`, \`__tests__/pages/challenges/index\`, \`__tests__/lib/challenge-runner\` (27 tests)
- [ ] Manual smoke against a live J0dI3 + signed-in troop:
  - [ ] Dashboard loads with topics, warmups, and progress bars populated
  - [ ] Click a warmup card → \`/challenges/[id]\` loads and is solvable
  - [ ] \`/challenges/browse\` filters by module/difficulty/topic, paginates, deep-links open
  - [ ] \`/jobs\` Matches tab shows real fit% and skill chips