### PR TITLE
feat(dark-mode): enable Tailwind class-based darkMode

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 /* eslint-disable import/no-extraneous-dependencies */
 module.exports = {
+    darkMode: "class",
     safelist: ["group-hover:tw-animate-wiggle"],
     content: ["./src/**/*.tsx"],
     prefix: "tw-",


### PR DESCRIPTION
## Summary
- Closes #1029.
- Adds `darkMode: "class"` to `tailwind.config.js` (note: actual file lives at repo root, not `src/`).
- Chose `class` over `media` because the dark-mode initiative ships an explicit toggle + persisted preference; `media` would ignore the toggle entirely.
- Verified zero `dark:` utilities currently in `src/`, so this change has no immediate visual effect — utilities only activate once the upcoming toggle adds the `dark` class to `<html>`.

## Test plan
- [x] `npm run build` succeeds.
- [ ] Smoke test: temporarily add `class="dark"` to `<html>` and a `dark:tw-bg-navy` utility somewhere; confirm it applies.
- [ ] No visual regressions on existing pages (no `dark:` utilities exist yet).