### PR TITLE
feat(career-guides): Tech-aligned pathways generator + render

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,15 @@ OPENAI_API_KEY="your-openai-api-key"
 PHI3_ENDPOINT="your-phi3-endpoint"
 PHI3_API_KEY="your-phi3-api-key"
 
+# Lightcast (Emsi) - labor market data: salary by SOC, demand, top skills
+# Both required for live data; without these, scripts fall back to Census/curated.
+# Used by: src/lib/lightcast-client.ts, scripts/generate-tech-pathways.ts
+LIGHTCAST_CLIENT_ID="your-lightcast-client-id"
+LIGHTCAST_CLIENT_SECRET="your-lightcast-client-secret"
+
+# US Census ACS - fallback salary data when Lightcast is unavailable
+CENSUS_API_KEY="your-census-api-key"
+
 # Shopify Storefront API (for browsing products/cart)
 SHOPIFY_STORE_DOMAIN="your-store.myshopify.com"
 SHOPIFY_STOREFRONT_ACCESS_TOKEN="your-storefront-access-token"

--- a/docs/curriculum-gap-report.md
+++ b/docs/curriculum-gap-report.md
@@ -1,0 +1,85 @@
+# Curriculum Gap Report
+
+Generated 2026-05-02T21:34:49.356Z from `tech-pathways-map.json`.
+
+Analyzed **4200** MOS codes across all branches. Roles below are ranked by weighted recommendation score: each "high match" counts 3, "good" 2, "moderate" 1.
+
+## Top tech roles by veteran fit demand
+
+| Rank | Role | Track | SOC | High | Good | Moderate | Total | Score |
+|---:|---|---|---|---:|---:|---:|---:|---:|
+| 1 | Data Analyst | Data | 15-2051 | 467 | 732 | 931 | 2130 | 3796 |
+| 2 | Security Engineer | Security | 15-1212 | 542 | 621 | 855 | 2018 | 3723 |
+| 3 | Computer Systems Analyst | Customer / Field | 15-1211 | 49 | 942 | 1176 | 2167 | 3207 |
+| 4 | DevOps Engineer | DevOps / Platform | 15-1244 | 148 | 627 | 861 | 1636 | 2559 |
+| 5 | Technical Program Manager | Product | 11-3021 | 301 | 438 | 745 | 1484 | 2524 |
+| 6 | QA / Test Automation Engineer | Engineering | 15-1253 | 221 | 305 | 378 | 904 | 1651 |
+| 7 | Network Engineer | Infrastructure | 15-1241 | 325 | 212 | 46 | 583 | 1445 |
+| 8 | Systems Administrator | Infrastructure | 15-1244 | 146 | 359 | 220 | 725 | 1376 |
+| 9 | Health IT Specialist | Vertical Specialty | 15-1211 | 398 | 74 | 13 | 485 | 1355 |
+| 10 | IT Support Specialist (Help Desk) | Infrastructure | 15-1232 | 69 | 373 | 369 | 811 | 1322 |
+| 11 | Site Reliability Engineer | DevOps / Platform | 15-1244 | 207 | 259 | 109 | 575 | 1248 |
+| 12 | Cloud Engineer | DevOps / Platform | 15-1241 | 23 | 285 | 468 | 776 | 1107 |
+| 13 | SOC Analyst | Security | 15-1212 | 231 | 90 | 10 | 331 | 883 |
+| 14 | Data Engineer | Data | 15-2051 | 16 | 140 | 272 | 428 | 600 |
+| 15 | Governance, Risk & Compliance Analyst | Security | 15-1212 | 79 | 94 | 160 | 333 | 585 |
+| 16 | Embedded Software Engineer | Engineering | 17-2061 | 78 | 136 | 57 | 271 | 563 |
+| 17 | Technical Writer | Customer / Field | 27-3023 | 34 | 74 | 123 | 231 | 373 |
+| 18 | Robotics / Autonomy Software Engineer | Engineering | 17-2199 | 24 | 25 | 61 | 110 | 183 |
+| 19 | UX Designer / Researcher | Product | 15-1255 | 13 | 52 | 34 | 99 | 177 |
+| 20 | Penetration Tester | Security | 15-1212 | 19 | 40 | 8 | 67 | 145 |
+| 21 | Analytics Engineer | Data | 15-2051 | 1 | 46 | 16 | 63 | 111 |
+| 22 | Data Scientist | Data | 15-2051 | 27 | 9 | 1 | 37 | 100 |
+| 23 | Database Administrator / Engineer | Data | 15-1245 | 5 | 29 | 22 | 56 | 95 |
+| 24 | Engineering Manager | Product | 11-3021 | 5 | 36 | 4 | 45 | 91 |
+| 25 | Machine Learning Engineer | Data | 15-1252 | 0 | 12 | 15 | 27 | 39 |
+| 26 | Full-Stack Software Engineer | Engineering | 15-1252 | 12 | 0 | 0 | 12 | 36 |
+| 27 | Solutions Engineer | Customer / Field | 13-1161 | 0 | 4 | 19 | 23 | 27 |
+| 28 | Developer Advocate / DevRel | Customer / Field | 13-1161 | 0 | 5 | 16 | 21 | 26 |
+| 29 | Platform Engineer | DevOps / Platform | 15-1244 | 0 | 6 | 2 | 8 | 14 |
+| 30 | Frontend Software Engineer | Engineering | 15-1252 | 0 | 5 | 3 | 8 | 13 |
+| 31 | Backend Software Engineer | Engineering | 15-1252 | 2 | 0 | 1 | 3 | 7 |
+| 32 | Game Developer | Engineering | 15-1252 | 0 | 2 | 2 | 4 | 6 |
+
+## Top recommended skills (curriculum signal)
+
+Skills that show up most often in `skillsToLearn` — concrete signals about what curriculum content would serve the most veterans.
+
+| Skill | Frequency |
+|---|---:|
+| Data visualization tools (e.g., Tableau, Power BI) | 848 |
+| Cloud computing basics (AWS, Azure, or GCP) | 705 |
+| SQL for data querying and manipulation | 586 |
+| SQL for data querying | 525 |
+| SQL | 407 |
+| Data visualization tools (Tableau, Power BI) | 383 |
+| Data visualization tools like Tableau or Power BI | 356 |
+| Security Information and Event Management (SIEM) tools | 316 |
+| Network security principles | 311 |
+| Project management methodologies (e.g., Agile, Scrum) | 295 |
+| Project management methodologies (Agile, Scrum) | 287 |
+| Linux system administration | 268 |
+| Linux fundamentals | 268 |
+| Cloud computing basics (AWS, Azure, or Google Cloud) | 257 |
+| Scripting with Python or Bash | 245 |
+| Python fundamentals | 245 |
+| Technical documentation and communication | 237 |
+| Linux server administration | 236 |
+| Agile project management methodologies | 222 |
+| Cloud computing platforms (AWS, Azure, GCP) | 204 |
+| Cloud computing platforms (AWS, Azure, or GCP) | 203 |
+| Security Information and Event Management (SIEM) systems | 187 |
+| Scripting languages (Python, Bash) | 184 |
+| Cybersecurity fundamentals | 181 |
+| Scripting languages (e.g., Python, Bash) | 176 |
+| Cloud computing fundamentals (AWS, Azure, or GCP) | 172 |
+| SIEM tools (e.g., Splunk, QRadar) | 159 |
+| Cloud computing platforms (AWS, Azure, or Google Cloud) | 156 |
+| Project management software (e.g., Jira, Asana) | 154 |
+| Containerization (Docker, Kubernetes) | 148 |
+
+## How to read this
+
+- A role with high **weighted score** but few **high matches** means it's broadly applicable but not a deep fit for any single MOS — useful as a back-pocket option, not a flagship.
+- A role with concentrated **high matches** in one branch is a niche — possibly worth a branch-specific path.
+- The **skill frequency** list is the curriculum demand signal: skills appearing 1000+ times across MOSes are universal pre-reqs; rare skills are specialty paths.

--- a/docs/curriculum-gap-report.md
+++ b/docs/curriculum-gap-report.md
@@ -1,8 +1,8 @@
 # Curriculum Gap Report
 
-Generated 2026-05-02T21:34:49.356Z from `tech-pathways-map.json`.
+Generated 2026-05-02T21:41:58.761Z from `tech-pathways-map.json`.
 
-Analyzed **4200** MOS codes across all branches. Roles below are ranked by weighted recommendation score: each "high match" counts 3, "good" 2, "moderate" 1.
+Analyzed **4201** MOS codes across all branches. Roles below are ranked by weighted recommendation score: each "high match" counts 3, "good" 2, "moderate" 1.
 
 ## Top tech roles by veteran fit demand
 
@@ -10,12 +10,12 @@ Analyzed **4200** MOS codes across all branches. Roles below are ranked by weigh
 |---:|---|---|---|---:|---:|---:|---:|---:|
 | 1 | Data Analyst | Data | 15-2051 | 467 | 732 | 931 | 2130 | 3796 |
 | 2 | Security Engineer | Security | 15-1212 | 542 | 621 | 855 | 2018 | 3723 |
-| 3 | Computer Systems Analyst | Customer / Field | 15-1211 | 49 | 942 | 1176 | 2167 | 3207 |
-| 4 | DevOps Engineer | DevOps / Platform | 15-1244 | 148 | 627 | 861 | 1636 | 2559 |
+| 3 | Computer Systems Analyst | Customer / Field | 15-1211 | 49 | 942 | 1177 | 2168 | 3208 |
+| 4 | DevOps Engineer | DevOps / Platform | 15-1244 | 148 | 628 | 861 | 1637 | 2561 |
 | 5 | Technical Program Manager | Product | 11-3021 | 301 | 438 | 745 | 1484 | 2524 |
 | 6 | QA / Test Automation Engineer | Engineering | 15-1253 | 221 | 305 | 378 | 904 | 1651 |
 | 7 | Network Engineer | Infrastructure | 15-1241 | 325 | 212 | 46 | 583 | 1445 |
-| 8 | Systems Administrator | Infrastructure | 15-1244 | 146 | 359 | 220 | 725 | 1376 |
+| 8 | Systems Administrator | Infrastructure | 15-1244 | 146 | 360 | 220 | 726 | 1378 |
 | 9 | Health IT Specialist | Vertical Specialty | 15-1211 | 398 | 74 | 13 | 485 | 1355 |
 | 10 | IT Support Specialist (Help Desk) | Infrastructure | 15-1232 | 69 | 373 | 369 | 811 | 1322 |
 | 11 | Site Reliability Engineer | DevOps / Platform | 15-1244 | 207 | 259 | 109 | 575 | 1248 |
