### PR TITLE
fix: Improve form error feedback accessibility

### DIFF
--- a/src/components/ui/form-elements/__tests__/accessible-feedback.test.tsx
+++ b/src/components/ui/form-elements/__tests__/accessible-feedback.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import Input from "../input";
+import Textarea from "../textarea";
+
+describe("form element error feedback accessibility", () => {
+    it("connects input errors with aria-describedby and alert feedback", () => {
+        render(
+            <Input
+                id="email"
+                name="email"
+                state="error"
+                feedbackText="Enter a valid email address"
+            />
+        );
+
+        const input = screen.getByRole("textbox");
+        const alert = screen.getByRole("alert");
+
+        expect(input).toHaveAttribute("aria-invalid", "true");
+        expect(input).toHaveAttribute("aria-describedby", "email-error");
+        expect(alert).toHaveAttribute("id", "email-error");
+        expect(alert).toHaveTextContent("Enter a valid email address");
+    });
+
+    it("connects textarea errors with aria-describedby and alert feedback", () => {
+        render(
+            <Textarea
+                id="message"
+                name="message"
+                state="error"
+                feedbackText="Message is required"
+            />
+        );
+
+        const textarea = screen.getByRole("textbox");
+        const alert = screen.getByRole("alert");
+
+        expect(textarea).toHaveAttribute("aria-invalid", "true");
+        expect(textarea).toHaveAttribute("aria-describedby", "message-error");
+        expect(alert).toHaveAttribute("id", "message-error");
+        expect(alert).toHaveTextContent("Message is required");
+    });
+});

--- a/src/components/ui/form-elements/__tests__/accessible-feedback.test.tsx
+++ b/src/components/ui/form-elements/__tests__/accessible-feedback.test.tsx
@@ -40,4 +40,22 @@ describe("form element error feedback accessibility", () => {
         expect(alert).toHaveAttribute("id", "message-error");
         expect(alert).toHaveTextContent("Message is required");
     });
+
+    it("uses a custom feedback id when provided", () => {
+        render(
+            <Input
+                id="email"
+                name="email"
+                state="error"
+                feedbackId="signup-email-feedback"
+                feedbackText="Enter a valid email address"
+            />
+        );
+
+        const input = screen.getByRole("textbox");
+        const alert = screen.getByRole("alert");
+
+        expect(input).toHaveAttribute("aria-describedby", "signup-email-feedback");
+        expect(alert).toHaveAttribute("id", "signup-email-feedback");
+    });
 });

--- a/src/components/ui/form-elements/feedback.tsx
+++ b/src/components/ui/form-elements/feedback.tsx
@@ -5,11 +5,14 @@ export interface IFeedback {
     state?: "success" | "warning" | "error";
     showErrorOnly?: boolean;
     children: React.ReactNode;
+    id?: string;
 }
 
