### PR TITLE
fix(engagement-modal): popup z-index and button text centering

### DIFF
--- a/src/components/ui/engagement-modal/EngagementModal.module.css
+++ b/src/components/ui/engagement-modal/EngagementModal.module.css
@@ -1,27 +1,29 @@
 /* Custom animations */
 @keyframes wiggle {
     0% {
-        transform: rotate(0deg);
+        transform: translateY(-50%) rotate(0deg);
     }
     25% {
-        transform: rotate(10deg);
+        transform: translateY(-50%) rotate(10deg);
     }
     50% {
-        transform: rotate(0deg);
+        transform: translateY(-50%) rotate(0deg);
     }
     75% {
-        transform: rotate(-10deg);
+        transform: translateY(-50%) rotate(-10deg);
     }
     100% {
-        transform: rotate(0deg);
+        transform: translateY(-50%) rotate(0deg);
     }
 }
 
 .emoji {
-    display: inline-block;
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
     opacity: 0;
-    margin-left: 0.5rem;
-    vertical-align: middle;
+    pointer-events: none;
     transition: opacity 0.3s ease;
 }
 

--- a/src/components/ui/engagement-modal/EngagementModal.tsx
+++ b/src/components/ui/engagement-modal/EngagementModal.tsx
@@ -104,7 +104,7 @@ export const EngagementModal: React.FC<EngagementModalProps> = ({
             <AnimatePresence>
                 {open && (
                     <motion.div
-                        className="tw-fixed tw-inset-0 tw-z-50 tw-flex tw-items-center tw-justify-center tw-bg-black/50 tw-p-2 sm:tw-p-6"
+                        className="tw-fixed tw-inset-0 tw-z-[100] tw-flex tw-items-center tw-justify-center tw-bg-black/50 tw-p-2 sm:tw-p-6"
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         exit={{ opacity: 0 }}
@@ -149,19 +149,17 @@ export const EngagementModal: React.FC<EngagementModalProps> = ({
                             <div className="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-gap-4 sm:tw-flex-row">
                                 <a
                                     href={cta1.href}
-                                    className={`${styles.button} tw-group tw-w-full tw-rounded tw-bg-primary tw-px-8 tw-py-4 tw-text-center tw-text-lg tw-font-semibold tw-text-white tw-transition hover:tw-bg-secondary hover:tw-text-white focus:tw-ring-2 focus:tw-ring-primary`}
+                                    className={`${styles.button} tw-group tw-relative tw-flex tw-w-full tw-items-center tw-justify-center tw-rounded tw-bg-primary tw-px-8 tw-py-4 tw-text-lg tw-font-semibold tw-text-white tw-transition hover:tw-bg-secondary hover:tw-text-white focus:tw-ring-2 focus:tw-ring-primary`}
                                 >
-                                    <span className="tw-group-hover:tw-mr-2 tw-inline-block tw-transition-all">
-                                        {cta1.label}
-                                    </span>
-                                    <span className={`${styles.emoji}`} aria-hidden="true">
+                                    <span className="tw-leading-none">{cta1.label}</span>
+                                    <span className={styles.emoji} aria-hidden="true">
                                         💖
                                     </span>
                                 </a>
                                 {cta2.href.startsWith("#") ? (
                                     <Link
                                         href={cta2.href}
-                                        className={`${styles.button} tw-group tw-w-full tw-rounded tw-bg-secondary tw-px-8 tw-py-4 tw-text-center tw-text-lg tw-font-semibold tw-text-white tw-transition hover:tw-bg-accent hover:tw-text-secondary focus:tw-ring-2 focus:tw-ring-secondary`}
+                                        className={`${styles.button} tw-group tw-relative tw-flex tw-w-full tw-items-center tw-justify-center tw-rounded tw-bg-secondary tw-px-8 tw-py-4 tw-text-lg tw-font-semibold tw-text-white tw-transition hover:tw-bg-accent hover:tw-text-secondary focus:tw-ring-2 focus:tw-ring-secondary`}
                                         passHref={true}
                                         onClick={(e) => {
                                             e.preventDefault();
@@ -178,22 +176,18 @@ export const EngagementModal: React.FC<EngagementModalProps> = ({
                                             }
                                         }}
                                     >
-                                        <span className="tw-group-hover:tw-mr-2 tw-inline-block tw-transition-all">
-                                            {cta2.label}
-                                        </span>
-                                        <span className={`${styles.emoji}`} aria-hidden="true">
+                                        <span className="tw-leading-none">{cta2.label}</span>
+                                        <span className={styles.emoji} aria-hidden="true">
                                             🚀
                                         </span>
                                     </Link>
                                 ) : (
                                     <a
                                         href={cta2.href}
-                                        className={`${styles.button} tw-group tw-w-full tw-rounded tw-bg-secondary tw-px-8 tw-py-4 tw-text-center tw-text-lg tw-font-semibold tw-text-white tw-transition hover:tw-bg-accent hover:tw-text-secondary focus:tw-ring-2 focus:tw-ring-secondary`}
+                                        className={`${styles.button} tw-group tw-relative tw-flex tw-w-full tw-items-center tw-justify-center tw-rounded tw-bg-secondary tw-px-8 tw-py-4 tw-text-lg tw-font-semibold tw-text-white tw-transition hover:tw-bg-accent hover:tw-text-secondary focus:tw-ring-2 focus:tw-ring-secondary`}
                                     >
-                                        <span className="tw-group-hover:tw-mr-2 tw-inline-block tw-transition-all">
-                                            {cta2.label}
-                                        </span>
-                                        <span className={`${styles.emoji}`} aria-hidden="true">
+                                        <span className="tw-leading-none">{cta2.label}</span>
+                                        <span className={styles.emoji} aria-hidden="true">
                                             🚀
                                         </span>
                                     </a>


### PR DESCRIPTION
## Summary
- Closes #1003 — bumps modal `tw-z-50` → `tw-z-[100]` so it sits above the header announcement banner (`tw-z-[60]`), unblocking the close button on mobile.
- Closes #1004 — switches CTA buttons to flex centering and positions the hover emoji absolutely. Previously the hidden emoji (`opacity:0` but `display:inline-block` + `margin-left`) occupied layout space and shifted the text leftward of true center.
- Wiggle keyframes now compose `translateY(-50%)` so the emoji stays vertically centered while animating on hover.

## Test plan
- [ ] Trigger homepage popup on mobile viewport with the announcement banner visible — close button is clickable and not occluded.
- [ ] Verify on desktop the modal still renders above all other layout chrome.
- [ ] Hover each CTA button — text remains horizontally centered, emoji fades in on the right and wiggles.
- [ ] Inspect at 320px, 375px, 768px, 1280px — text stays centered across breakpoints.