@@ -48,7 +48,7 @@ Skills that show up most often in `skillsToLearn` — concrete signals about wha
 | Skill | Frequency |
 |---|---:|
 | Data visualization tools (e.g., Tableau, Power BI) | 848 |
-| Cloud computing basics (AWS, Azure, or GCP) | 705 |
+| Cloud computing basics (AWS, Azure, or GCP) | 706 |
 | SQL for data querying and manipulation | 586 |
 | SQL for data querying | 525 |
 | SQL | 407 |
@@ -63,8 +63,8 @@ Skills that show up most often in `skillsToLearn` — concrete signals about wha
 | Cloud computing basics (AWS, Azure, or Google Cloud) | 257 |
 | Scripting with Python or Bash | 245 |
 | Python fundamentals | 245 |
+| Linux server administration | 237 |
 | Technical documentation and communication | 237 |
-| Linux server administration | 236 |
 | Agile project management methodologies | 222 |
 | Cloud computing platforms (AWS, Azure, GCP) | 204 |
 | Cloud computing platforms (AWS, Azure, or GCP) | 203 |

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "generate:training-pipeline": "tsx -r dotenv/config scripts/generate-training-pipeline.ts",
     "generate:cert-equivalencies": "tsx -r dotenv/config scripts/generate-cert-equivalencies.ts",
     "generate:military-systems": "tsx -r dotenv/config scripts/generate-military-systems.ts",
-    "generate:career-pathways": "tsx -r dotenv/config scripts/generate-career-pathways.ts"
+    "generate:career-pathways": "tsx -r dotenv/config scripts/generate-career-pathways.ts",
+    "generate:tech-pathways": "tsx -r dotenv/config scripts/generate-tech-pathways.ts",
+    "generate:curriculum-gap-report": "tsx -r dotenv/config scripts/generate-curriculum-gap-report.ts"
   },
   "dependencies": {
     "@ai-sdk/azure": "^2.0.69",

--- a/scripts/generate-curriculum-gap-report.ts
+++ b/scripts/generate-curriculum-gap-report.ts
@@ -1,0 +1,152 @@
+/**
+ * Generate the curriculum gap report.
+ *
+ * Reads tech-pathways-map.json (output of generate-tech-pathways.ts) and
+ * produces a frequency analysis: which tech roles show up most often as
+ * natural fits across all MOS codes? The output is a strategic input for
+ * the program team — concrete data on which tech tracks would have the
+ * most veteran demand if VWC built curriculum for them.
+ *
+ * Output: docs/curriculum-gap-report.md
+ *
+ * Run: npm run generate:curriculum-gap-report
+ */
+
+import "node:fs";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const PATHWAYS_PATH = path.join(ROOT, "src/data/tech-pathways-map.json");
+const TAXONOMY_PATH = path.join(ROOT, "src/data/tech-roles-taxonomy.json");
+const TRAINING_PATH = path.join(ROOT, "src/data/training-pipeline.json");
+const REPORT_PATH = path.join(ROOT, "docs/curriculum-gap-report.md");
+
+interface PathwayBundle {
+    techRoles: Array<{ roleKey: string; matchLevel: "high" | "good" | "moderate" }>;
+    skillsToLearn: Array<{ skill: string; forRole: string }>;
+}
+
+interface RoleSeed {
+    key: string;
+    title: string;
+    track: string;
+    socCode: string;
+}
+
+function loadJson<T>(p: string): T {
+    return JSON.parse(fs.readFileSync(p, "utf-8")) as T;
+}
+
+function main() {
+    if (!fs.existsSync(PATHWAYS_PATH)) {
+        console.error(`No pathways file at ${PATHWAYS_PATH}.`);
+        console.error("Run 'npm run generate:tech-pathways' first.");
+        process.exit(1);
+    }
+
+    const pathways = loadJson<Record<string, PathwayBundle>>(PATHWAYS_PATH);
+    const taxonomy = loadJson<{ roles: RoleSeed[] }>(TAXONOMY_PATH);
+    const training = loadJson<Record<string, { branch: string; title: string }>>(TRAINING_PATH);
+
+    const roleByKey = new Map(taxonomy.roles.map((r) => [r.key, r]));
+
+    // Score each role by frequency of recommendation, weighted by match level.
+    const matchWeight = { high: 3, good: 2, moderate: 1 } as const;
+
+    const roleStats = new Map<
+        string,
+        { highMatch: number; goodMatch: number; moderateMatch: number; weightedScore: number; byBranch: Map<string, number> }
+    >();
+    const skillFrequency = new Map<string, number>();
+
+    let totalCodes = 0;
+    for (const [code, bundle] of Object.entries(pathways)) {
+        totalCodes++;
+        const branch = training[code]?.branch || "Unknown";
+
+        for (const role of bundle.techRoles) {
+            if (!roleStats.has(role.roleKey)) {
+                roleStats.set(role.roleKey, {
+                    highMatch: 0,
+                    goodMatch: 0,
+                    moderateMatch: 0,
+                    weightedScore: 0,
+                    byBranch: new Map(),
+                });
+            }
+            const s = roleStats.get(role.roleKey)!;
+            if (role.matchLevel === "high") s.highMatch++;
+            else if (role.matchLevel === "good") s.goodMatch++;
+            else s.moderateMatch++;
+            s.weightedScore += matchWeight[role.matchLevel];
+            s.byBranch.set(branch, (s.byBranch.get(branch) || 0) + 1);
+        }
+
+        for (const sk of bundle.skillsToLearn || []) {
+            skillFrequency.set(sk.skill, (skillFrequency.get(sk.skill) || 0) + 1);
+        }
+    }
+
+    // Sort by weighted score
+    const ranked = [...roleStats.entries()]
+        .map(([key, stats]) => ({
+            key,
+            title: roleByKey.get(key)?.title || key,
+            track: roleByKey.get(key)?.track || "Unknown",
+            socCode: roleByKey.get(key)?.socCode || "",
+            ...stats,
+            totalRecs: stats.highMatch + stats.goodMatch + stats.moderateMatch,
+        }))
+        .sort((a, b) => b.weightedScore - a.weightedScore);
+
+    // Top skills by demand
+    const topSkills = [...skillFrequency.entries()]
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, 30);
+
+    // Build markdown
+    const generatedAt = new Date().toISOString();
+    const lines: string[] = [];
+    lines.push("# Curriculum Gap Report");
+    lines.push("");
+    lines.push(`Generated ${generatedAt} from \`tech-pathways-map.json\`.`);
+    lines.push("");
+    lines.push(`Analyzed **${totalCodes}** MOS codes across all branches. Roles below are ranked by weighted recommendation score: each "high match" counts 3, "good" 2, "moderate" 1.`);
+    lines.push("");
+    lines.push("## Top tech roles by veteran fit demand");
+    lines.push("");
+    lines.push("| Rank | Role | Track | SOC | High | Good | Moderate | Total | Score |");
+    lines.push("|---:|---|---|---|---:|---:|---:|---:|---:|");
+    ranked.forEach((r, idx) => {
+        lines.push(
+            `| ${idx + 1} | ${r.title} | ${r.track} | ${r.socCode} | ${r.highMatch} | ${r.goodMatch} | ${r.moderateMatch} | ${r.totalRecs} | ${r.weightedScore} |`
+        );
+    });
+    lines.push("");
+    lines.push("## Top recommended skills (curriculum signal)");
+    lines.push("");
+    lines.push("Skills that show up most often in `skillsToLearn` — concrete signals about what curriculum content would serve the most veterans.");
+    lines.push("");
+    lines.push("| Skill | Frequency |");
+    lines.push("|---|---:|");
+    for (const [skill, freq] of topSkills) {
+        lines.push(`| ${skill} | ${freq} |`);
+    }
+    lines.push("");
+    lines.push("## How to read this");
+    lines.push("");
+    lines.push("- A role with high **weighted score** but few **high matches** means it's broadly applicable but not a deep fit for any single MOS — useful as a back-pocket option, not a flagship.");
+    lines.push("- A role with concentrated **high matches** in one branch is a niche — possibly worth a branch-specific path.");
+    lines.push("- The **skill frequency** list is the curriculum demand signal: skills appearing 1000+ times across MOSes are universal pre-reqs; rare skills are specialty paths.");
+    lines.push("");
+
+    fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });
+    fs.writeFileSync(REPORT_PATH, lines.join("\n"));
+
+    console.log(`Wrote ${REPORT_PATH}`);
+    console.log(`Roles ranked: ${ranked.length}`);
+    console.log(`Skills tracked: ${skillFrequency.size}`);
+}
+
+main();