-const Feedback: FC<IFeedback> = ({ state, showErrorOnly, children }) => {
+const Feedback: FC<IFeedback> = ({ state, showErrorOnly, children, id }) => {
     return (
         <span
+            id={id}
+            role={state === "error" ? "alert" : undefined}
             className={clsx(
                 "tw-mt-1 tw-block tw-w-full tw-text-md",
                 state !== "error" && showErrorOnly && "tw-hidden",

--- a/src/components/ui/form-elements/input.tsx
+++ b/src/components/ui/form-elements/input.tsx
@@ -1,9 +1,9 @@
 import cn from "clsx";
 import { forwardRef } from "react";
 import Feedback from "./feedback";
-import { IInputProps } from "./types";
+import { ITextInputProps } from "./types";
 
-interface IProps extends IInputProps {
+interface IProps extends ITextInputProps {
     type?: string;
     bg?: "white" | "light";
 }

--- a/src/components/ui/form-elements/input.tsx
+++ b/src/components/ui/form-elements/input.tsx
@@ -17,6 +17,7 @@ const Input = forwardRef<HTMLInputElement, IProps>(
             disabled,
             state,
             feedbackText,
+            feedbackId,
             id,
             name,
             onChange,
@@ -49,6 +50,8 @@ const Input = forwardRef<HTMLInputElement, IProps>(
         const errorClass = state === "error" && "!tw-border-danger";
         const focusBorderClass = customStyle !== "nofocus" && !state && "focus:tw-border-primary";
         const noFocusClass = customStyle === "nofocus" && "focus:tw-outline-0";
+        const errorFeedbackId = feedbackId || `${id}-error`;
+        const showErrorFeedback = !!feedbackText && showState && state === "error";
 
         return (
             <>
@@ -80,10 +83,16 @@ const Input = forwardRef<HTMLInputElement, IProps>(
                     readOnly={readonly}
                     min={min}
                     max={max}
+                    aria-invalid={state === "error" ? true : undefined}
+                    aria-describedby={showErrorFeedback ? errorFeedbackId : undefined}
                     {...restProps}
                 />
                 {feedbackText && showState && (
-                    <Feedback state={state} showErrorOnly={showErrorOnly}>
+                    <Feedback
+                        id={showErrorFeedback ? errorFeedbackId : undefined}
+                        state={state}
+                        showErrorOnly={showErrorOnly}
+                    >
                         {feedbackText}
                     </Feedback>
                 )}

--- a/src/components/ui/form-elements/textarea.tsx
+++ b/src/components/ui/form-elements/textarea.tsx
@@ -1,9 +1,9 @@
 import cn from "clsx";
 import { forwardRef } from "react";
 import Feedback from "./feedback";
-import { IInputProps } from "./types";
+import { ITextInputProps } from "./types";
 
-interface IProps extends IInputProps {
+interface IProps extends ITextInputProps {
     rows?: number;
     bg?: "white" | "light";
 }

--- a/src/components/ui/form-elements/textarea.tsx
+++ b/src/components/ui/form-elements/textarea.tsx
@@ -16,6 +16,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, IProps>(
             disabled,
             state,
             feedbackText,
+            feedbackId,
             id,
             name,
             onChange,
@@ -47,6 +48,8 @@ const Textarea = forwardRef<HTMLTextAreaElement, IProps>(
         const focusBorderClass =
             customStyle !== "nofocus" && !state && "focus:tw-border-navy-ocean";
         const noFocusClass = customStyle === "nofocus" && "focus:tw-outline-0";
+        const errorFeedbackId = feedbackId || `${id}-error`;
+        const showErrorFeedback = !!feedbackText && showState && state === "error";
 
         return (
             <>
@@ -75,10 +78,16 @@ const Textarea = forwardRef<HTMLTextAreaElement, IProps>(
                     onBlur={onBlur}
                     value={value}
                     readOnly={readonly}
+                    aria-invalid={state === "error" ? true : undefined}
+                    aria-describedby={showErrorFeedback ? errorFeedbackId : undefined}
                     {...restProps}
                 />
                 {feedbackText && showState && (
-                    <Feedback state={state} showErrorOnly={showErrorOnly}>
+                    <Feedback
+                        id={showErrorFeedback ? errorFeedbackId : undefined}
+                        state={state}
+                        showErrorOnly={showErrorOnly}
+                    >
                         {feedbackText}
                     </Feedback>
                 )}

--- a/src/components/ui/form-elements/types.ts
+++ b/src/components/ui/form-elements/types.ts
@@ -14,7 +14,6 @@ export interface IInputProps extends IFeedback {
     disabled?: boolean;
     readonly?: boolean;
     feedbackText?: string;
-    feedbackId?: string;
     id: string;
     name: string;
     placeholder?: string;
@@ -26,4 +25,8 @@ export interface IInputProps extends IFeedback {
     onClick?: (e: MouseEvent<TInput>) => void;
     onBlur?: (e: FocusEvent<TInput>) => void;
     customStyle?: TCustomStyle;
+}
+
+export interface ITextInputProps extends IInputProps {
+    feedbackId?: string;
 }

--- a/src/components/ui/form-elements/types.ts
+++ b/src/components/ui/form-elements/types.ts
@@ -14,6 +14,7 @@ export interface IInputProps extends IFeedback {
     disabled?: boolean;
     readonly?: boolean;
     feedbackText?: string;
+    feedbackId?: string;
     id: string;
     name: string;
     placeholder?: string;


### PR DESCRIPTION
## Summary

- Add accessible IDs to shared form feedback messages.
- Mark error feedback as `role="alert"` so screen readers announce validation errors.
- Connect invalid inputs and textareas to their error text with `aria-describedby` and `aria-invalid`.
- Add focused tests for the shared `Input` and `Textarea` components.

## Accessibility impact

This improves the shared form components used across application forms. When a field has validation feedback, assistive technology can now identify the field as invalid and read the matching error message.

Relates to #895.

## Validation

- `npm test -- src/components/ui/form-elements/__tests__/accessible-feedback.test.tsx` — passed
- `npx biome check src/components/ui/form-elements/__tests__/accessible-feedback.test.tsx src/components/ui/form-elements/feedback.tsx src/components/ui/form-elements/input.tsx src/components/ui/form-elements/textarea.tsx src/components/ui/form-elements/types.ts` — passed with existing complexity warnings in `input.tsx` and `textarea.tsx`
- `npm run typecheck` — blocked by pre-existing unrelated test typing errors in `__tests__/lib/j0di3` and `__tests__/pages/api/j0di3`
