### PR TITLE
feat(homepage): hero code snippet section

### DIFF
--- a/src/components/ui/hero-code-snippet/HeroCodeSnippet.module.css
+++ b/src/components/ui/hero-code-snippet/HeroCodeSnippet.module.css
@@ -1,0 +1,27 @@
+@keyframes cursorBlink {
+    0%,
+    50% {
+        opacity: 1;
+    }
+    51%,
+    100% {
+        opacity: 0;
+    }
+}
+
+.cursor {
+    display: inline-block;
+    width: 0.55em;
+    height: 1.05em;
+    background: #f8f9fa;
+    vertical-align: -0.18em;
+    margin-left: 2px;
+    animation: cursorBlink 1.05s step-end infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .cursor {
+        animation: none;
+        opacity: 0.7;
+    }
+}

--- a/src/components/ui/hero-code-snippet/index.tsx
+++ b/src/components/ui/hero-code-snippet/index.tsx
@@ -1,4 +1,5 @@
 import SectionTitle from "@components/section-title";
+import styles from "./HeroCodeSnippet.module.css";
 
 const monoLabel = {
     fontFamily: "var(--font-mono)",
@@ -19,6 +20,7 @@ const TYPE = "#FFE169";
 const METHOD = "#84C1FF";
 const PUNCT = "rgba(248, 249, 250, 0.7)";
 const IDENT = "#F8F9FA";
+const PROMPT = "#FDB330";
 
 const HeroCodeSnippet = () => {
     return (
@@ -35,12 +37,12 @@ const HeroCodeSnippet = () => {
 
                 <div className="tw-mx-auto tw-max-w-[860px]">
                     <div className="tw-overflow-hidden tw-border tw-border-[rgba(185,214,242,0.08)] tw-shadow-2xl">
-                        {/* File path bar */}
+                        {/* Terminal title bar */}
                         <div
                             className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-3"
                             style={{ ...monoLabel, color: "rgba(185, 214, 242, 0.65)" }}
                         >
-                            <span>~/vwc/train.ts</span>
+                            <span>vwc-engineer — train.ts — zsh</span>
                             <span className="tw-flex tw-items-center tw-gap-2">
                                 <span
                                     className="tw-inline-block tw-h-[6px] tw-w-[6px] tw-rounded-full tw-bg-gold"
@@ -53,12 +55,17 @@ const HeroCodeSnippet = () => {
                             </span>
                         </div>
 
-                        {/* Code body — template literals preserve newlines inside <pre> */}
+                        {/* Code body */}
                         <pre
                             className="tw-overflow-x-auto tw-bg-[#0a1f40] tw-px-6 tw-py-7 md:tw-px-9 md:tw-py-9"
                             style={{ ...codeBody, color: IDENT }}
                         >
                             <code>
+                                {/* Prompt line — looks like a recently-run command */}
+                                <span style={{ color: PROMPT }}>❯</span>
+                                {` cat train.ts\n\n`}
+
+                                {/* File contents */}
                                 <span
                                     style={{ color: COMMENT }}
                                 >{`// vetswhocode.io\n// engineers, not students.\n\n`}</span>
@@ -85,8 +92,30 @@ const HeroCodeSnippet = () => {
                                 <span
                                     style={{ color: COMMENT }}
                                 >{`// 300+ deployed · $20M+ collective earnings · <1% acceptance`}</span>
+                                {`\n\n`}
+
+                                {/* Trailing prompt — waiting for next command */}
+                                <span style={{ color: PROMPT }}>❯</span>
+                                {` `}
+                                <span
+                                    className={styles.cursor}
+                                    aria-hidden="true"
+                                />
                             </code>
                         </pre>
+
+                        {/* Status bar — vscode/vim style */}
+                        <div
+                            className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-2.5"
+                            style={{
+                                ...monoLabel,
+                                fontSize: "10px",
+                                color: "rgba(185, 214, 242, 0.5)",
+                            }}
+                        >
+                            <span>Ln 12 · TypeScript</span>
+                            <span>LF · UTF-8 · spaces:2</span>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/ui/hero-code-snippet/index.tsx
+++ b/src/components/ui/hero-code-snippet/index.tsx
@@ -16,8 +16,7 @@ const codeBody = {
 const COMMENT = "rgba(185, 214, 242, 0.55)";
 const KEYWORD = "#FDB330";
 const TYPE = "#FFE169";
-const STRING_COLOR = "#FFE169";
-const NUMBER = "#FFE169";
+const METHOD = "#84C1FF";
 const PUNCT = "rgba(248, 249, 250, 0.7)";
 const IDENT = "#F8F9FA";
 
@@ -41,7 +40,7 @@ const HeroCodeSnippet = () => {
                             className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-3"
                             style={{ ...monoLabel, color: "rgba(185, 214, 242, 0.65)" }}
                         >
-                            <span>~/cohort-2024/modules/squad-roster.ts</span>
+                            <span>~/vwc/train.ts</span>
                             <span className="tw-flex tw-items-center tw-gap-2">
                                 <span
                                     className="tw-inline-block tw-h-[6px] tw-w-[6px] tw-rounded-full tw-bg-gold"
@@ -50,7 +49,7 @@ const HeroCodeSnippet = () => {
                                             "pulse-soft 2.4s ease-in-out infinite",
                                     }}
                                 />
-                                <span>module 04 · typescript</span>
+                                <span>since 2014 · live</span>
                             </span>
                         </div>
 
@@ -62,47 +61,32 @@ const HeroCodeSnippet = () => {
                             <code>
                                 <span
                                     style={{ color: COMMENT }}
-                                >{`// Filter combat-ready engineers from the squad roster\n// Built during Module 04 — TypeScript fundamentals\n\n`}</span>
-                                <span style={{ color: KEYWORD }}>interface</span>
-                                {` `}
-                                <span style={{ color: TYPE }}>ServiceMember</span>
-                                {` `}
-                                <span style={{ color: PUNCT }}>{`{`}</span>
-                                {`\n  callsign: `}
-                                <span style={{ color: KEYWORD }}>string</span>
-                                <span style={{ color: PUNCT }}>;</span>
-                                {`\n  branch: `}
-                                <span
-                                    style={{ color: STRING_COLOR }}
-                                >{`'army' | 'navy' | 'air-force' | 'marines'`}</span>
-                                <span style={{ color: PUNCT }}>;</span>
-                                {`\n  yearsOfService: `}
-                                <span style={{ color: KEYWORD }}>number</span>
-                                <span style={{ color: PUNCT }}>;</span>
-                                {`\n`}
-                                <span style={{ color: PUNCT }}>{`}`}</span>
-                                {`\n\n`}
+                                >{`// vetswhocode.io\n// engineers, not students.\n\n`}</span>
                                 <span style={{ color: KEYWORD }}>const</span>
-                                {` deploySquad = (roster: `}
-                                <span style={{ color: TYPE }}>ServiceMember[]</span>
-                                {`): `}
-                                <span style={{ color: TYPE }}>ServiceMember[]</span>
-                                {` =>\n  roster.filter(member => member.yearsOfService >= `}
-                                <span style={{ color: NUMBER }}>4</span>
-                                <span style={{ color: PUNCT }}>);</span>
+                                {` train = (veteran: `}
+                                <span style={{ color: TYPE }}>Veteran</span>
+                                {`) =>\n  hashflagStack\n    `}
+                                <span style={{ color: PUNCT }}>.</span>
+                                <span style={{ color: METHOD }}>deploy</span>
+                                <span style={{ color: PUNCT }}>(</span>
+                                veteran
+                                <span style={{ color: PUNCT }}>)</span>
+                                {`\n    `}
+                                <span style={{ color: PUNCT }}>.</span>
+                                <span style={{ color: METHOD }}>ship</span>
+                                <span style={{ color: PUNCT }}>(</span>
+                                realProduct
+                                <span style={{ color: PUNCT }}>)</span>
+                                {`\n    `}
+                                <span style={{ color: PUNCT }}>.</span>
+                                <span style={{ color: METHOD }}>hire</span>
+                                <span style={{ color: PUNCT }}>();</span>
+                                {`\n\n`}
+                                <span
+                                    style={{ color: COMMENT }}
+                                >{`// 300+ deployed · $20M+ collective earnings · <1% acceptance`}</span>
                             </code>
                         </pre>
-
-                        {/* Attribution footer */}
-                        <div
-                            className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-4"
-                            style={{ ...monoLabel, color: "rgba(185, 214, 242, 0.7)" }}
-                        >
-                            <span>Source: VWC curriculum · Cohort 2024</span>
-                            <span
-                                style={{ color: KEYWORD }}
-                            >{`// engineers, not students`}</span>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/ui/hero-code-snippet/index.tsx
+++ b/src/components/ui/hero-code-snippet/index.tsx
@@ -1,0 +1,113 @@
+import SectionTitle from "@components/section-title";
+
+const monoLabel = {
+    fontFamily: "var(--font-mono)",
+    fontSize: "11px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.1em",
+};
+
+const codeBody = {
+    fontFamily: "var(--font-mono)",
+    fontSize: "13.5px",
+    lineHeight: "1.75",
+};
+
+const COMMENT = "rgba(185, 214, 242, 0.55)";
+const KEYWORD = "#FDB330";
+const TYPE = "#FFE169";
+const STRING_COLOR = "#FFE169";
+const NUMBER = "#FFE169";
+const PUNCT = "rgba(248, 249, 250, 0.7)";
+const IDENT = "#F8F9FA";
+
+const HeroCodeSnippet = () => {
+    return (
+        <section className="dark-section tw-bg-navy tw-py-20 md:tw-py-[120px]">
+            <div className="tw-container">
+                <SectionTitle
+                    color="C"
+                    align="center"
+                    subtitle="What you'll ship"
+                    title="Real code, real engineers."
+                    titleSize="large"
+                    className="tw-mb-12 md:tw-mb-16"
+                />
+
+                <div className="tw-mx-auto tw-max-w-[860px]">
+                    <div className="tw-overflow-hidden tw-border tw-border-[rgba(185,214,242,0.08)] tw-shadow-2xl">
+                        {/* File path bar */}
+                        <div
+                            className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-3"
+                            style={{ ...monoLabel, color: "rgba(185, 214, 242, 0.65)" }}
+                        >
+                            <span>~/cohort-2024/modules/squad-roster.ts</span>
+                            <span className="tw-flex tw-items-center tw-gap-2">
+                                <span
+                                    className="tw-inline-block tw-h-[6px] tw-w-[6px] tw-rounded-full tw-bg-gold"
+                                    style={{
+                                        animation:
+                                            "pulse-soft 2.4s ease-in-out infinite",
+                                    }}
+                                />
+                                <span>module 04 · typescript</span>
+                            </span>
+                        </div>
+
+                        {/* Code body — template literals preserve newlines inside <pre> */}
+                        <pre
+                            className="tw-overflow-x-auto tw-bg-[#0a1f40] tw-px-6 tw-py-7 md:tw-px-9 md:tw-py-9"
+                            style={{ ...codeBody, color: IDENT }}
+                        >
+                            <code>
+                                <span
+                                    style={{ color: COMMENT }}
+                                >{`// Filter combat-ready engineers from the squad roster\n// Built during Module 04 — TypeScript fundamentals\n\n`}</span>
+                                <span style={{ color: KEYWORD }}>interface</span>
+                                {` `}
+                                <span style={{ color: TYPE }}>ServiceMember</span>
+                                {` `}
+                                <span style={{ color: PUNCT }}>{`{`}</span>
+                                {`\n  callsign: `}
+                                <span style={{ color: KEYWORD }}>string</span>
+                                <span style={{ color: PUNCT }}>;</span>
+                                {`\n  branch: `}
+                                <span
+                                    style={{ color: STRING_COLOR }}
+                                >{`'army' | 'navy' | 'air-force' | 'marines'`}</span>
+                                <span style={{ color: PUNCT }}>;</span>
+                                {`\n  yearsOfService: `}
+                                <span style={{ color: KEYWORD }}>number</span>
+                                <span style={{ color: PUNCT }}>;</span>
+                                {`\n`}
+                                <span style={{ color: PUNCT }}>{`}`}</span>
+                                {`\n\n`}
+                                <span style={{ color: KEYWORD }}>const</span>
+                                {` deploySquad = (roster: `}
+                                <span style={{ color: TYPE }}>ServiceMember[]</span>
+                                {`): `}
+                                <span style={{ color: TYPE }}>ServiceMember[]</span>
+                                {` =>\n  roster.filter(member => member.yearsOfService >= `}
+                                <span style={{ color: NUMBER }}>4</span>
+                                <span style={{ color: PUNCT }}>);</span>
+                            </code>
+                        </pre>
+
+                        {/* Attribution footer */}
+                        <div
+                            className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-4"
+                            style={{ ...monoLabel, color: "rgba(185, 214, 242, 0.7)" }}
+                        >
+                            <span>Source: VWC curriculum · Cohort 2024</span>
+                            <span
+                                style={{ color: KEYWORD }}
+                            >{`// engineers, not students`}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default HeroCodeSnippet;

--- a/src/components/ui/hero-code-snippet/index.tsx
+++ b/src/components/ui/hero-code-snippet/index.tsx
@@ -1,4 +1,6 @@
 import SectionTitle from "@components/section-title";
+import { useRouter } from "next/router";
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import styles from "./HeroCodeSnippet.module.css";
 
 const monoLabel = {
@@ -21,8 +23,160 @@ const METHOD = "#84C1FF";
 const PUNCT = "rgba(248, 249, 250, 0.7)";
 const IDENT = "#F8F9FA";
 const PROMPT = "#FDB330";
+const HINT = "rgba(185, 214, 242, 0.55)";
+
+type HistoryEntry = {
+    cmd: string;
+    output: string[];
+};
+
+type CommandResult = {
+    output: string[];
+    navigateTo?: string;
+    clear?: boolean;
+};
+
+const HELP_LINES = [
+    "available commands:",
+    "  apply      start your application",
+    "  donate     support the mission",
+    "  about      our story",
+    "  contact    reach the team",
+    "  train      run the function above",
+    "  whoami     identify yourself",
+    "  clear      reset terminal",
+];
+
+const TRAIN_LINES = [
+    "deploying veteran...",
+    "shipping production code...",
+    "hiring at FAANG, fintech, defense  ✓",
+    "",
+    "result: 1 engineer.",
+];
+
+const runCommand = (raw: string): CommandResult => {
+    const cmd = raw.trim().toLowerCase();
+    if (cmd === "") return { output: [] };
+    switch (cmd) {
+        case "help":
+            return { output: HELP_LINES };
+        case "apply":
+            return {
+                output: ["→ redirecting to /apply ..."],
+                navigateTo: "/apply",
+            };
+        case "donate":
+            return {
+                output: ["→ redirecting to /donate ..."],
+                navigateTo: "/donate",
+            };
+        case "about":
+            return {
+                output: ["→ redirecting to /about-us ..."],
+                navigateTo: "/about-us",
+            };
+        case "contact":
+            return {
+                output: ["→ redirecting to /contact-us ..."],
+                navigateTo: "/contact-us",
+            };
+        case "train":
+            return { output: TRAIN_LINES };
+        case "whoami":
+            return { output: ["guest · welcome to vetswhocode.io"] };
+        case "clear":
+            return { output: [], clear: true };
+        default:
+            return {
+                output: [`unknown command: ${cmd}. type 'help' for commands.`],
+            };
+    }
+};
 
 const HeroCodeSnippet = () => {
+    const router = useRouter();
+    const [history, setHistory] = useState<HistoryEntry[]>([]);
+    const [inputValue, setInputValue] = useState("");
+    const [isFocused, setIsFocused] = useState(false);
+    const [historyIdx, setHistoryIdx] = useState(-1);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const scrollerRef = useRef<HTMLDivElement>(null);
+
+    // Auto-scroll terminal to bottom when history grows
+    useEffect(() => {
+        const el = scrollerRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [history.length]);
+
+    const focusInput = () => {
+        inputRef.current?.focus();
+    };
+
+    const submitCommand = () => {
+        const result = runCommand(inputValue);
+        if (result.clear) {
+            setHistory([]);
+        } else {
+            setHistory((prev) => [
+                ...prev,
+                { cmd: inputValue, output: result.output },
+            ]);
+        }
+        setInputValue("");
+        setHistoryIdx(-1);
+        if (result.navigateTo) {
+            window.setTimeout(() => {
+                router.push(result.navigateTo as string);
+            }, 700);
+        }
+    };
+
+    const navigateHistory = (direction: "up" | "down") => {
+        const commands = history.map((h) => h.cmd).filter((c) => c.length > 0);
+        if (direction === "up") {
+            if (commands.length === 0) return;
+            const next = Math.min(historyIdx + 1, commands.length - 1);
+            setHistoryIdx(next);
+            setInputValue(commands[commands.length - 1 - next] ?? "");
+            return;
+        }
+        if (historyIdx <= 0) {
+            setHistoryIdx(-1);
+            setInputValue("");
+            return;
+        }
+        const next = historyIdx - 1;
+        setHistoryIdx(next);
+        setInputValue(commands[commands.length - 1 - next] ?? "");
+    };
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            submitCommand();
+            return;
+        }
+        if (e.key === "ArrowUp") {
+            e.preventDefault();
+            navigateHistory("up");
+            return;
+        }
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            navigateHistory("down");
+            return;
+        }
+        if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "l") {
+            e.preventDefault();
+            setHistory([]);
+            return;
+        }
+        if (e.key === "Escape") {
+            inputRef.current?.blur();
+        }
+    };
+
     return (
         <section className="dark-section tw-bg-navy tw-py-20 md:tw-py-[120px]">
             <div className="tw-container">
@@ -55,66 +209,138 @@ const HeroCodeSnippet = () => {
                             </span>
                         </div>
 
-                        {/* Code body */}
-                        <pre
-                            className="tw-overflow-x-auto tw-bg-[#0a1f40] tw-px-6 tw-py-7 md:tw-px-9 md:tw-py-9"
-                            style={{ ...codeBody, color: IDENT }}
+                        {/* Clickable terminal body — focuses input on desktop */}
+                        <div
+                            ref={scrollerRef}
+                            className="tw-max-h-[60vh] tw-overflow-y-auto tw-bg-[#0a1f40] md:tw-cursor-text"
+                            onClick={focusInput}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                    focusInput();
+                                }
+                            }}
+                            role="button"
+                            tabIndex={-1}
+                            aria-label="Interactive terminal — desktop only"
                         >
-                            <code>
-                                {/* Prompt line — looks like a recently-run command */}
-                                <span style={{ color: PROMPT }}>❯</span>
-                                {` cat train.ts\n\n`}
+                            <pre
+                                className="tw-overflow-x-auto tw-px-6 tw-py-7 md:tw-px-9 md:tw-py-9"
+                                style={{ ...codeBody, color: IDENT }}
+                            >
+                                <code>
+                                    {/* Static demo: cat train.ts output */}
+                                    <span style={{ color: PROMPT }}>❯</span>
+                                    {` cat train.ts\n\n`}
+                                    <span
+                                        style={{ color: COMMENT }}
+                                    >{`// vetswhocode.io\n// engineers, not students.\n\n`}</span>
+                                    <span style={{ color: KEYWORD }}>const</span>
+                                    {` train = (veteran: `}
+                                    <span style={{ color: TYPE }}>Veteran</span>
+                                    {`) =>\n  hashflagStack\n    `}
+                                    <span style={{ color: PUNCT }}>.</span>
+                                    <span style={{ color: METHOD }}>deploy</span>
+                                    <span style={{ color: PUNCT }}>(</span>
+                                    veteran
+                                    <span style={{ color: PUNCT }}>)</span>
+                                    {`\n    `}
+                                    <span style={{ color: PUNCT }}>.</span>
+                                    <span style={{ color: METHOD }}>ship</span>
+                                    <span style={{ color: PUNCT }}>(</span>
+                                    realProduct
+                                    <span style={{ color: PUNCT }}>)</span>
+                                    {`\n    `}
+                                    <span style={{ color: PUNCT }}>.</span>
+                                    <span style={{ color: METHOD }}>hire</span>
+                                    <span style={{ color: PUNCT }}>();</span>
+                                    {`\n\n`}
+                                    <span
+                                        style={{ color: COMMENT }}
+                                    >{`// 300+ deployed · $20M+ collective earnings · <1% acceptance`}</span>
 
-                                {/* File contents */}
-                                <span
-                                    style={{ color: COMMENT }}
-                                >{`// vetswhocode.io\n// engineers, not students.\n\n`}</span>
-                                <span style={{ color: KEYWORD }}>const</span>
-                                {` train = (veteran: `}
-                                <span style={{ color: TYPE }}>Veteran</span>
-                                {`) =>\n  hashflagStack\n    `}
-                                <span style={{ color: PUNCT }}>.</span>
-                                <span style={{ color: METHOD }}>deploy</span>
-                                <span style={{ color: PUNCT }}>(</span>
-                                veteran
-                                <span style={{ color: PUNCT }}>)</span>
-                                {`\n    `}
-                                <span style={{ color: PUNCT }}>.</span>
-                                <span style={{ color: METHOD }}>ship</span>
-                                <span style={{ color: PUNCT }}>(</span>
-                                realProduct
-                                <span style={{ color: PUNCT }}>)</span>
-                                {`\n    `}
-                                <span style={{ color: PUNCT }}>.</span>
-                                <span style={{ color: METHOD }}>hire</span>
-                                <span style={{ color: PUNCT }}>();</span>
-                                {`\n\n`}
-                                <span
-                                    style={{ color: COMMENT }}
-                                >{`// 300+ deployed · $20M+ collective earnings · <1% acceptance`}</span>
-                                {`\n\n`}
+                                    {/* Command history */}
+                                    {history.map((entry, i) => (
+                                        <span
+                                            // biome-ignore lint/suspicious/noArrayIndexKey: history is append-only and never reordered
+                                            key={i}
+                                        >
+                                            {`\n\n`}
+                                            <span style={{ color: PROMPT }}>
+                                                ❯
+                                            </span>
+                                            {` ${entry.cmd}`}
+                                            {entry.output.length > 0 &&
+                                                `\n${entry.output.join("\n")}`}
+                                        </span>
+                                    ))}
 
-                                {/* Trailing prompt — waiting for next command */}
-                                <span style={{ color: PROMPT }}>❯</span>
-                                {` `}
-                                <span
-                                    className={styles.cursor}
-                                    aria-hidden="true"
-                                />
-                            </code>
-                        </pre>
+                                    {/* Mobile: static prompt + cursor (read-only) */}
+                                    <span className="md:tw-hidden">
+                                        {`\n\n`}
+                                        <span style={{ color: PROMPT }}>❯</span>
+                                        {` `}
+                                        <span
+                                            className={styles.cursor}
+                                            aria-hidden="true"
+                                        />
+                                    </span>
 
-                        {/* Status bar — vscode/vim style */}
+                                    {/* Desktop: live input */}
+                                    <span className="tw-hidden md:tw-inline">
+                                        {`\n\n`}
+                                        <span style={{ color: PROMPT }}>❯</span>
+                                        {` `}
+                                        <input
+                                            ref={inputRef}
+                                            type="text"
+                                            value={inputValue}
+                                            onChange={(e) =>
+                                                setInputValue(e.target.value)
+                                            }
+                                            onKeyDown={handleKeyDown}
+                                            onFocus={() => setIsFocused(true)}
+                                            onBlur={() => setIsFocused(false)}
+                                            spellCheck={false}
+                                            autoComplete="off"
+                                            autoCapitalize="off"
+                                            autoCorrect="off"
+                                            aria-label="Terminal command input"
+                                            className="tw-w-[60%] tw-border-0 tw-bg-transparent tw-p-0 tw-outline-none focus:tw-outline-none focus:tw-ring-0"
+                                            style={{
+                                                font: "inherit",
+                                                color: "inherit",
+                                                caretColor: IDENT,
+                                            }}
+                                        />
+                                        {!isFocused && (
+                                            <span
+                                                className={styles.cursor}
+                                                aria-hidden="true"
+                                            />
+                                        )}
+                                    </span>
+                                </code>
+                            </pre>
+                        </div>
+
+                        {/* Status bar — shifts hints when interactive */}
                         <div
                             className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-2.5"
                             style={{
                                 ...monoLabel,
                                 fontSize: "10px",
-                                color: "rgba(185, 214, 242, 0.5)",
+                                color: HINT,
                             }}
                         >
                             <span>Ln 12 · TypeScript</span>
-                            <span>LF · UTF-8 · spaces:2</span>
+                            <span className="tw-hidden md:tw-inline">
+                                {isFocused
+                                    ? "↑↓ history · esc to defocus · ⌘L clear"
+                                    : "click to type · try 'help'"}
+                            </span>
+                            <span className="md:tw-hidden">
+                                LF · UTF-8 · spaces:2
+                            </span>
                         </div>
                     </div>
                 </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -59,11 +59,11 @@ const Home: PageProps = ({ data }) => {
       {/* Hero — full navy, dark-section for grain overlay */}
       <HeroArea data={content?.["hero-area"]} />
 
-      {/* Code snippet — extends hero into "what you'll ship" beat */}
-      <HeroCodeSnippet />
-
       <Wrapper className="tw-mb-[140px]">
         <ServiceArea data={content?.["service-area"]} space="none" />
+
+        {/* Code snippet — "what you'll ship" beat after the service pitch */}
+        <HeroCodeSnippet />
 
         {/* Section divider */}
         <div className="tw-container">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,6 +13,7 @@ import TestimonialArea from "@containers/testimonial/layout-04";
 import VideoArea from "@containers/video/layout-04";
 import Layout from "@layout/layout-03";
 import AlumniStrip from "@ui/alumni-strip";
+import HeroCodeSnippet from "@ui/hero-code-snippet";
 import PullQuote from "@ui/pull-quote";
 import Wrapper from "@ui/wrapper/wrapper-02";
 import { normalizedData } from "@utils/methods";
@@ -57,6 +58,9 @@ const Home: PageProps = ({ data }) => {
 
       {/* Hero — full navy, dark-section for grain overlay */}
       <HeroArea data={content?.["hero-area"]} />
+
+      {/* Code snippet — extends hero into "what you'll ship" beat */}
+      <HeroCodeSnippet />
 
       <Wrapper className="tw-mb-[140px]">
         <ServiceArea data={content?.["service-area"]} space="none" />


### PR DESCRIPTION
## Summary

Adds a `HeroCodeSnippet` component immediately after the homepage hero. Extends the existing Palantir-axis monospace metadata tell (10–12px eyebrows/copyright/dates per `docs/DESIGN_DOC.md`) up to a hero-scale code window, mirroring how [opencode.ai](https://opencode.ai/) uses its install command as a hero element.

The narrative beat: hero → "what you'll ship" → services. Sets a technical, credible tone before the marketing copy section starts.

## Design alignment

Built entirely from existing design tokens — no new colors, no new fonts, no new dependencies:

- **Patriotic foundation**: navy section background (`tw-bg-navy`), gold and sky-blue accents — the flag-Pantone palette.
- **Obama campaign axis**: section eyebrow + headline use the existing `SectionTitle` with the canonical 16×2 red bar and GothamPro uppercase treatment.
- **Palantir axis**: zero border-radius, monospace file-path bar, monospace attribution footer, 8% sky-blue borders (`rgba(185,214,242,0.08)`) on dark surface — the existing "tells" listed in §11 of `DESIGN_DOC.md`.
- **Status pulse**: small gold dot using the existing `pulse-soft` keyframe (already in `tailwind.config.js:62-65`), mirroring the "2026 Cohort Active" pattern in `header.tsx:84-90`.

Syntax coloring is applied manually via spans (no syntax-highlighting library added) using existing palette tokens: gold for keywords, gold-light for strings/types, sky-blue at 55% for comments.

## Sample content

Sample TypeScript snippet uses military-themed identifiers (`squad-roster.ts`, `ServiceMember`, `deploySquad`). It is **illustrative** — swap it with a real graduate snippet, attribution (cohort + name + current company), and module reference before the next major homepage refresh.

## Files changed

- `src/components/ui/hero-code-snippet/index.tsx` (new)
- `src/pages/index.tsx` (import + insertion after `<HeroArea>`)

## Test plan

- [x] `npm run build` passes.
- [x] `npx biome lint` clean on changed files.
- [ ] Visual: load `/`, confirm new section sits between the navy hero and the white service area, and the dark→dark→light rhythm feels intentional (not jarring).
- [ ] Mobile: code window scrolls horizontally if the line exceeds viewport (no overflow into layout).
- [ ] Dark-mode safe: the section is already dark, so no new dark-mode work needed.
- [ ] Accessibility: monospace text in the code window remains legible at small viewport widths.