### PR TITLE
feat(homepage): hero stat belt with three above-the-fold outcomes

### DIFF
--- a/src/components/ui/hero-stat-belt/index.tsx
+++ b/src/components/ui/hero-stat-belt/index.tsx
@@ -1,0 +1,102 @@
+type Stat = {
+    /** Big number/value, e.g. "300+", "$20M+", "<1%" */
+    value: string;
+    /** Short label, displayed beneath the value in monospace uppercase */
+    label: string;
+    /** Optional second-line context, e.g. "since 2014" */
+    sub?: string;
+};
+
+const STATS: Stat[] = [
+    {
+        value: "300+",
+        label: "Veterans Deployed",
+        sub: "as production engineers since 2014",
+    },
+    {
+        value: "$20M+",
+        label: "Collective Earnings",
+        sub: "first-year compensation, alumni",
+    },
+    {
+        value: "<1%",
+        label: "Acceptance Rate",
+        sub: "selectivity comparable to top CS programs",
+    },
+];
+
+const monoLabel = {
+    fontFamily: "var(--font-mono)",
+    fontSize: "11px",
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.12em",
+};
+
+const HeroStatBelt = () => {
+    return (
+        <section
+            className="dark-section tw-bg-navy tw-border-t tw-border-[rgba(185,214,242,0.08)] tw-py-10 md:tw-py-14"
+            aria-label="Vets Who Code outcomes"
+        >
+            <div className="tw-container">
+                <ul className="tw-grid tw-grid-cols-1 tw-gap-8 sm:tw-grid-cols-3 sm:tw-gap-6 md:tw-gap-10">
+                    {STATS.map((stat) => (
+                        <li
+                            key={stat.label}
+                            className="tw-flex tw-flex-col tw-gap-2"
+                        >
+                            {/* Top row: pulse dot + label */}
+                            <div
+                                className="tw-flex tw-items-center tw-gap-2.5"
+                                style={{
+                                    ...monoLabel,
+                                    color: "rgba(185, 214, 242, 0.7)",
+                                }}
+                            >
+                                <span
+                                    className="tw-inline-block tw-h-[6px] tw-w-[6px] tw-rounded-full tw-bg-gold"
+                                    style={{
+                                        animation:
+                                            "pulse-soft 2.4s ease-in-out infinite",
+                                    }}
+                                    aria-hidden="true"
+                                />
+                                <span>{stat.label}</span>
+                            </div>
+
+                            {/* Big value — Obama-axis GothamPro */}
+                            <div
+                                className="tw-text-white"
+                                style={{
+                                    fontFamily: "var(--font-headline)",
+                                    fontWeight: 800,
+                                    fontSize: "clamp(40px, 5.4vw, 64px)",
+                                    lineHeight: 1.05,
+                                    letterSpacing: "-0.02em",
+                                }}
+                            >
+                                {stat.value}
+                            </div>
+
+                            {/* Sub-context */}
+                            {stat.sub && (
+                                <div
+                                    style={{
+                                        fontFamily: "var(--font-body)",
+                                        fontSize: "13px",
+                                        lineHeight: 1.5,
+                                        color: "rgba(185, 214, 242, 0.55)",
+                                    }}
+                                >
+                                    {stat.sub}
+                                </div>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        </section>
+    );
+};
+
+export default HeroStatBelt;

--- a/src/components/ui/stat-belt/index.tsx
+++ b/src/components/ui/stat-belt/index.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 type Stat = {
     /** Big number/value, e.g. "300+", "$20M+", "<1%" */
     value: string;
@@ -32,13 +34,45 @@ const monoLabel = {
     letterSpacing: "0.12em",
 };
 
-const HeroStatBelt = () => {
+const StatBelt = () => {
     return (
         <section
             className="dark-section tw-bg-navy tw-border-t tw-border-[rgba(185,214,242,0.08)] tw-py-10 md:tw-py-14"
             aria-label="Vets Who Code outcomes"
         >
             <div className="tw-container">
+                {/* Tagline + CTA bar — sits above the three stats */}
+                <div className="tw-mb-8 tw-flex tw-flex-col tw-items-start tw-justify-between tw-gap-3 tw-border-b tw-border-[rgba(185,214,242,0.08)] tw-pb-8 sm:tw-flex-row sm:tw-items-center md:tw-mb-10 md:tw-pb-10">
+                    <p
+                        className="tw-m-0 tw-text-white"
+                        style={{
+                            fontFamily: "var(--font-headline)",
+                            fontWeight: 700,
+                            fontSize: "clamp(18px, 2vw, 22px)",
+                            letterSpacing: "-0.01em",
+                            lineHeight: 1.3,
+                        }}
+                    >
+                        First commit to production. Built by veterans.
+                    </p>
+                    <Link
+                        href="/projects"
+                        className="tw-group tw-inline-flex tw-items-center tw-gap-2 tw-whitespace-nowrap tw-text-gold hover:tw-text-gold-light"
+                        style={{
+                            ...monoLabel,
+                            letterSpacing: "0.1em",
+                        }}
+                    >
+                        <span>See the work</span>
+                        <span
+                            className="tw-inline-block tw-transition-transform group-hover:tw-translate-x-1"
+                            aria-hidden="true"
+                        >
+                            →
+                        </span>
+                    </Link>
+                </div>
+
                 <ul className="tw-grid tw-grid-cols-1 tw-gap-8 sm:tw-grid-cols-3 sm:tw-gap-6 md:tw-gap-10">
                     {STATS.map((stat) => (
                         <li
@@ -99,4 +133,4 @@ const HeroStatBelt = () => {
     );
 };
 
-export default HeroStatBelt;
+export default StatBelt;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,8 +14,8 @@ import VideoArea from "@containers/video/layout-04";
 import Layout from "@layout/layout-03";
 import AlumniStrip from "@ui/alumni-strip";
 import HeroCodeSnippet from "@ui/hero-code-snippet";
-import HeroStatBelt from "@ui/hero-stat-belt";
 import PullQuote from "@ui/pull-quote";
+import StatBelt from "@ui/stat-belt";
 import Wrapper from "@ui/wrapper/wrapper-02";
 import { normalizedData } from "@utils/methods";
 import { IBlog, ICourse, IEvent, IMedia } from "@utils/types";
@@ -81,7 +81,7 @@ const Home: PageProps = ({ data }) => {
       </div>
 
       {/* Outcomes belt — results gate before the subjects/courses section */}
-      <HeroStatBelt />
+      <StatBelt />
 
       <CourseArea
         data={{ ...content?.["course-area"], courses: data.courses }}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,6 +14,7 @@ import VideoArea from "@containers/video/layout-04";
 import Layout from "@layout/layout-03";
 import AlumniStrip from "@ui/alumni-strip";
 import HeroCodeSnippet from "@ui/hero-code-snippet";
+import HeroStatBelt from "@ui/hero-stat-belt";
 import PullQuote from "@ui/pull-quote";
 import Wrapper from "@ui/wrapper/wrapper-02";
 import { normalizedData } from "@utils/methods";
@@ -58,6 +59,9 @@ const Home: PageProps = ({ data }) => {
 
       {/* Hero — full navy, dark-section for grain overlay */}
       <HeroArea data={content?.["hero-area"]} />
+
+      {/* Outcomes belt — three above-the-fold stats attached to hero */}
+      <HeroStatBelt />
 
       <Wrapper className="tw-mb-[140px]">
         <ServiceArea data={content?.["service-area"]} space="none" />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,9 +60,6 @@ const Home: PageProps = ({ data }) => {
       {/* Hero — full navy, dark-section for grain overlay */}
       <HeroArea data={content?.["hero-area"]} />
 
-      {/* Outcomes belt — three above-the-fold stats attached to hero */}
-      <HeroStatBelt />
-
       <Wrapper className="tw-mb-[140px]">
         <ServiceArea data={content?.["service-area"]} space="none" />
 
@@ -82,6 +79,9 @@ const Home: PageProps = ({ data }) => {
       <div className="tw-container">
         <div className="section-divider" />
       </div>
+
+      {/* Outcomes belt — results gate before the subjects/courses section */}
+      <HeroStatBelt />
 
       <CourseArea
         data={{ ...content?.["course-area"], courses: data.courses }}


### PR DESCRIPTION
## Summary

Adds a `HeroStatBelt` component immediately after `<HeroArea>`. Promotes the three headline outcome numbers — **300+ deployed**, **\$20M+ collective earnings**, **<1% acceptance** — to above-the-fold real estate using the live-status pulsing gold dot pattern from `header.tsx`, mirroring how [opencode.ai](https://opencode.ai/) presents its 150K stars / 850 contributors / 6.5M monthly users.

## Design alignment

Every token already exists in the system — no new colors, no new fonts, no new dependencies:

- **Patriotic foundation**: dark navy section, gold pulse dot, sky-blue muted text. Flag-Pantone palette.
- **Obama campaign axis**: large value renders in GothamPro 800 with `letter-spacing: -0.02em` and fluid `clamp(40px, 5.4vw, 64px)` — the canonical "command poster" treatment.
- **Palantir axis**: monospace uppercase label at 11px / `letter-spacing: 0.12em`, sky-blue 8% top border (`rgba(185,214,242,0.08)`), zero radius, no decorative chrome.
- **Live signal**: 6×6px gold dot using the existing `pulse-soft` keyframe — same DNA as the header's "2026 Cohort Active" badge.

## Why a belt and not a replacement for FunfactArea

The existing `FunfactArea` mid-page already shows these stats inside a full section with title, motto, and 4-tile grid — that's the **deep-dive** treatment. The belt is the **scannable above-the-fold** treatment. Veterans/donors landing on the page see the hard numbers immediately; FunfactArea later gives them the context. Reinforcement, not duplication.

## Files changed

- `src/components/ui/hero-stat-belt/index.tsx` (new)
- `src/pages/index.tsx` (import + insertion between `<HeroArea>` and `<Wrapper>`)

## Test plan

- [x] `npm run build` passes.
- [x] `npx biome lint` clean on changed files.
- [ ] Visual: load `/`, confirm belt sits flush under the hero with the 1px top border reading as a divider.
- [ ] Mobile (≤sm): three stats stack vertically with comfortable spacing.
- [ ] Tablet+: three stats render in a single row, values dominant, labels secondary.
- [ ] Pulsing dots animate at the same cadence as the header cohort badge.
- [ ] Stats numbers can be updated by editing the `STATS` array at the top of the component.