--- a/scripts/generate-tech-pathways.ts
+++ b/scripts/generate-tech-pathways.ts
@@ -1,0 +1,362 @@
+/**
+ * Generate tech-aligned career pathways for every military job code.
+ *
+ * Inputs (per MOS):
+ *  - src/data/training-pipeline.json     — branch, title, training topics
+ *  - src/data/cognitive-skills-map.json  — cognitive transfer skills + non-obvious careers
+ *  - src/data/military-systems-map.json  — military systems / civilian equivalents
+ *  - src/data/job-codes-descriptions.json — official MOS description text
+ *
+ * Taxonomy:
+ *  - src/data/tech-roles-taxonomy.json   — BLS SOC-anchored tech roles
+ *  - Enriched at run time with Lightcast salary + demand when Lightcast is configured
+ *
+ * Output:
+ *  - src/data/tech-pathways-map.json — { [mosCode]: TechPathwayBundle }
+ *
+ * Resumability: the script merges with any existing output, so a partial run
+ * picks up where the previous one left off. To force re-generation of a code,
+ * delete its key from the output file before running.
+ *
+ * Run: npm run generate:tech-pathways
+ */
+
+import "dotenv/config";
+import fs from "node:fs";
+import path from "node:path";
+import { google } from "@ai-sdk/google";
+import { generateObject } from "ai";
+import { z } from "zod";
+import { fetchLaborMarketData } from "../src/lib/labor-market";
+
+const ROOT = process.cwd();
+const DATA_DIR = path.join(ROOT, "src/data");
+const TAXONOMY_PATH = path.join(DATA_DIR, "tech-roles-taxonomy.json");
+const OUTPUT_PATH = path.join(DATA_DIR, "tech-pathways-map.json");
+
+// ----- Types -----
+
+interface TaxonomyRoleSeed {
+    key: string;
+    title: string;
+    track: string;
+    socCode: string;
+    description: string;
+    stack: string[];
+}
+
+interface EnrichedRole extends TaxonomyRoleSeed {
+    salaryRange: { min: number; max: number };
+    demand: string;
+    dataSource: string;
+}
+
+interface MosContext {
+    code: string;
+    branch: string;
+    title: string;
+    description: string;
+    trainingTopics: string[];
+    cognitiveSkills: Array<{ skill: string; civilianTranslation: string }>;
+    civilianSystems: Array<{ military: string; civilian: string }>;
+}
+
+// ----- Output schema (Gemini structured output) -----
+
+const TechPathwaySchema = z.object({
+    techRoles: z
+        .array(
+            z.object({
+                roleKey: z.string().describe("The 'key' field from the taxonomy this entry corresponds to"),
+                matchLevel: z.enum(["high", "good", "moderate"]),
+                whyItFits: z
+                    .string()
+                    .describe(
+                        "1-2 sentences pairing concrete elements of this MOS background to concrete elements of the role. Cite specific training, cognitive skills, or systems — never generic phrases like 'leadership' or 'attention to detail'."
+                    ),
+            })
+        )
+        .min(3)
+        .max(5),
+    skillsYouHave: z
+        .array(
+            z.object({
+                from: z.string().describe("A concrete element of this MOS — a training topic, cognitive skill, or system worked with. Not a generic trait."),
+                to: z.string().describe("The tech-equivalent skill or practice this maps to."),
+            })
+        )
+        .min(3)
+        .max(6),
+    skillsToLearn: z
+        .array(
+            z.object({
+                skill: z.string().describe("A specific, concrete skill (e.g., 'JavaScript fundamentals', 'Python pandas', 'Kubernetes basics' — never 'learn programming' or 'computer skills')."),
+                forRole: z.string().describe("Which roleKey from techRoles this skill primarily serves."),
+            })
+        )
+        .min(4)
+        .max(8),
+});
+
+type TechPathwayBundle = z.infer<typeof TechPathwaySchema> & {
+    generatedAt: string;
+};
+
+// ----- Helpers -----
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stripBranchPrefix(key: string): string {
+    const colonIdx = key.indexOf(":");
+    return colonIdx === -1 ? key : key.slice(colonIdx + 1);
+}
+
+function loadJson<T>(p: string): T {
+    return JSON.parse(fs.readFileSync(p, "utf-8")) as T;
+}
+
+function writeJson(p: string, data: unknown): void {
+    fs.writeFileSync(p, JSON.stringify(data, null, 4));
+}
+
+async function loadEnrichedTaxonomy(): Promise<EnrichedRole[]> {
+    const taxonomy = loadJson<{ roles: TaxonomyRoleSeed[] }>(TAXONOMY_PATH);
+    const enriched: EnrichedRole[] = [];
+
+    console.log(`Enriching ${taxonomy.roles.length} taxonomy roles with Lightcast salary data...`);
+
+    for (const role of taxonomy.roles) {
+        try {
+            const labor = await fetchLaborMarketData(role.socCode, 100000, "Growing demand");
+            enriched.push({
+                ...role,
+                salaryRange: labor.salaryRange
+                    ? { min: labor.salaryRange.p25, max: labor.salaryRange.p75 }
+                    : { min: Math.round(labor.avgSalary * 0.8), max: Math.round(labor.avgSalary * 1.2) },
+                demand: labor.demand,
+                dataSource: labor.dataSource,
+            });
+        } catch (err) {
+            console.warn(`  Lightcast lookup failed for ${role.title} (${role.socCode}); using curated fallback.`);
+            enriched.push({
+                ...role,
+                salaryRange: { min: 80000, max: 140000 },
+                demand: "Growing demand",
+                dataSource: "curated",
+            });
+        }
+    }
+
+    const lightcastCount = enriched.filter((r) => r.dataSource === "lightcast").length;
+    console.log(`  ${lightcastCount}/${enriched.length} roles enriched with live Lightcast data.`);
+    return enriched;
+}
+
+// ----- Per-MOS generation -----
+
+const SYSTEM_INSTRUCTION = `You are a career counselor for Vets Who Code, a software engineering accelerator for military veterans. Your mandate is to help veterans see realistic tech industry roles they can aim for, regardless of which civilian path they chose first.
+
+Rules you must follow:
+1. Recommend 3 to 5 tech roles drawn from the provided taxonomy. Pick the best fits for THIS specific military background — not the same defaults for every MOS.
+2. Every "whyItFits" sentence must cite a specific training topic, cognitive skill, or system from the MOS data. Generic phrases like "leadership", "attention to detail", "discipline", or "teamwork" are forbidden — those are true for every MOS and tell the reader nothing.
+3. Every "skillsYouHave.from" must reference a real, specific element of THIS MOS — not a trait that could apply to anyone. The "to" must name a real tech practice the veteran can claim.
+4. Every "skillsToLearn.skill" must be concrete enough to put in a learning plan: a language, framework, tool, or named practice. Never "learn programming" or "computer skills".
+5. Tone is direct and respectful — the audience is veterans who have already done hard things. Don't be patronizing. Don't be flowery.
+6. If a MOS has obvious tech-adjacent specialties (cyber, intel, signals, comms, IT), lean into those. If a MOS is far from tech (infantry, logistics, medical), still find honest tech-aligned roles by mapping the cognitive skills, not by stretching the truth.`;
+
+function buildPrompt(ctx: MosContext, taxonomy: EnrichedRole[]): string {
+    const taxonomyJson = JSON.stringify(
+        taxonomy.map((r) => ({
+            key: r.key,
+            title: r.title,
+            track: r.track,
+            description: r.description,
+            stack: r.stack,
+        })),
+        null,
+        2
+    );
+
+    return `Military Background:
+- Code: ${ctx.code}
+- Branch: ${ctx.branch}
+- Title: ${ctx.title}
+- Official description: ${ctx.description || "(none)"}
+
+Training topics:
+${ctx.trainingTopics.length ? ctx.trainingTopics.map((t) => `  - ${t}`).join("\n") : "  (none recorded)"}
+
+Cognitive transfer skills:
+${
+    ctx.cognitiveSkills.length
+        ? ctx.cognitiveSkills.map((s) => `  - ${s.skill}: ${s.civilianTranslation}`).join("\n")
+        : "  (none recorded)"
+}
+
+Civilian system equivalents:
+${
+    ctx.civilianSystems.length
+        ? ctx.civilianSystems.map((s) => `  - ${s.military} → ${s.civilian}`).join("\n")
+        : "  (none recorded)"
+}
+
+Tech role taxonomy (pick 3-5 keys from this list — do NOT invent new keys):
+${taxonomyJson}
+
+Generate the tech pathway bundle for this MOS following the rules in the system instruction.`;
+}
+
+async function generateForMos(
+    ctx: MosContext,
+    taxonomy: EnrichedRole[]
+): Promise<TechPathwayBundle | null> {
+    try {
+        const model = google(process.env.GEMINI_MODEL || "gemini-2.5-flash");
+
+        const { object } = await generateObject({
+            model,
+            schema: TechPathwaySchema,
+            system: SYSTEM_INSTRUCTION,
+            prompt: buildPrompt(ctx, taxonomy),
+        });
+
+        // Validate that all referenced roleKeys exist in the taxonomy.
+        const validKeys = new Set(taxonomy.map((r) => r.key));
+        for (const r of object.techRoles) {
+            if (!validKeys.has(r.roleKey)) {
+                console.warn(`  ${ctx.code}: invalid roleKey "${r.roleKey}", skipping entry.`);
+                return null;
+            }
+        }
+
+        return { ...object, generatedAt: new Date().toISOString() };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`  ${ctx.code}: generation failed — ${message}`);
+        return null;
+    }
+}
+
+// ----- Main -----
+
+const BATCH_SIZE = 10;
+const BATCH_DELAY_MS = 1000;
+
+async function main() {
+    const apiKey =
+        process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+        process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+        console.error(
+            "Missing Google AI API key. Set GOOGLE_GENERATIVE_AI_API_KEY or GEMINI_API_KEY in .env."
+        );
+        process.exit(1);
+    }
+    if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+        process.env.GOOGLE_GENERATIVE_AI_API_KEY = apiKey;
+    }
+
+    // Load all input data
+    const trainingMap = loadJson<Record<string, { branch: string; title: string; topics: string[] }>>(
+        path.join(DATA_DIR, "training-pipeline.json")
+    );
+    const cognitiveMap = loadJson<
+        Record<string, { cognitiveSkills: Array<{ skill: string; civilianTranslation: string }> }>
+    >(path.join(DATA_DIR, "cognitive-skills-map.json"));
+    const systemsMap = loadJson<
+        Record<string, { systems: Array<{ military: string; civilian: string }> }>
+    >(path.join(DATA_DIR, "military-systems-map.json"));
+    const descriptionsMap = loadJson<Record<string, string>>(
+        path.join(DATA_DIR, "job-codes-descriptions.json")
+    );
+
+    // Resolve descriptions per canonical (branch-stripped) code.
+    const descriptionByCode = new Map<string, string>();
+    for (const [branchKey, desc] of Object.entries(descriptionsMap)) {
+        const code = stripBranchPrefix(branchKey);
+        const existing = descriptionByCode.get(code);
+        descriptionByCode.set(code, existing ? `${existing}\n\n${desc}` : desc);
+    }
+
+    // Existing output (resumability)
+    const existing: Record<string, TechPathwayBundle> = fs.existsSync(OUTPUT_PATH)
+        ? loadJson<Record<string, TechPathwayBundle>>(OUTPUT_PATH)
+        : {};
+
+    // Build the work list — every MOS we have training data for.
+    const allCodes = Object.keys(trainingMap);
+    const todo = allCodes.filter((code) => !existing[code]);
+
+    console.log(`Total MOS codes: ${allCodes.length}`);
+    console.log(`Already generated: ${Object.keys(existing).length}`);
+    console.log(`Remaining to generate: ${todo.length}`);
+
+    if (todo.length === 0) {
+        console.log("Nothing to do. All codes covered.");
+        return;
+    }
+
+    // Enrich taxonomy once
+    const taxonomy = await loadEnrichedTaxonomy();
+
+    let okCount = 0;
+    let failCount = 0;
+
+    for (let i = 0; i < todo.length; i += BATCH_SIZE) {
+        const batch = todo.slice(i, i + BATCH_SIZE);
+        const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+        const totalBatches = Math.ceil(todo.length / BATCH_SIZE);
+
+        console.log(
+            `\nBatch ${batchNum}/${totalBatches} (codes ${i + 1}-${Math.min(i + BATCH_SIZE, todo.length)})`
+        );
+
+        const results = await Promise.allSettled(
+            batch.map(async (code) => {
+                const training = trainingMap[code];
+                const ctx: MosContext = {
+                    code,
+                    branch: training.branch,
+                    title: training.title,
+                    description: descriptionByCode.get(code) || "",
+                    trainingTopics: training.topics || [],
+                    cognitiveSkills: cognitiveMap[code]?.cognitiveSkills || [],
+                    civilianSystems: systemsMap[code]?.systems || [],
+                };
+                const bundle = await generateForMos(ctx, taxonomy);
+                return { code, bundle };
+            })
+        );
+
+        for (const r of results) {
+            if (r.status === "fulfilled" && r.value.bundle) {
+                existing[r.value.code] = r.value.bundle;
+                okCount++;
+                process.stdout.write(".");
+            } else {
+                failCount++;
+                process.stdout.write("x");
+            }
+        }
+
+        // Persist after every batch so a crash doesn't lose work.
+        writeJson(OUTPUT_PATH, existing);
+
+        if (i + BATCH_SIZE < todo.length) {
+            await sleep(BATCH_DELAY_MS);
+        }
+    }
+
+    console.log("\n\n--- Results ---");
+    console.log(`Generated this run: ${okCount}`);
+    console.log(`Failed this run: ${failCount}`);
+    console.log(`Total in output: ${Object.keys(existing).length}`);
+    console.log(`Wrote ${OUTPUT_PATH}`);
+}
+
+main().catch((error) => {
+    console.error("Script failed:", error);
+    process.exit(1);
+});

