### PR TITLE
feat(nav): Auth-aware top-level menu with Programs and Train surfaces

### DIFF
--- a/src/components/socials/social-01.tsx
+++ b/src/components/socials/social-01.tsx
@@ -13,9 +13,6 @@ const Social01 = ({ className }: { className?: string }) => (
         >
             <i className="fab fa-facebook-f" />
         </SocialLink>
-        <SocialLink href="https://dev.to/vetswhocode" label="Practical Dev" className="tw-px-2.5">
-            <i className="fab fa-dev" />
-        </SocialLink>
         <SocialLink
             href="https://www.linkedin.com/company/vets-who-code"
             label="linkedin"

--- a/src/components/widgets/text-widget.tsx
+++ b/src/components/widgets/text-widget.tsx
@@ -32,9 +32,6 @@ const TextWidget = ({ className, mode }: TProps) => {
                 >
                     <i className="fab fa-facebook-square" />
                 </SocialLink>
-                <SocialLink href="https://dev.to/vetswhocode" label="Practical Dev">
-                    <i className="fab fa-dev" />
-                </SocialLink>
                 <SocialLink href="https://github.com/Vets-Who-Code" label="Github">
                     <i className="fab fa-github" />
                 </SocialLink>

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -6,6 +6,8 @@ interface MenuItem {
     path: string;
     external?: boolean;
     status?: MenuStatus;
+    requiresAuth?: boolean;
+    hideWhenAuth?: boolean;
 }
 
 interface SubMenuItem extends MenuItem {
@@ -26,21 +28,6 @@ const navigation: NavigationItem[] = [
                 path: "/about-us",
             },
             {
-                id: 102,
-                label: "Subjects & Skills",
-                path: "/subjects/all",
-            },
-            {
-                id: 103,
-                label: "FAQ",
-                path: "/faq",
-            },
-            {
-                id: 104,
-                label: "Open Source Projects",
-                path: "/projects",
-            },
-            {
                 id: 105,
                 label: "Theory of Change",
                 path: "/theory-of-change",
@@ -50,18 +37,120 @@ const navigation: NavigationItem[] = [
                 label: "Team",
                 path: "/team",
             },
+            {
+                id: 104,
+                label: "Open Source Projects",
+                path: "/projects",
+            },
+            {
+                id: 103,
+                label: "FAQ",
+                path: "/faq",
+            },
+        ],
+    },
+    {
+        id: 9,
+        label: "Programs",
+        path: "#!",
+        submenu: [
+            {
+                id: 901,
+                label: "Overview",
+                path: "/programs",
+            },
+            {
+                id: 902,
+                label: "Core Curriculum",
+                path: "/programs/core-curriculum",
+            },
+            {
+                id: 903,
+                label: "Mission-Ready",
+                path: "/programs/mission-ready",
+            },
+            {
+                id: 904,
+                label: "Mentorship",
+                path: "/programs/mentorship",
+            },
+            {
+                id: 905,
+                label: "Studio",
+                path: "/programs/studio",
+            },
         ],
     },
     {
         id: 2,
         label: "Apply",
         path: "/apply",
+        hideWhenAuth: true,
+    },
+    {
+        id: 10,
+        label: "My Cohort",
+        path: "#!",
+        requiresAuth: true,
+        submenu: [
+            {
+                id: 1001,
+                label: "Profile",
+                path: "/profile",
+            },
+        ],
+    },
+    {
+        id: 11,
+        label: "Train",
+        path: "#!",
+        requiresAuth: true,
+        submenu: [
+            {
+                id: 1101,
+                label: "Reps",
+                path: "/challenges",
+                status: "new",
+            },
+            {
+                id: 1102,
+                label: "Assessment",
+                path: "/assessment",
+            },
+            {
+                id: 1103,
+                label: "Subjects & Skills",
+                path: "/subjects/all",
+            },
+            {
+                id: 1104,
+                label: "J0d!e",
+                path: "/jodie",
+            },
+            {
+                id: 1105,
+                label: "Portfolio Checklist",
+                path: "/portfolio-checklist",
+            },
+        ],
     },
     {
         id: 3,
-        label: "Jobs",
-        path: "/jobs",
-        status: "new",
+        label: "Hire",
+        path: "#!",
+        submenu: [
+            {
+                id: 301,
+                label: "Job Board",
+                path: "/jobs",
+                status: "new",
+            },
+            {
+                id: 302,
+                label: "Career Guides",
+                path: "/career-guides",
+            },
+        ],
     },
     {
         id: 4,
@@ -71,42 +160,30 @@ const navigation: NavigationItem[] = [
     },
     {
         id: 5,
-        label: "Engage",
+        label: "Community",
         path: "#!",
         submenu: [
             {
                 id: 701,
-                label: "Game",
-                path: "/game",
-            },
-            {
-                id: 702,
                 label: "Events",
                 path: "/events",
             },
             {
-                id: 703,
+                id: 702,
                 label: "Blog",
                 path: "/blogs/blog",
             },
             {
-                id: 704, // New ID for Media
+                id: 703,
                 label: "Media",
                 path: "/media",
             },
             {
-                id: 705,
-                label: "Portfolio Checklist",
-                path: "/portfolio-checklist",
-                status: "new",
+                id: 704,
+                label: "Game",
+                path: "/game",
             },
         ],
-    },
-    {
-        id: 8,
-        label: "J0d!e",
-        path: "/jodie",
-        status: "new",
     },
     {
         id: 6,
@@ -119,5 +196,27 @@ const navigation: NavigationItem[] = [
         path: "/contact-us",
     },
 ];
+
+export function filterMenuByAuth(items: NavigationItem[], isAuthed: boolean): NavigationItem[] {
+    return items
+        .filter((item) => {
+            if (item.requiresAuth && !isAuthed) return false;
+            if (item.hideWhenAuth && isAuthed) return false;
+            return true;
+        })
+        .map((item) => {
+            if ("submenu" in item && item.submenu) {
+                return {
+                    ...item,
+                    submenu: item.submenu.filter((child) => {
+                        if (child.requiresAuth && !isAuthed) return false;
+                        if (child.hideWhenAuth && isAuthed) return false;
+                        return true;
+                    }),
+                };
+            }
+            return item;
+        });
+}
 
 export default navigation;

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -82,10 +82,23 @@ const navigation: NavigationItem[] = [
         ],
     },
     {
-        id: 2,
-        label: "Apply",
-        path: "/apply",
-        hideWhenAuth: true,
+        id: 12,
+        label: "Join",
+        path: "#!",
+        submenu: [
+            {
+                id: 1201,
+                label: "Apply",
+                path: "/apply",
+                hideWhenAuth: true,
+            },
+            {
+                id: 1202,
+                label: "Mentor",
+                path: "/mentor",
+                status: "hot",
+            },
+        ],
     },
     {
         id: 10,
@@ -153,12 +166,6 @@ const navigation: NavigationItem[] = [
         ],
     },
     {
-        id: 4,
-        label: "Mentor",
-        path: "/mentor",
-        status: "hot",
-    },
-    {
         id: 5,
         label: "Community",
         path: "#!",
@@ -198,24 +205,25 @@ const navigation: NavigationItem[] = [
 ];
 
 export function filterMenuByAuth(items: NavigationItem[], isAuthed: boolean): NavigationItem[] {
+    const visible = (item: MenuItem) => {
+        if (item.requiresAuth && !isAuthed) return false;
+        if (item.hideWhenAuth && isAuthed) return false;
+        return true;
+    };
+
     return items
-        .filter((item) => {
-            if (item.requiresAuth && !isAuthed) return false;
-            if (item.hideWhenAuth && isAuthed) return false;
-            return true;
-        })
+        .filter(visible)
         .map((item) => {
             if ("submenu" in item && item.submenu) {
-                return {
-                    ...item,
-                    submenu: item.submenu.filter((child) => {
-                        if (child.requiresAuth && !isAuthed) return false;
-                        if (child.hideWhenAuth && isAuthed) return false;
-                        return true;
-                    }),
-                };
+                return { ...item, submenu: item.submenu.filter(visible) };
             }
             return item;
+        })
+        // Drop parents whose submenu became empty after filtering — a parent
+        // that hovers but reveals nothing is worse than a hidden parent.
+        .filter((item) => {
+            if ("submenu" in item && item.submenu && item.submenu.length === 0) return false;
+            return true;
         });
 }
 

--- a/src/layouts/headers/header-02.tsx
+++ b/src/layouts/headers/header-02.tsx
@@ -1,12 +1,13 @@
 import Logo from "@components/logo";
 import MainMenu from "@components/menu/main-menu";
-import menu from "@data/menu";
+import menu, { filterMenuByAuth } from "@data/menu";
 import { useSticky } from "@hooks";
 import BurgerButton from "@ui/burger-button";
 import clsx from "clsx";
+import { useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const MobileMenu = dynamic(() => import("../../components/menu/mobile-menu"), {
     ssr: false,
@@ -21,6 +22,11 @@ const Header = ({ shadow, fluid }: TProps) => {
     const router = useRouter();
     const [offcanvas, setOffcanvas] = useState(false);
     const { sticky, measuredRef } = useSticky();
+    const { status } = useSession();
+    const filteredMenu = useMemo(
+        () => filterMenuByAuth(menu, status === "authenticated"),
+        [status]
+    );
 
     useEffect(() => {
         setOffcanvas(false);
@@ -45,7 +51,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                             fluid && "tw-max-w-full tw-px-3.8 3xl:tw-px-37"
                         )}
                     >
-                        <MainMenu menu={menu} hoverStyle="B" className="tw-hidden xl:tw-block" />
+                        <MainMenu menu={filteredMenu} hoverStyle="B" className="tw-hidden xl:tw-block" />
                         <Logo variant="dark" className="tw-max-w-[120px] sm:tw-max-w-[158px]" />
                         <div className="tw-flex tw-items-center tw-justify-end">
                             <BurgerButton
@@ -59,7 +65,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                 </div>
                 <div className="tw-h-20" />
             </header>
-            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={menu} />
+            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={filteredMenu} />
         </>
     );
 };

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -74,18 +74,21 @@ const Header = ({ shadow, fluid }: TProps) => {
                     >
                         <div
                             className={clsx(
-                                "tw-container tw-grid tw-grid-flow-col tw-items-center xl:tw-grid-cols-[22%_minmax(56%,_1fr)_22%]",
+                                "tw-container tw-flex tw-items-center tw-justify-between tw-gap-6",
                                 fluid && "tw-max-w-full tw-px-3.8 3xl:tw-px-37"
                             )}
                         >
-                            <Logo variant="dark" className="tw-max-w-[120px] sm:tw-max-w-[158px]" />
+                            <Logo
+                                variant="dark"
+                                className="tw-flex tw-items-center tw-shrink-0 tw-max-w-[120px] sm:tw-max-w-[158px]"
+                            />
                             <MainMenu
                                 className="tw-hidden xl:tw-block"
                                 align="center"
                                 menu={filteredMenu}
                                 hoverStyle="B"
                             />
-                            <div className="tw-flex tw-items-center tw-justify-end tw-gap-4">
+                            <div className="tw-flex tw-items-center tw-justify-end tw-gap-4 tw-shrink-0">
                                 <div className="tw-hidden lg:tw-flex tw-items-center tw-gap-2">
                                     <span className="tw-relative tw-flex tw-h-[5px] tw-w-[5px]">
                                         <span className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-rounded-full tw-bg-red tw-opacity-75" style={{ animation: "statusBlink 2s ease-in-out infinite" }} />

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -1,15 +1,16 @@
 import Logo from "@components/logo";
 import MainMenu from "@components/menu/main-menu";
 import Social01 from "@components/socials/social-01";
-import menu from "@data/menu";
+import menu, { filterMenuByAuth } from "@data/menu";
 import { useSticky } from "@hooks";
 import BurgerButton from "@ui/burger-button";
 import Button from "@ui/button";
 import CountdownTimer from "@ui/countdown-timer/layout-03";
 import clsx from "clsx";
+import { useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const MobileMenu = dynamic(() => import("../../components/menu/mobile-menu"), {
     ssr: false,
@@ -24,6 +25,11 @@ const Header = ({ shadow, fluid }: TProps) => {
     const router = useRouter();
     const [offcanvas, setOffcanvas] = useState(false);
     const { sticky, measuredRef } = useSticky();
+    const { status } = useSession();
+    const filteredMenu = useMemo(
+        () => filterMenuByAuth(menu, status === "authenticated"),
+        [status]
+    );
 
     useEffect(() => {
         setOffcanvas(false);
@@ -76,7 +82,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                             <MainMenu
                                 className="tw-hidden xl:tw-block"
                                 align="center"
-                                menu={menu}
+                                menu={filteredMenu}
                                 hoverStyle="B"
                             />
                             <div className="tw-flex tw-items-center tw-justify-end tw-gap-4">
@@ -102,7 +108,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                     <div className="tw-h-20" />
                 </div>
             </header>
-            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={menu} />
+            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={filteredMenu} />
         </>
     );
 };


### PR DESCRIPTION
## Summary

Restructures the main navigation so signed-out and signed-in users see different items based on intent. Public visitors land on a marketing funnel; authenticated alumni see a return-loop instead of being nudged to Apply to a program they're already in.

## Public nav (signed-out)
About → **Programs** → Apply → **Hire** → Mentor → **Community** → Shop → Contact

## Member nav (signed-in)
About → **Programs** → **My Cohort** → **Train** → **Hire** → Mentor → **Community** → Shop → Contact

## Surfaces lifted out of obscurity
- **Programs** (top-level public): submenu links to Overview, Core Curriculum, Mission-Ready, Mentorship, Studio — all 5 mdx pages exist on disk but had no nav entry. Closes #790.
- **Train** (member-only): Reps (challenges, just shipped in #1080), Assessment, Subjects & Skills, J0d!e, Portfolio Checklist. Three of these moved here from misfit homes (see below).
- **Hire** (renames Jobs, public): Job Board + Career Guides / MOS Translator. The MOS translator is one of the most shareable veteran-audience surfaces and it had no nav.
- **My Cohort** (member-only): replaces Apply with a Profile entry point — alumni shouldn't see Apply.

## Items moved
- **J0d!e**: was top-level public, now Train submenu. It's an alumni AI tool, not a marketing surface.
- **Subjects & Skills**: was About submenu, now Train. It's the curriculum, not company info.
- **Portfolio Checklist**: was Engage submenu, now Train. It's an alumni tool, not engagement.
- **Engage** renamed to **Community** to match its actual content (Events, Blog, Media, Game).

## How auth-awareness works

Data-driven. Each `MenuItem` can opt into `requiresAuth` or `hideWhenAuth`. The new `filterMenuByAuth(items, isAuthed)` helper in `src/data/menu.ts` walks the tree and prunes accordingly. Both `header.tsx` and `header-02.tsx` call `useSession()` and pass the filtered tree to `MainMenu` / `MobileMenu`, so the existing menu components don't need to change.

```ts
{ id: 11, label: "Train", path: "#!", requiresAuth: true, submenu: [...] }
{ id: 2,  label: "Apply", path: "/apply", hideWhenAuth: true }
```

## Test plan
- [ ] Sign out → confirm public nav shows: About, Programs, Apply, Hire, Mentor, Community, Shop, Contact (no My Cohort, no Train)
- [ ] Sign in → confirm member nav shows: About, Programs, My Cohort, Train, Hire, Mentor, Community, Shop, Contact (no Apply)
- [ ] Programs submenu shows all 5 program pages and they all resolve
- [ ] Train submenu (when signed in) shows Reps → /challenges, Assessment, Subjects & Skills, J0d!e, Portfolio Checklist — all resolve
- [ ] Hire submenu shows Job Board + Career Guides — both resolve
- [ ] My Cohort submenu shows Profile and resolves to /profile
- [ ] Mobile menu reflects the same auth-aware filtering
- [ ] Initial paint while session is loading shows the public menu (acceptable default; no flash to broken state)

## Closes
- #790

## Notes for reviewers
- A momentary flash from public to member nav can occur during first hydration if a signed-in user lands cold. Acceptable for v1; treat any later "flash of public menu" issue as a separate UX ticket.
- A global Sign Out button in the header chrome is intentionally **not** part of this PR — that's tracked in #1054 and belongs in its own diff alongside the Sign In button.
- Three currently-shipped product surfaces (Resume Tools, Mock Interview, Public Badge) are deliberately **not** added to nav yet — they'll land alongside their underlying issues (#1094, j0di3 hub work, #1092).