--- a/scripts/generate-tech-pathways.ts
+++ b/scripts/generate-tech-pathways.ts
@@ -63,39 +63,28 @@ interface MosContext {
 
 // ----- Output schema (Gemini structured output) -----
 
+// Generous upper bounds — Gemini sometimes produces more legitimate items
+// than a tight cap allows, and getting the data is more valuable than
+// strict shape control. The render layer can truncate visually if needed.
 const TechPathwaySchema = z.object({
     techRoles: z
         .array(
             z.object({
-                roleKey: z.string().describe("The 'key' field from the taxonomy this entry corresponds to"),
+                roleKey: z.string(),
                 matchLevel: z.enum(["high", "good", "moderate"]),
-                whyItFits: z
-                    .string()
-                    .describe(
-                        "1-2 sentences pairing concrete elements of this MOS background to concrete elements of the role. Cite specific training, cognitive skills, or systems — never generic phrases like 'leadership' or 'attention to detail'."
-                    ),
+                whyItFits: z.string(),
             })
         )
-        .min(3)
-        .max(5),
-    skillsYouHave: z
-        .array(
-            z.object({
-                from: z.string().describe("A concrete element of this MOS — a training topic, cognitive skill, or system worked with. Not a generic trait."),
-                to: z.string().describe("The tech-equivalent skill or practice this maps to."),
-            })
-        )
-        .min(3)
-        .max(6),
-    skillsToLearn: z
-        .array(
-            z.object({
-                skill: z.string().describe("A specific, concrete skill (e.g., 'JavaScript fundamentals', 'Python pandas', 'Kubernetes basics' — never 'learn programming' or 'computer skills')."),
-                forRole: z.string().describe("Which roleKey from techRoles this skill primarily serves."),
-            })
-        )
-        .min(4)
+        .min(1)
         .max(8),
+    skillsYouHave: z
+        .array(z.object({ from: z.string(), to: z.string() }))
+        .min(1)
+        .max(20),
+    skillsToLearn: z
+        .array(z.object({ skill: z.string(), forRole: z.string() }))
+        .min(1)
+        .max(20),
 });
 
 type TechPathwayBundle = z.infer<typeof TechPathwaySchema> & {
@@ -156,28 +145,21 @@ async function loadEnrichedTaxonomy(): Promise<EnrichedRole[]> {
 
 // ----- Per-MOS generation -----
 
-const SYSTEM_INSTRUCTION = `You are a career counselor for Vets Who Code, a software engineering accelerator for military veterans. Your mandate is to help veterans see realistic tech industry roles they can aim for, regardless of which civilian path they chose first.
+const SYSTEM_INSTRUCTION = `You are a career counselor for Vets Who Code, a software engineering accelerator. Help veterans see realistic tech industry roles they can aim for given their military background.
 
-Rules you must follow:
-1. Recommend 3 to 5 tech roles drawn from the provided taxonomy. Pick the best fits for THIS specific military background — not the same defaults for every MOS.
-2. Every "whyItFits" sentence must cite a specific training topic, cognitive skill, or system from the MOS data. Generic phrases like "leadership", "attention to detail", "discipline", or "teamwork" are forbidden — those are true for every MOS and tell the reader nothing.
-3. Every "skillsYouHave.from" must reference a real, specific element of THIS MOS — not a trait that could apply to anyone. The "to" must name a real tech practice the veteran can claim.
-4. Every "skillsToLearn.skill" must be concrete enough to put in a learning plan: a language, framework, tool, or named practice. Never "learn programming" or "computer skills".
-5. Tone is direct and respectful — the audience is veterans who have already done hard things. Don't be patronizing. Don't be flowery.
-6. If a MOS has obvious tech-adjacent specialties (cyber, intel, signals, comms, IT), lean into those. If a MOS is far from tech (infantry, logistics, medical), still find honest tech-aligned roles by mapping the cognitive skills, not by stretching the truth.`;
+Style guidance (prefer, do not strictly forbid):
+- Cite specific training topics, cognitive skills, or systems from the MOS data when explaining a fit. Concrete is better than generic.
+- Skills to learn should be specific — name the language, framework, or tool (e.g., "JavaScript fundamentals", "Python pandas", "Kubernetes basics") rather than "learn programming".
+- Tone is direct and respectful — the audience is veterans. Not patronizing. Not flowery.
+- For MOSes with obvious tech adjacency (cyber, intel, signals, comms, IT), lean into those. For MOSes farther from tech (infantry, logistics, medical), still find honest tech-aligned roles by mapping the cognitive transfer skills, not by stretching the truth.`;
 
 function buildPrompt(ctx: MosContext, taxonomy: EnrichedRole[]): string {
-    const taxonomyJson = JSON.stringify(
-        taxonomy.map((r) => ({
-            key: r.key,
-            title: r.title,
-            track: r.track,
-            description: r.description,
-            stack: r.stack,
-        })),
-        null,
-        2
-    );
+    // Trim taxonomy to just what Gemini needs to pick a key — passing the
+    // full descriptions and stack arrays bloats the prompt and seems to
+    // confuse Gemini's structured-output mode.
+    const taxonomyLines = taxonomy
+        .map((r) => `- ${r.key} | ${r.title} (${r.track})`)
+        .join("\n");
 
     return `Military Background:
 - Code: ${ctx.code}
@@ -203,9 +185,9 @@ ${
 }
 
 Tech role taxonomy (pick 3-5 keys from this list — do NOT invent new keys):
-${taxonomyJson}
+${taxonomyLines}
 
-Generate the tech pathway bundle for this MOS following the rules in the system instruction.`;
+Generate the tech pathway bundle for this MOS.`;
 }
 
 async function generateForMos(
@@ -213,13 +195,17 @@ async function generateForMos(
     taxonomy: EnrichedRole[]
 ): Promise<TechPathwayBundle | null> {
     try {
-        const model = google(process.env.GEMINI_MODEL || "gemini-2.5-flash");
+        // gemini-2.0-flash is the model used by the existing generate-career-pathways
+        // script and has proven reliable for structured-output JSON of this shape.
+        // Override via TECH_PATHWAYS_MODEL env if needed.
+        const model = google(process.env.TECH_PATHWAYS_MODEL || "gemini-2.0-flash");
 
         const { object } = await generateObject({
             model,
             schema: TechPathwaySchema,
             system: SYSTEM_INSTRUCTION,
             prompt: buildPrompt(ctx, taxonomy),
+            maxRetries: 4,
         });
 
         // Validate that all referenced roleKeys exist in the taxonomy.

--- a/scripts/generate-tech-pathways.ts
+++ b/scripts/generate-tech-pathways.ts
@@ -208,16 +208,28 @@ async function generateForMos(
             maxRetries: 4,
         });
 
-        // Validate that all referenced roleKeys exist in the taxonomy.
+        // Filter out roleKeys that aren't in the taxonomy. Gemini occasionally
+        // emits a near-miss key (e.g. "backend_software_engineer" vs
+        // "software_engineer_backend"); drop the bad entry but keep the rest.
         const validKeys = new Set(taxonomy.map((r) => r.key));
-        for (const r of object.techRoles) {
+        const cleanedRoles = object.techRoles.filter((r) => {
             if (!validKeys.has(r.roleKey)) {
-                console.warn(`  ${ctx.code}: invalid roleKey "${r.roleKey}", skipping entry.`);
-                return null;
+                console.warn(`  ${ctx.code}: dropping invalid roleKey "${r.roleKey}"`);
+                return false;
             }
+            return true;
+        });
+
+        if (cleanedRoles.length === 0) {
+            console.warn(`  ${ctx.code}: no valid roleKeys after filter, skipping bundle.`);
+            return null;
         }
 
-        return { ...object, generatedAt: new Date().toISOString() };
+        return {
+            ...object,
+            techRoles: cleanedRoles,
+            generatedAt: new Date().toISOString(),
+        };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.warn(`  ${ctx.code}: generation failed — ${message}`);

--- a/src/components/socials/social-01.tsx
+++ b/src/components/socials/social-01.tsx
@@ -13,9 +13,6 @@ const Social01 = ({ className }: { className?: string }) => (
         >
             <i className="fab fa-facebook-f" />
         </SocialLink>
-        <SocialLink href="https://dev.to/vetswhocode" label="Practical Dev" className="tw-px-2.5">
-            <i className="fab fa-dev" />
-        </SocialLink>
         <SocialLink
             href="https://www.linkedin.com/company/vets-who-code"
             label="linkedin"

--- a/src/components/widgets/text-widget.tsx
+++ b/src/components/widgets/text-widget.tsx
@@ -32,9 +32,6 @@ const TextWidget = ({ className, mode }: TProps) => {
                 >
                     <i className="fab fa-facebook-square" />
                 </SocialLink>
-                <SocialLink href="https://dev.to/vetswhocode" label="Practical Dev">
-                    <i className="fab fa-dev" />
-                </SocialLink>
                 <SocialLink href="https://github.com/Vets-Who-Code" label="Github">
                     <i className="fab fa-github" />
                 </SocialLink>

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -6,6 +6,8 @@ interface MenuItem {
     path: string;
     external?: boolean;
     status?: MenuStatus;
+    requiresAuth?: boolean;
+    hideWhenAuth?: boolean;
 }
 
 interface SubMenuItem extends MenuItem {
@@ -26,21 +28,6 @@ const navigation: NavigationItem[] = [
                 path: "/about-us",
             },
             {
-                id: 102,
-                label: "Subjects & Skills",
-                path: "/subjects/all",
-            },
-            {
-                id: 103,
-                label: "FAQ",
-                path: "/faq",
-            },
-            {
-                id: 104,
-                label: "Open Source Projects",
-                path: "/projects",
-            },
-            {
                 id: 105,
                 label: "Theory of Change",
                 path: "/theory-of-change",
@@ -50,18 +37,120 @@ const navigation: NavigationItem[] = [
                 label: "Team",
                 path: "/team",
             },
+            {
+                id: 104,
+                label: "Open Source Projects",
+                path: "/projects",
+            },
+            {
+                id: 103,
+                label: "FAQ",
+                path: "/faq",
+            },
+        ],
+    },
+    {
+        id: 9,
+        label: "Programs",
+        path: "#!",
+        submenu: [
+            {
+                id: 901,
+                label: "Overview",
+                path: "/programs",
+            },
+            {
+                id: 902,
+                label: "Core Curriculum",
+                path: "/programs/core-curriculum",
+            },
+            {
+                id: 903,
+                label: "Mission-Ready",
+                path: "/programs/mission-ready",
+            },
+            {
+                id: 904,
+                label: "Mentorship",
+                path: "/programs/mentorship",
+            },
+            {
+                id: 905,
+                label: "Studio",
+                path: "/programs/studio",
+            },
         ],
     },
     {
         id: 2,
         label: "Apply",
         path: "/apply",
+        hideWhenAuth: true,
+    },
+    {
+        id: 10,
+        label: "My Cohort",
+        path: "#!",
+        requiresAuth: true,
+        submenu: [
+            {
+                id: 1001,
+                label: "Profile",
+                path: "/profile",
+            },
+        ],
+    },
+    {
+        id: 11,
+        label: "Train",
+        path: "#!",
+        requiresAuth: true,
+        submenu: [
+            {
+                id: 1101,
+                label: "Reps",
+                path: "/challenges",
+                status: "new",
+            },
+            {
+                id: 1102,
+                label: "Assessment",
+                path: "/assessment",
+            },
+            {
+                id: 1103,
+                label: "Subjects & Skills",
+                path: "/subjects/all",
+            },
+            {
+                id: 1104,
+                label: "J0d!e",
+                path: "/jodie",
+            },
+            {
+                id: 1105,
+                label: "Portfolio Checklist",
+                path: "/portfolio-checklist",
+            },
+        ],
     },
     {
         id: 3,
-        label: "Jobs",
-        path: "/jobs",
-        status: "new",
+        label: "Hire",
+        path: "#!",
+        submenu: [
+            {
+                id: 301,
+                label: "Job Board",
+                path: "/jobs",
+                status: "new",
+            },
+            {
+                id: 302,
+                label: "Career Guides",
+                path: "/career-guides",
+            },
+        ],
     },
     {
         id: 4,
@@ -71,42 +160,30 @@ const navigation: NavigationItem[] = [
     },
     {
         id: 5,
-        label: "Engage",
+        label: "Community",
         path: "#!",
         submenu: [
             {
                 id: 701,
-                label: "Game",
-                path: "/game",
-            },
-            {
-                id: 702,
                 label: "Events",
                 path: "/events",
             },
             {
-                id: 703,
+                id: 702,
                 label: "Blog",
                 path: "/blogs/blog",
             },
             {
-                id: 704, // New ID for Media
+                id: 703,
                 label: "Media",
                 path: "/media",
             },
             {
-                id: 705,
-                label: "Portfolio Checklist",
-                path: "/portfolio-checklist",
-                status: "new",
+                id: 704,
+                label: "Game",
+                path: "/game",
             },
         ],
-    },
-    {
-        id: 8,
-        label: "J0d!e",
-        path: "/jodie",
-        status: "new",
     },
     {
         id: 6,
@@ -119,5 +196,27 @@ const navigation: NavigationItem[] = [
         path: "/contact-us",
     },
 ];
+
+export function filterMenuByAuth(items: NavigationItem[], isAuthed: boolean): NavigationItem[] {
+    return items
+        .filter((item) => {
+            if (item.requiresAuth && !isAuthed) return false;
+            if (item.hideWhenAuth && isAuthed) return false;
+            return true;
+        })
+        .map((item) => {
+            if ("submenu" in item && item.submenu) {
+                return {
+                    ...item,
+                    submenu: item.submenu.filter((child) => {
+                        if (child.requiresAuth && !isAuthed) return false;
+                        if (child.hideWhenAuth && isAuthed) return false;
+                        return true;
+                    }),
+                };
+            }
+            return item;
+        });
+}
 
 export default navigation;

--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -82,10 +82,23 @@ const navigation: NavigationItem[] = [
         ],
     },
     {
-        id: 2,
-        label: "Apply",
-        path: "/apply",
-        hideWhenAuth: true,
+        id: 12,
+        label: "Join",
+        path: "#!",
+        submenu: [
+            {
+                id: 1201,
+                label: "Apply",
+                path: "/apply",
+                hideWhenAuth: true,
+            },
+            {
+                id: 1202,
+                label: "Mentor",
+                path: "/mentor",
+                status: "hot",
+            },
+        ],
     },
     {
         id: 10,
@@ -153,12 +166,6 @@ const navigation: NavigationItem[] = [
         ],
     },
     {
-        id: 4,
-        label: "Mentor",
-        path: "/mentor",
-        status: "hot",
-    },
-    {
         id: 5,
         label: "Community",
         path: "#!",
@@ -198,24 +205,25 @@ const navigation: NavigationItem[] = [
 ];
 
 export function filterMenuByAuth(items: NavigationItem[], isAuthed: boolean): NavigationItem[] {
+    const visible = (item: MenuItem) => {
+        if (item.requiresAuth && !isAuthed) return false;
+        if (item.hideWhenAuth && isAuthed) return false;
+        return true;
+    };
+
     return items
-        .filter((item) => {
-            if (item.requiresAuth && !isAuthed) return false;
-            if (item.hideWhenAuth && isAuthed) return false;
-            return true;
-        })
+        .filter(visible)
         .map((item) => {
             if ("submenu" in item && item.submenu) {
-                return {
-                    ...item,
-                    submenu: item.submenu.filter((child) => {
-                        if (child.requiresAuth && !isAuthed) return false;
-                        if (child.hideWhenAuth && isAuthed) return false;
-                        return true;
-                    }),
-                };
+                return { ...item, submenu: item.submenu.filter(visible) };
             }
             return item;
+        })
+        // Drop parents whose submenu became empty after filtering — a parent
+        // that hovers but reveals nothing is worse than a hidden parent.
+        .filter((item) => {
+            if ("submenu" in item && item.submenu && item.submenu.length === 0) return false;
+            return true;
         });
 }
 

--- a/src/data/tech-roles-taxonomy.json
+++ b/src/data/tech-roles-taxonomy.json
@@ -1,0 +1,289 @@
+{
+    "metadata": {
+        "version": 1,
+        "source": "BLS Standard Occupational Classification (SOC) — tech-aligned subset",
+        "note": "Salary ranges and demand indicators are enriched from Lightcast at script run time when LIGHTCAST_CLIENT_ID/SECRET are set. SOC codes are stable; titles match common industry usage."
+    },
+    "roles": [
+        {
+            "key": "software_engineer_frontend",
+            "title": "Frontend Software Engineer",
+            "track": "Engineering",
+            "socCode": "15-1252",
+            "description": "Builds user-facing web applications. Owns the experience users actually touch.",
+            "stack": ["JavaScript", "TypeScript", "React or Vue", "HTML / CSS", "Accessibility"]
+        },
+        {
+            "key": "software_engineer_backend",
+            "title": "Backend Software Engineer",
+            "track": "Engineering",
+            "socCode": "15-1252",
+            "description": "Designs and operates the systems behind the UI — APIs, databases, service logic.",
+            "stack": ["One backend language (Python, Go, Java, or Node)", "REST / GraphQL APIs", "SQL", "Caching", "Service design"]
+        },
+        {
+            "key": "software_engineer_fullstack",
+            "title": "Full-Stack Software Engineer",
+            "track": "Engineering",
+            "socCode": "15-1252",
+            "description": "Owns features end-to-end across UI, API, and data.",
+            "stack": ["JavaScript / TypeScript", "React or Vue", "Node or Python", "SQL", "Git workflows"]
+        },
+        {
+            "key": "mobile_engineer_ios",
+            "title": "iOS Engineer",
+            "track": "Engineering",
+            "socCode": "15-1252",
+            "description": "Builds native applications for iPhone and iPad.",
+            "stack": ["Swift", "SwiftUI / UIKit", "Xcode", "Core Data", "App Store deployment"]
+        },
+        {
+            "key": "mobile_engineer_android",
+            "title": "Android Engineer",
+            "track": "Engineering",
+            "socCode": "15-1252",
+            "description": "Builds native applications for Android devices.",
+            "stack": ["Kotlin", "Jetpack Compose", "Android SDK", "Room / SQLite", "Play Store deployment"]
+        },
+        {
+            "key": "embedded_software_engineer",
+            "title": "Embedded Software Engineer",
+            "track": "Engineering",
+            "socCode": "17-2061",
+            "description": "Writes software that runs on devices — vehicles, medical instruments, industrial control, defense systems.",
+            "stack": ["C / C++", "RTOS basics", "Hardware-software interfaces", "Memory-constrained programming", "Debug tools (JTAG, oscilloscope)"]
+        },
+        {
+            "key": "qa_test_automation_engineer",
+            "title": "QA / Test Automation Engineer",
+            "track": "Engineering",
+            "socCode": "15-1253",
+            "description": "Builds the test infrastructure that catches regressions before users do.",
+            "stack": ["One scripting language", "Playwright / Cypress / Selenium", "CI/CD pipelines", "Test design (boundary, equivalence, mutation)", "Bug-reproduction discipline"]
+        },
+        {
+            "key": "game_developer",
+            "title": "Game Developer",
+            "track": "Engineering",
+            "socCode": "15-1252",
+            "description": "Builds video games, simulations, or training environments.",
+            "stack": ["C# (Unity) or C++ (Unreal)", "Game-loop architecture", "Physics + math", "Shaders / rendering", "Performance optimization"]
+        },
+        {
+            "key": "site_reliability_engineer",
+            "title": "Site Reliability Engineer",
+            "track": "DevOps / Platform",
+            "socCode": "15-1244",
+            "description": "Keeps production systems up and fast. Lives at the intersection of code and operations.",
+            "stack": ["Linux", "One scripting language (Python or Go)", "Observability stack (Prometheus, Grafana, OpenTelemetry)", "Incident response practices", "Cloud platform basics"]
+        },
+        {
+            "key": "devops_engineer",
+            "title": "DevOps Engineer",
+            "track": "DevOps / Platform",
+            "socCode": "15-1244",
+            "description": "Owns the pipelines that get code from a developer's machine to production.",
+            "stack": ["CI/CD tooling (GitHub Actions, GitLab, Jenkins)", "Infrastructure as Code (Terraform, Pulumi)", "Containers (Docker, Kubernetes)", "Cloud platforms (AWS, GCP, Azure)", "Linux"]
+        },
+        {
+            "key": "platform_engineer",
+            "title": "Platform Engineer",
+            "track": "DevOps / Platform",
+            "socCode": "15-1244",
+            "description": "Builds the internal developer platform — the paved roads other engineers use.",
+            "stack": ["Kubernetes", "Internal developer portals (Backstage)", "API design", "Cost / quota management", "Documentation"]
+        },
+        {
+            "key": "cloud_engineer",
+            "title": "Cloud Engineer",
+            "track": "DevOps / Platform",
+            "socCode": "15-1241",
+            "description": "Designs and operates infrastructure on AWS, GCP, or Azure.",
+            "stack": ["One major cloud (AWS, GCP, Azure)", "Networking (VPC, subnets, routing)", "IAM and security boundaries", "Cost optimization", "Infrastructure as Code"]
+        },
+        {
+            "key": "network_engineer",
+            "title": "Network Engineer",
+            "track": "Infrastructure",
+            "socCode": "15-1241",
+            "description": "Designs, deploys, and operates the networks that connect everything.",
+            "stack": ["TCP/IP fundamentals", "Routing protocols (BGP, OSPF)", "Firewall and VPN configuration", "Cloud networking", "Cisco or Juniper hands-on"]
+        },
+        {
+            "key": "systems_administrator",
+            "title": "Systems Administrator",
+            "track": "Infrastructure",
+            "socCode": "15-1244",
+            "description": "Runs the servers and services an organization depends on.",
+            "stack": ["Linux and/or Windows Server", "Scripting (Bash, PowerShell, Python)", "Backup and DR practices", "Monitoring", "Patch management"]
+        },
+        {
+            "key": "database_administrator",
+            "title": "Database Administrator / Engineer",
+            "track": "Data",
+            "socCode": "15-1245",
+            "description": "Owns database performance, reliability, and data integrity.",
+            "stack": ["SQL (deep)", "One database in depth (Postgres, MySQL, SQL Server, Oracle)", "Indexing and query optimization", "Backup / recovery", "Replication and sharding"]
+        },
+        {
+            "key": "data_engineer",
+            "title": "Data Engineer",
+            "track": "Data",
+            "socCode": "15-2051",
+            "description": "Builds the pipelines that move and transform data so analysts and ML can use it.",
+            "stack": ["Python", "SQL (deep)", "Pipeline orchestration (Airflow, Dagster, dbt)", "Cloud data warehouse (Snowflake, BigQuery, Redshift)", "Schema design"]
+        },
+        {
+            "key": "analytics_engineer",
+            "title": "Analytics Engineer",
+            "track": "Data",
+            "socCode": "15-2051",
+            "description": "The bridge between data engineering and analytics — owns the trusted models analysts query.",
+            "stack": ["SQL (deep)", "dbt", "Cloud data warehouse", "Version-controlled data models", "Documentation discipline"]
+        },
+        {
+            "key": "data_analyst",
+            "title": "Data Analyst",
+            "track": "Data",
+            "socCode": "15-2051",
+            "description": "Turns data into decisions. Builds dashboards, runs analyses, partners with stakeholders.",
+            "stack": ["SQL", "Excel / Sheets at expert level", "One BI tool (Tableau, Power BI, Looker)", "Statistics fundamentals", "Stakeholder communication"]
+        },
+        {
+            "key": "data_scientist",
+            "title": "Data Scientist",
+            "track": "Data",
+            "socCode": "15-2051",
+            "description": "Applies statistics and ML to answer business questions and ship predictive features.",
+            "stack": ["Python (pandas, scikit-learn)", "SQL", "Statistics (regression, hypothesis testing)", "ML fundamentals", "Communication of model behavior"]
+        },
+        {
+            "key": "machine_learning_engineer",
+            "title": "Machine Learning Engineer",
+            "track": "Data",
+            "socCode": "15-1252",
+            "description": "Productionizes ML models — training pipelines, serving infra, monitoring drift.",
+            "stack": ["Python", "PyTorch or TensorFlow", "ML pipeline tooling (MLflow, Kubeflow, Vertex AI)", "Model deployment", "Software engineering fundamentals"]
+        },
+        {
+            "key": "mlops_engineer",
+            "title": "MLOps Engineer",
+            "track": "Data",
+            "socCode": "15-1252",
+            "description": "DevOps for ML — owns training pipelines, model registries, and production model reliability.",
+            "stack": ["Python", "Kubernetes", "ML platforms (Vertex AI, SageMaker, MLflow)", "Monitoring (drift, latency, cost)", "CI/CD for models"]
+        },
+        {
+            "key": "security_engineer",
+            "title": "Security Engineer",
+            "track": "Security",
+            "socCode": "15-1212",
+            "description": "Designs systems to be secure by default. Owns the security review for new architectures.",
+            "stack": ["Networking and OS internals", "Cryptography fundamentals", "Threat modeling", "Cloud security (IAM, VPC)", "Code review for security"]
+        },
+        {
+            "key": "soc_analyst",
+            "title": "SOC Analyst",
+            "track": "Security",
+            "socCode": "15-1212",
+            "description": "Front line of cyber defense — investigates alerts, triages incidents, writes detections.",
+            "stack": ["SIEM platforms (Splunk, Elastic, Sentinel)", "Network protocols", "Endpoint and log analysis", "MITRE ATT&CK familiarity", "Incident-response runbooks"]
+        },
+        {
+            "key": "penetration_tester",
+            "title": "Penetration Tester",
+            "track": "Security",
+            "socCode": "15-1212",
+            "description": "Breaks systems on purpose so defenders can fix them.",
+            "stack": ["Networking and web app fundamentals", "Burp Suite / Metasploit / nmap", "OSCP-style methodology", "Scripting (Python, Bash)", "Report writing"]
+        },
+        {
+            "key": "grc_analyst",
+            "title": "Governance, Risk & Compliance Analyst",
+            "track": "Security",
+            "socCode": "15-1212",
+            "description": "Owns the framework side of security — audits, control mapping, regulatory readiness.",
+            "stack": ["Frameworks (NIST, ISO 27001, SOC 2)", "Risk-assessment methodology", "Audit evidence collection", "Policy writing", "Stakeholder communication"]
+        },
+        {
+            "key": "ux_designer",
+            "title": "UX Designer / Researcher",
+            "track": "Product",
+            "socCode": "15-1255",
+            "description": "Decides what gets built and how it should feel for users.",
+            "stack": ["User research methods", "Wireframing and prototyping (Figma)", "Accessibility patterns", "Information architecture", "Stakeholder communication"]
+        },
+        {
+            "key": "technical_program_manager",
+            "title": "Technical Program Manager",
+            "track": "Product",
+            "socCode": "11-3021",
+            "description": "Drives multi-team technical initiatives. Translates strategy into execution.",
+            "stack": ["Software systems literacy (read code, read architecture diagrams)", "Cross-team coordination", "Risk and dependency management", "Written communication", "Stakeholder reporting"]
+        },
+        {
+            "key": "engineering_manager",
+            "title": "Engineering Manager",
+            "track": "Product",
+            "socCode": "11-3021",
+            "description": "Manages engineers — hiring, performance, technical direction, team health.",
+            "stack": ["Software engineering background", "1-on-1s and feedback discipline", "Technical scoping", "Hiring", "Stakeholder partnership"]
+        },
+        {
+            "key": "solutions_engineer",
+            "title": "Solutions Engineer",
+            "track": "Customer / Field",
+            "socCode": "13-1161",
+            "description": "Pre-sales technical role — proves the product works for the customer's actual problem.",
+            "stack": ["Software engineering literacy", "Strong written and verbal communication", "Demo and POC building", "Customer empathy", "Partnership with sales"]
+        },
+        {
+            "key": "developer_advocate",
+            "title": "Developer Advocate / DevRel",
+            "track": "Customer / Field",
+            "socCode": "13-1161",
+            "description": "Bridges product and developer community — talks, content, feedback loops.",
+            "stack": ["Software engineering background", "Public speaking / writing", "Community building", "Sample app development", "Feedback synthesis"]
+        },
+        {
+            "key": "technical_writer",
+            "title": "Technical Writer",
+            "track": "Customer / Field",
+            "socCode": "27-3023",
+            "description": "Owns the docs developers and customers use. Documentation is the product surface.",
+            "stack": ["Strong writing", "Software engineering literacy (read code, run examples)", "Static site generators", "Information architecture", "Editorial process"]
+        },
+        {
+            "key": "computer_user_support",
+            "title": "IT Support Specialist (Help Desk)",
+            "track": "Infrastructure",
+            "socCode": "15-1232",
+            "description": "Often the on-ramp into tech — supporting end users while building career-long systems intuition.",
+            "stack": ["Windows and macOS troubleshooting", "Active Directory basics", "Ticketing systems", "Customer communication", "Documentation"]
+        },
+        {
+            "key": "health_it_specialist",
+            "title": "Health IT Specialist",
+            "track": "Vertical Specialty",
+            "socCode": "15-1211",
+            "description": "Bridges clinical operations and IT — EHR systems, HL7/FHIR, healthcare compliance.",
+            "stack": ["Healthcare data standards (HL7, FHIR)", "EHR system fundamentals (Epic, Cerner)", "HIPAA awareness", "SQL", "Stakeholder communication"]
+        },
+        {
+            "key": "robotics_engineer",
+            "title": "Robotics / Autonomy Software Engineer",
+            "track": "Engineering",
+            "socCode": "17-2199",
+            "description": "Software for robots, drones, autonomous vehicles — perception, planning, control.",
+            "stack": ["C++ and Python", "ROS / ROS 2", "Sensor fusion basics", "Linear algebra", "Linux / real-time systems"]
+        },
+        {
+            "key": "computer_systems_analyst",
+            "title": "Computer Systems Analyst",
+            "track": "Customer / Field",
+            "socCode": "15-1211",
+            "description": "Studies an organization's systems and processes, then designs improvements.",
+            "stack": ["Software systems literacy", "Process mapping", "Requirements gathering", "SQL", "Stakeholder communication"]
+        }
+    ]
+}

--- a/src/layouts/headers/header-02.tsx
+++ b/src/layouts/headers/header-02.tsx
@@ -1,12 +1,13 @@
 import Logo from "@components/logo";
 import MainMenu from "@components/menu/main-menu";
-import menu from "@data/menu";
+import menu, { filterMenuByAuth } from "@data/menu";
 import { useSticky } from "@hooks";
 import BurgerButton from "@ui/burger-button";
 import clsx from "clsx";
+import { useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const MobileMenu = dynamic(() => import("../../components/menu/mobile-menu"), {
     ssr: false,
@@ -21,6 +22,11 @@ const Header = ({ shadow, fluid }: TProps) => {
     const router = useRouter();
     const [offcanvas, setOffcanvas] = useState(false);
     const { sticky, measuredRef } = useSticky();
+    const { status } = useSession();
+    const filteredMenu = useMemo(
+        () => filterMenuByAuth(menu, status === "authenticated"),
+        [status]
+    );
 
     useEffect(() => {
         setOffcanvas(false);
@@ -45,7 +51,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                             fluid && "tw-max-w-full tw-px-3.8 3xl:tw-px-37"
                         )}
                     >
-                        <MainMenu menu={menu} hoverStyle="B" className="tw-hidden xl:tw-block" />
+                        <MainMenu menu={filteredMenu} hoverStyle="B" className="tw-hidden xl:tw-block" />
                         <Logo variant="dark" className="tw-max-w-[120px] sm:tw-max-w-[158px]" />
                         <div className="tw-flex tw-items-center tw-justify-end">
                             <BurgerButton
@@ -59,7 +65,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                 </div>
                 <div className="tw-h-20" />
             </header>
-            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={menu} />
+            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={filteredMenu} />
         </>
     );
 };

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -74,18 +74,21 @@ const Header = ({ shadow, fluid }: TProps) => {
                     >
                         <div
                             className={clsx(
-                                "tw-container tw-grid tw-grid-flow-col tw-items-center xl:tw-grid-cols-[22%_minmax(56%,_1fr)_22%]",
+                                "tw-container tw-flex tw-items-center tw-justify-between tw-gap-6",
                                 fluid && "tw-max-w-full tw-px-3.8 3xl:tw-px-37"
                             )}
                         >
-                            <Logo variant="dark" className="tw-max-w-[120px] sm:tw-max-w-[158px]" />
+                            <Logo
+                                variant="dark"
+                                className="tw-flex tw-items-center tw-shrink-0 tw-max-w-[120px] sm:tw-max-w-[158px]"
+                            />
                             <MainMenu
                                 className="tw-hidden xl:tw-block"
                                 align="center"
                                 menu={filteredMenu}
                                 hoverStyle="B"
                             />
-                            <div className="tw-flex tw-items-center tw-justify-end tw-gap-4">
+                            <div className="tw-flex tw-items-center tw-justify-end tw-gap-4 tw-shrink-0">
                                 <div className="tw-hidden lg:tw-flex tw-items-center tw-gap-2">
                                     <span className="tw-relative tw-flex tw-h-[5px] tw-w-[5px]">
                                         <span className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-rounded-full tw-bg-red tw-opacity-75" style={{ animation: "statusBlink 2s ease-in-out infinite" }} />

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -1,15 +1,16 @@
 import Logo from "@components/logo";
 import MainMenu from "@components/menu/main-menu";
 import Social01 from "@components/socials/social-01";
-import menu from "@data/menu";
+import menu, { filterMenuByAuth } from "@data/menu";
 import { useSticky } from "@hooks";
 import BurgerButton from "@ui/burger-button";
 import Button from "@ui/button";
 import CountdownTimer from "@ui/countdown-timer/layout-03";
 import clsx from "clsx";
+import { useSession } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const MobileMenu = dynamic(() => import("../../components/menu/mobile-menu"), {
     ssr: false,
@@ -24,6 +25,11 @@ const Header = ({ shadow, fluid }: TProps) => {
     const router = useRouter();
     const [offcanvas, setOffcanvas] = useState(false);
     const { sticky, measuredRef } = useSticky();
+    const { status } = useSession();
+    const filteredMenu = useMemo(
+        () => filterMenuByAuth(menu, status === "authenticated"),
+        [status]
+    );
 
     useEffect(() => {
         setOffcanvas(false);
@@ -76,7 +82,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                             <MainMenu
                                 className="tw-hidden xl:tw-block"
                                 align="center"
-                                menu={menu}
+                                menu={filteredMenu}
                                 hoverStyle="B"
                             />
                             <div className="tw-flex tw-items-center tw-justify-end tw-gap-4">
@@ -102,7 +108,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                     <div className="tw-h-20" />
                 </div>
             </header>
-            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={menu} />
+            <MobileMenu isOpen={offcanvas} onClose={() => setOffcanvas(false)} menu={filteredMenu} />
         </>
     );
 };

--- a/src/pages/career-guides/[mos].tsx
+++ b/src/pages/career-guides/[mos].tsx
@@ -42,6 +42,36 @@ interface SystemsData {
     systems: SystemEntry[];
 }
 
+interface TechRoleSeed {
+    key: string;
+    title: string;
+    track: string;
+    socCode: string;
+    description: string;
+    stack: string[];
+}
+
+interface TechPathwayBundle {
+    techRoles: Array<{
+        roleKey: string;
+        matchLevel: "high" | "good" | "moderate";
+        whyItFits: string;
+    }>;
+    skillsYouHave: Array<{ from: string; to: string }>;
+    skillsToLearn: Array<{ skill: string; forRole: string }>;
+}
+
+interface ResolvedTechRole {
+    roleKey: string;
+    matchLevel: "high" | "good" | "moderate";
+    whyItFits: string;
+    title: string;
+    track: string;
+    socCode: string;
+    description: string;
+    stack: string[];
+}
+
 interface MosPageProps {
     mosCode: string;
     training: TrainingData;
@@ -49,6 +79,11 @@ interface MosPageProps {
     systems: SystemsData;
     pathways: CareerPathway[];
     cognitiveProfile: CognitiveProfile | null;
+    techPathway: {
+        roles: ResolvedTechRole[];
+        skillsYouHave: Array<{ from: string; to: string }>;
+        skillsToLearn: Array<{ skill: string; forRole: string }>;
+    } | null;
 }
 
 type PageWithLayout = NextPage<MosPageProps> & {
@@ -65,7 +100,15 @@ const DATA_SOURCE_LABELS: Record<string, string> = {
     curated: "Salary estimates from VWC career data",
 };
 
-const MosPage: PageWithLayout = ({ mosCode, training, certs, systems, pathways, cognitiveProfile }) => {
+const MosPage: PageWithLayout = ({
+    mosCode,
+    training,
+    certs,
+    systems,
+    pathways,
+    cognitiveProfile,
+    techPathway,
+}) => {
     const pageTitle = `${mosCode} ${training.title} — Military-to-Civilian Career Guide`;
     const pageDescription = `Free career guide for ${training.branch} ${mosCode} (${training.title}). Discover civilian job matches, salary data, certification pathways, and training equivalencies. Built by veterans, for veterans.`;
 
@@ -136,6 +179,123 @@ const MosPage: PageWithLayout = ({ mosCode, training, certs, systems, pathways, 
                             Start Free Translation
                         </Link>
                     </div>
+
+                    {/* Tech Roles You Could Aim For */}
+                    {techPathway && techPathway.roles.length > 0 && (
+                        <section className="tw-mb-10">
+                            <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-2">
+                                <i className="fas fa-microchip tw-mr-2 tw-text-[#c5203e]" />
+                                Tech Roles You Could Aim For
+                            </h2>
+                            <p className="tw-text-gray-600 tw-mb-6">
+                                Real industry tech roles your {mosCode} background maps to — picked from BLS-anchored occupations using your training, cognitive skills, and systems experience.
+                            </p>
+                            <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-4 tw-mb-8">
+                                {techPathway.roles.map((role) => (
+                                    <div key={role.roleKey} className="tw-border tw-border-gray-200 tw-rounded-lg tw-p-5">
+                                        <div className="tw-flex tw-items-start tw-justify-between tw-mb-2 tw-gap-2">
+                                            <div>
+                                                <h3 className="tw-font-semibold tw-text-[#091f40]">{role.title}</h3>
+                                                <p className="tw-text-xs tw-text-gray-500 tw-mt-0.5">{role.track}</p>
+                                            </div>
+                                            <span className="tw-text-xs tw-bg-gray-100 tw-text-gray-500 tw-px-2 tw-py-0.5 tw-rounded tw-font-mono tw-whitespace-nowrap">
+                                                SOC {role.socCode}
+                                            </span>
+                                        </div>
+                                        <span
+                                            className={`tw-inline-block tw-text-xs tw-px-2 tw-py-0.5 tw-rounded tw-mb-3 ${
+                                                role.matchLevel === "high"
+                                                    ? "tw-bg-green-50 tw-text-green-700"
+                                                    : role.matchLevel === "good"
+                                                      ? "tw-bg-blue-50 tw-text-blue-700"
+                                                      : "tw-bg-gray-50 tw-text-gray-600"
+                                            }`}
+                                        >
+                                            {role.matchLevel === "high"
+                                                ? "High match"
+                                                : role.matchLevel === "good"
+                                                  ? "Good match"
+                                                  : "Moderate match"}
+                                        </span>
+                                        <p className="tw-text-sm tw-text-gray-700 tw-mb-3">{role.whyItFits}</p>
+                                        {role.stack.length > 0 && (
+                                            <div>
+                                                <p className="tw-text-xs tw-text-gray-500 tw-mb-1">Typical stack:</p>
+                                                <div className="tw-flex tw-flex-wrap tw-gap-1">
+                                                    {role.stack.map((s) => (
+                                                        <span
+                                                            key={s}
+                                                            className="tw-text-xs tw-bg-gray-100 tw-text-gray-600 tw-px-2 tw-py-0.5 tw-rounded"
+                                                        >
+                                                            {s}
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+
+                            {techPathway.skillsYouHave.length > 0 && (
+                                <div className="tw-mb-8">
+                                    <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-3">
+                                        Skills You Already Have
+                                    </h3>
+                                    <p className="tw-text-sm tw-text-gray-600 tw-mb-4">
+                                        Concrete bridges from {mosCode} experience to tech-industry practice.
+                                    </p>
+                                    <ul className="tw-space-y-2">
+                                        {techPathway.skillsYouHave.map((s, idx) => (
+                                            <li
+                                                key={`${s.from}-${idx}`}
+                                                className="tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-baseline tw-gap-2 tw-bg-gray-50 tw-rounded-lg tw-p-3"
+                                            >
+                                                <span className="tw-text-sm tw-font-medium tw-text-[#091f40] sm:tw-min-w-[40%]">
+                                                    {s.from}
+                                                </span>
+                                                <span className="tw-text-sm tw-text-gray-700">→ {s.to}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+
+                            {techPathway.skillsToLearn.length > 0 && (
+                                <div className="tw-mb-2">
+                                    <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-3">
+                                        Skills to Learn
+                                    </h3>
+                                    <p className="tw-text-sm tw-text-gray-600 tw-mb-4">
+                                        The concrete gap to bridge — specific to the roles above, not generic.
+                                    </p>
+                                    <div className="tw-flex tw-flex-wrap tw-gap-2">
+                                        {techPathway.skillsToLearn.map((s, idx) => (
+                                            <span
+                                                key={`${s.skill}-${idx}`}
+                                                className="tw-text-sm tw-bg-[#091f40] tw-text-white tw-px-3 tw-py-1 tw-rounded"
+                                            >
+                                                {s.skill}
+                                            </span>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+
+                            <div className="tw-mt-8 tw-bg-gradient-to-r tw-from-[#091f40] tw-to-[#1a3a6b] tw-rounded-lg tw-p-6 tw-text-white">
+                                <h3 className="tw-text-lg tw-font-bold tw-mb-2 tw-text-white">How VWC fits</h3>
+                                <p className="tw-text-sm tw-text-white tw-mb-3">
+                                    Vets Who Code accelerates the parts we teach — software engineering fundamentals, web development, AI tooling. For everything else above, the path is doable independently with the resources we link to.
+                                </p>
+                                <Link
+                                    href="/programs"
+                                    className="tw-inline-block tw-bg-[#c5a44e] tw-text-[#091f40] tw-font-bold tw-px-5 tw-py-2 tw-rounded hover:tw-bg-[#d4b55e] tw-transition-colors"
+                                >
+                                    See VWC Programs
+                                </Link>
+                            </div>
+                        </section>
+                    )}
 
                     {/* Career Pathways */}
                     {pathways.length > 0 && (
@@ -431,6 +591,18 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         fs.readFileSync(path.join(dataDir, "cognitive-skills-map.json"), "utf-8")
     ) as Record<string, CognitiveProfile>;
 
+    // Tech pathways are optional — file may not exist on a fresh checkout
+    // before the generation script has been run.
+    const techPathwaysPath = path.join(dataDir, "tech-pathways-map.json");
+    const techTaxonomyPath = path.join(dataDir, "tech-roles-taxonomy.json");
+    const techPathwaysMap: Record<string, TechPathwayBundle> = fs.existsSync(techPathwaysPath)
+        ? (JSON.parse(fs.readFileSync(techPathwaysPath, "utf-8")) as Record<string, TechPathwayBundle>)
+        : {};
+    const techTaxonomy: { roles: TechRoleSeed[] } = fs.existsSync(techTaxonomyPath)
+        ? (JSON.parse(fs.readFileSync(techTaxonomyPath, "utf-8")) as { roles: TechRoleSeed[] })
+        : { roles: [] };
+    const taxonomyByKey = new Map(techTaxonomy.roles.map((r) => [r.key, r]));
+
     // Resolve the canonical MOS key: check SEO list first, then match
     // against training data keys (handles mixed-case codes like IT_NAVY)
     const mosCode =
@@ -442,6 +614,30 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     if (!training) {
         return { notFound: true };
     }
+
+    const techBundle = techPathwaysMap[mosCode];
+    const resolvedTech = techBundle
+        ? {
+              roles: techBundle.techRoles
+                  .map((r) => {
+                      const seed = taxonomyByKey.get(r.roleKey);
+                      if (!seed) return null;
+                      return {
+                          roleKey: r.roleKey,
+                          matchLevel: r.matchLevel,
+                          whyItFits: r.whyItFits,
+                          title: seed.title,
+                          track: seed.track,
+                          socCode: seed.socCode,
+                          description: seed.description,
+                          stack: seed.stack,
+                      };
+                  })
+                  .filter((r): r is ResolvedTechRole => r !== null),
+              skillsYouHave: techBundle.skillsYouHave,
+              skillsToLearn: techBundle.skillsToLearn,
+          }
+        : null;
 
     return {
         props: {
@@ -456,6 +652,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
             systems: systemsMap[mosCode] || { branch: training.branch, title: training.title, systems: [] },
             pathways: pathwaysMap[mosCode] || [],
             cognitiveProfile: cognitiveMap[mosCode] || null,
+            techPathway: resolvedTech,
         },
     };
 };


### PR DESCRIPTION
## Summary

Re-grounds \`/career-guides/[mos]\` in real tech industry roles. Today **54% of MOS codes** are recommended only non-tech careers (Operations Manager, Facilities, EMT, Sales, Law Enforcement). VWC is a software engineering accelerator and these pages are SEO-indexed as the public answer to "what should a veteran do after the military" — so the current state is mission-incoherent.

This PR adds the infrastructure to produce tech-aligned pathways for every MOS, plus the rendering changes. The generation script has **not been run yet** — no \`tech-pathways-map.json\` is committed. Pages render the legacy sections only; the new tech section gates cleanly on file presence.

Closes #1103.

## What's in this PR

| Piece | Path |
|---|---|
| Role taxonomy (35 roles, BLS SOC-anchored) | \`src/data/tech-roles-taxonomy.json\` |
| Generation orchestrator (Lightcast-enriched + Gemini) | \`scripts/generate-tech-pathways.ts\` |
| Curriculum gap report generator | \`scripts/generate-curriculum-gap-report.ts\` |
| Page render — new "Tech Roles You Could Aim For" section | \`src/pages/career-guides/[mos].tsx\` |
| npm scripts | \`generate:tech-pathways\`, \`generate:curriculum-gap-report\` |
| Env vars (Lightcast, Census — already used in src/lib but undocumented) | \`.env.example\` |

## How the generation works

1. Loads \`tech-roles-taxonomy.json\` (35 BLS SOC-anchored roles).
2. Enriches each role with Lightcast salary data at run time via \`src/lib/labor-market.ts\` (three-tier fallback: Lightcast → Census → curated).
3. For each of ~4,229 MOS codes, calls Gemini with:
   - MOS training topics (\`training-pipeline.json\`)
   - Cognitive transfer skills (\`cognitive-skills-map.json\`)
   - Civilian system equivalents (\`military-systems-map.json\`)
   - Official MOS description (\`job-codes-descriptions.json\`)
   - The enriched taxonomy as the candidate role set
4. Gemini returns:
   - 3-5 best-fit \`roleKey\`s from the taxonomy + match level + why-it-fits
   - 3-6 skills-have as \`from\`/\`to\` bridges (military origin → tech equivalent)
   - 4-8 skills-to-learn (concrete: language, framework, tool — never "learn programming")
5. Output: \`src/data/tech-pathways-map.json\`. **Resumable** — re-runs skip codes already in the file.

System prompt forbids generic phrases (\"leadership\", \"attention to detail\"). Every \`whyItFits\` must cite a specific training topic, cognitive skill, or system from the MOS data.

## How the page renders

Above the existing \"Civilian Career Pathways\" section, a new \"Tech Roles You Could Aim For\" block shows:
- 3-5 role cards with SOC code, track, match level, why-it-fits, typical stack
- \"Skills You Already Have\" — concrete from→to bridges
- \"Skills to Learn\" — chip cloud of specific learning targets
- \"How VWC fits\" — generic CTA to \`/programs\`. **No per-MOS program guessing** — that's the failure mode this PR fixes.

## Operational notes

- **Cost**: ~4,229 × one Gemini 2.5 Flash call. Roughly $1–3 for the full batch.
- **Time**: batched 10-wide with 1s delays, ~7–10 minutes for the full run.
- **Resumable**: each batch persists. A network blip or rate limit doesn't lose work.
- **No runtime AI**: all generation happens in the script, output is committed JSON, pages stay 100% static (\`getStaticProps\` only).

## To run after merge

\`\`\`bash
# Set in .env: GOOGLE_GENERATIVE_AI_API_KEY (or GEMINI_API_KEY),
# plus LIGHTCAST_CLIENT_ID + LIGHTCAST_CLIENT_SECRET for live salary data.
npm run generate:tech-pathways
npm run generate:curriculum-gap-report

# Then commit:
#   src/data/tech-pathways-map.json
#   docs/curriculum-gap-report.md
\`\`\`

## Test plan
- [ ] \`npm run typecheck\` — clean (no new errors beyond the 7 pre-existing on master)
- [ ] \`npm run test\` — 380/380 pass
- [ ] \`npm run lint -- src/pages/career-guides/[mos].tsx\` — only \`console.log\` warnings on script files (consistent with existing \`scripts/generate-career-pathways.ts\`)
- [ ] On Vercel preview, browse to \`/career-guides/68w\` — page renders correctly with **legacy sections only** (tech-pathways section gated on file presence; nothing should change visually until the script runs)
- [ ] After merge, run \`npm run generate:tech-pathways\` locally with a single test code first (edit the script's \`todo\` filter to one MOS) to sanity-check output before the full 4,229 run