### PR TITLE
feat(career-guides): Redesign as searchable hashflag index

### DIFF
--- a/src/containers/career-guides/branch-meta.ts
+++ b/src/containers/career-guides/branch-meta.ts
@@ -1,0 +1,12 @@
+import type { Branch, BranchShort } from "./types";
+
+// Distinct branch colors (handoff §Branch colors), tuned for use on our navy ground.
+export const BRANCH_META: Record<Branch, { short: BranchShort; color: string }> = {
+    Army: { short: "ARMY", color: "#6b8050" },
+    Navy: { short: "NAVY", color: "#5b87c4" },
+    "Air Force": { short: "USAF", color: "#8eb4d8" },
+    "Marine Corps": { short: "USMC", color: "#d9514a" },
+    "Coast Guard": { short: "USCG", color: "#e89149" },
+};
+
+export const BRANCH_ORDER: Branch[] = ["Army", "Navy", "Air Force", "Marine Corps", "Coast Guard"];

--- a/src/containers/career-guides/category-showcase.tsx
+++ b/src/containers/career-guides/category-showcase.tsx
@@ -1,0 +1,96 @@
+import clsx from "clsx";
+import type { Family, GuideEntry } from "./types";
+
+interface Props {
+    guides: GuideEntry[];
+    onPick: (family: Family) => void;
+}
+
+const FEATURED_FAMILIES: Array<{
+    family: Family;
+    number: string;
+    blurb: string;
+}> = [
+    {
+        family: "Cyber",
+        number: "/ 01",
+        blurb: "Signal warfare and cryptologic operators translate directly to security engineering.",
+    },
+    {
+        family: "IT / Comms",
+        number: "/ 02",
+        blurb: "Network and signal techs become DevOps, SRE, and platform engineers.",
+    },
+    {
+        family: "Aviation",
+        number: "/ 03",
+        blurb: "Avionics and aircrew specialties bridge to embedded systems and aerospace software.",
+    },
+    {
+        family: "Intelligence",
+        number: "/ 04",
+        blurb: "Intel analysts move into data engineering, threat hunting, and ML for defense.",
+    },
+];
+
+const medianSalary = (rows: GuideEntry[]): string => {
+    if (rows.length === 0) return "—";
+    const lows = rows.map((r) => r.salaryLow).sort((a, b) => a - b);
+    const highs = rows.map((r) => r.salaryHigh).sort((a, b) => a - b);
+    const lo = lows[Math.floor(lows.length / 2)];
+    const hi = highs[Math.floor(highs.length / 2)];
+    return `$${lo}–${hi}K typical`;
+};
+
+const CategoryShowcase = ({ guides, onPick }: Props) => {
+    return (
+        <section className="tw-bg-secondary tw-py-16 md:tw-py-20">
+            <div className="tw-container">
+                <div className="tw-mb-10 tw-flex tw-items-center tw-gap-3">
+                    <span className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-primary" />
+                    <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        Pathways that ship in civilian roles
+                    </span>
+                </div>
+
+                <div className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-4 tw-border-t tw-border-cream/10">
+                    {FEATURED_FAMILIES.map(({ family, number, blurb }, idx) => {
+                        const rows = guides.filter((g) => g.family === family);
+                        return (
+                            <button
+                                type="button"
+                                key={family}
+                                onClick={() => onPick(family)}
+                                className={clsx(
+                                    "tw-group tw-flex tw-flex-col tw-gap-5 tw-px-6 tw-py-8 tw-text-left tw-transition-colors tw-duration-150",
+                                    "hover:tw-bg-[#0c2549]",
+                                    idx > 0 && "lg:tw-border-l lg:tw-border-cream/10",
+                                    idx > 0 && idx < FEATURED_FAMILIES.length && "sm:tw-border-l sm:tw-border-cream/10",
+                                )}
+                            >
+                                <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#5a6478] group-hover:tw-text-accent">
+                                    {number}
+                                </span>
+                                <span className="tw-font-heading tw-text-[22px] tw-font-medium tw-uppercase tw-text-cream [letter-spacing:-0.01em]">
+                                    {family}
+                                </span>
+                                <span className="tw-font-body tw-text-[14px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                                    {blurb}
+                                </span>
+                                <span className="tw-mt-auto tw-flex tw-flex-col tw-gap-1 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.08em] tw-text-[#8590a6]">
+                                    <span>
+                                        <span className="tw-text-cream">{rows.length.toLocaleString()}</span>{" "}
+                                        guides
+                                    </span>
+                                    <span>{medianSalary(rows)}</span>
+                                </span>
+                            </button>
+                        );
+                    })}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default CategoryShowcase;

--- a/src/containers/career-guides/cta-band.tsx
+++ b/src/containers/career-guides/cta-band.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+const CtaBand = () => (
+    <section className="tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-20 md:tw-py-24">
+        <div className="tw-container">
+            <div className="tw-mb-6 tw-flex tw-items-center tw-gap-3">
+                <span className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-primary" />
+                <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                    Cohort 2027 · Intake Open
+                </span>
+            </div>
+
+            <h2 className="tw-font-heading tw-font-semibold tw-uppercase tw-text-cream [letter-spacing:-0.02em] [line-height:1] [font-size:clamp(32px,4.5vw,56px)]">
+                Found your translation?
+                <br />
+                <span className="tw-text-[#8590a6]">
+                    Now build the skills to land it.
+                </span>
+            </h2>
+
+            <p className="tw-mt-7 tw-max-w-[680px] tw-font-body tw-text-[17px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                Vets Who Code is a free, full-time software engineering accelerator for active duty,
+                veterans, and military spouses. 17 weeks, 25 modules, and a portfolio that ships.
+            </p>
+
+            <div className="tw-mt-9 tw-flex tw-flex-wrap tw-gap-4">
+                <Link
+                    href="/apply"
+                    className="tw-inline-flex tw-items-center tw-gap-2 tw-bg-accent tw-px-7 tw-py-4 tw-font-mono tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.1em] tw-text-secondary tw-transition-colors hover:tw-bg-gold-bright active:tw-scale-[0.97]"
+                >
+                    Apply for Cohort 2027 →
+                </Link>
+                <Link
+                    href="/programs/core-curriculum"
+                    className="tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-cream/[0.18] tw-px-7 tw-py-4 tw-font-mono tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.1em] tw-text-cream tw-transition-colors hover:tw-border-cream hover:tw-bg-cream/5 active:tw-scale-[0.97]"
+                >
+                    Read the curriculum
+                </Link>
+            </div>
+        </div>
+    </section>
+);
+
+export default CtaBand;

--- a/src/containers/career-guides/filters.tsx
+++ b/src/containers/career-guides/filters.tsx
@@ -1,0 +1,194 @@
+import clsx from "clsx";
+import { BRANCH_META, BRANCH_ORDER } from "./branch-meta";
+import { FAMILIES } from "@/lib/career-guides";
+import type { Branch, Family, Rank, SortKey } from "./types";
+
+interface Props {
+    branchCounts: Record<Branch, number>;
+    branch: "all" | Branch;
+    onBranch: (v: "all" | Branch) => void;
+    rank: "all" | Rank;
+    onRank: (v: "all" | Rank) => void;
+    family: "all" | Family;
+    onFamily: (v: "all" | Family) => void;
+    sort: SortKey;
+    onSort: (v: SortKey) => void;
+    showing: number;
+    total: number;
+}
+
+const RANK_OPTS: Array<{ key: "all" | Rank; label: string }> = [
+    { key: "all", label: "All" },
+    { key: "Enlisted", label: "Enlisted" },
+    { key: "Warrant", label: "Warrant" },
+    { key: "Officer", label: "Officer" },
+];
+
+const SORT_OPTS: Array<{ key: SortKey; label: string }> = [
+    { key: "code", label: "Code (A→Z)" },
+    { key: "title", label: "Title (A→Z)" },
+    { key: "salaryHigh", label: "Salary (High→Low)" },
+    { key: "salaryLow", label: "Salary (Low→High)" },
+    { key: "demand", label: "Demand" },
+];
+
+const RAINBOW =
+    "linear-gradient(90deg, #6b8050 0%, #6b8050 20%, #5b87c4 20%, #5b87c4 40%, #8eb4d8 40%, #8eb4d8 60%, #d9514a 60%, #d9514a 80%, #e89149 80%, #e89149 100%)";
+
+const Filters = ({
+    branchCounts,
+    branch,
+    onBranch,
+    rank,
+    onRank,
+    family,
+    onFamily,
+    sort,
+    onSort,
+    showing,
+    total,
+}: Props) => {
+    const allCount = BRANCH_ORDER.reduce((sum, b) => sum + branchCounts[b], 0);
+
+    return (
+        <div className="tw-flex tw-flex-col tw-gap-6">
+            {/* Branch chips */}
+            <div className="tw-flex tw-flex-wrap tw-gap-2">
+                <button
+                    type="button"
+                    onClick={() => onBranch("all")}
+                    className={clsx(
+                        "tw-flex tw-items-center tw-gap-2.5 tw-border tw-px-3.5 tw-py-2 tw-font-mono tw-text-[11.5px] tw-uppercase tw-tracking-[0.08em] tw-transition-colors",
+                        branch === "all"
+                            ? "tw-border-accent tw-bg-accent tw-text-secondary"
+                            : "tw-border-cream/[0.18] tw-bg-secondary tw-text-[#c4cad6] hover:tw-border-[#8590a6] hover:tw-text-cream",
+                    )}
+                >
+                    <span
+                        aria-hidden
+                        className="tw-h-2 tw-w-2"
+                        style={{ backgroundImage: RAINBOW }}
+                    />
+                    All
+                    <span
+                        className={clsx(
+                            "tw-tabular-nums",
+                            branch === "all" ? "tw-text-secondary/60" : "tw-text-[#8590a6]",
+                        )}
+                    >
+                        {allCount.toLocaleString()}
+                    </span>
+                </button>
+                {BRANCH_ORDER.map((b) => {
+                    const active = branch === b;
+                    return (
+                        <button
+                            type="button"
+                            key={b}
+                            onClick={() => onBranch(b)}
+                            className={clsx(
+                                "tw-flex tw-items-center tw-gap-2.5 tw-border tw-px-3.5 tw-py-2 tw-font-mono tw-text-[11.5px] tw-uppercase tw-tracking-[0.08em] tw-transition-colors",
+                                active
+                                    ? "tw-border-accent tw-bg-accent tw-text-secondary"
+                                    : "tw-border-cream/[0.18] tw-bg-secondary tw-text-[#c4cad6] hover:tw-border-[#8590a6] hover:tw-text-cream",
+                            )}
+                        >
+                            <span
+                                aria-hidden
+                                className="tw-h-2 tw-w-2"
+                                style={{ backgroundColor: BRANCH_META[b].color }}
+                            />
+                            {BRANCH_META[b].short}
+                            <span
+                                className={clsx(
+                                    "tw-tabular-nums",
+                                    active ? "tw-text-secondary/60" : "tw-text-[#8590a6]",
+                                )}
+                            >
+                                {branchCounts[b].toLocaleString()}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
+            {/* Facet bar */}
+            <div className="tw-flex tw-flex-col tw-gap-6 tw-border-t tw-border-cream/10 tw-border-b tw-py-5 lg:tw-flex-row lg:tw-flex-wrap lg:tw-items-center">
+                {/* Rank segmented */}
+                <div className="tw-flex tw-items-center tw-gap-3">
+                    <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        Rank
+                    </span>
+                    <div className="tw-flex tw-border tw-border-cream/[0.18]">
+                        {RANK_OPTS.map((r) => (
+                            <button
+                                key={r.key}
+                                type="button"
+                                onClick={() => onRank(r.key)}
+                                className={clsx(
+                                    "tw-px-3 tw-py-1.5 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-transition-colors",
+                                    rank === r.key
+                                        ? "tw-bg-accent tw-text-secondary"
+                                        : "tw-bg-secondary tw-text-[#c4cad6] hover:tw-text-cream",
+                                )}
+                            >
+                                {r.label}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Family */}
+                <label className="tw-flex tw-items-center tw-gap-3">
+                    <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        Family
+                    </span>
+                    <select
+                        value={family}
+                        onChange={(e) => onFamily(e.target.value as Family | "all")}
+                        className="tw-border tw-border-cream/[0.18] tw-bg-secondary tw-px-3 tw-py-1.5 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-cream tw-outline-none focus:tw-border-accent"
+                    >
+                        <option value="all">All families</option>
+                        {FAMILIES.map((f) => (
+                            <option key={f} value={f}>
+                                {f}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
+                {/* Sort */}
+                <label className="tw-flex tw-items-center tw-gap-3">
+                    <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        Sort
+                    </span>
+                    <select
+                        value={sort}
+                        onChange={(e) => onSort(e.target.value as SortKey)}
+                        className="tw-border tw-border-cream/[0.18] tw-bg-secondary tw-px-3 tw-py-1.5 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-cream tw-outline-none focus:tw-border-accent"
+                    >
+                        {SORT_OPTS.map((s) => (
+                            <option key={s.key} value={s.key}>
+                                {s.label}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
+                <span className="tw-ml-auto tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                    Showing{" "}
+                    <span className="tw-font-bold tw-text-cream tw-tabular-nums">
+                        {showing.toLocaleString()}
+                    </span>{" "}
+                    of{" "}
+                    <span className="tw-font-bold tw-text-cream tw-tabular-nums">
+                        {total.toLocaleString()}
+                    </span>{" "}
+                    Guides
+                </span>
+            </div>
+        </div>
+    );
+};
+
+export default Filters;

--- a/src/containers/career-guides/grid-view.tsx
+++ b/src/containers/career-guides/grid-view.tsx
@@ -1,0 +1,118 @@
+import clsx from "clsx";
+import Link from "next/link";
+import { BRANCH_META } from "./branch-meta";
+import type { GuideEntry } from "./types";
+
+interface Props {
+    rows: GuideEntry[];
+}
+
+const GuideCard = ({ g }: { g: GuideEntry }) => {
+    const meta = BRANCH_META[g.branch];
+    const visibleCerts = g.certs.slice(0, 4);
+    const extra = g.certs.length - visibleCerts.length;
+
+    return (
+        <Link
+            href={`/career-guides/${g.code.toLowerCase()}`}
+            className={clsx(
+                "tw-group tw-relative tw-flex tw-flex-col tw-gap-5 tw-border-t tw-border-l tw-border-cream/10 tw-bg-secondary tw-p-6 tw-transition-colors tw-duration-150",
+                "hover:tw-border-accent hover:tw-bg-[#102c55]",
+            )}
+        >
+            {/* Top: code + branch */}
+            <div className="tw-flex tw-items-start tw-justify-between">
+                <span className="tw-font-mono tw-text-[13.5px] tw-tracking-[0.04em] tw-text-cream">
+                    {g.featured && (
+                        <span aria-hidden className="tw-mr-1 tw-text-accent">
+                            ★
+                        </span>
+                    )}
+                    {g.code}
+                </span>
+                <span className="tw-flex tw-items-center tw-gap-2 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#c4cad6]">
+                    <span
+                        aria-hidden
+                        className="tw-h-2 tw-w-2"
+                        style={{ backgroundColor: meta.color }}
+                    />
+                    {meta.short}
+                </span>
+            </div>
+
+            {/* Title + civilian */}
+            <div className="tw-flex tw-flex-col tw-gap-1.5">
+                <span className="tw-font-heading tw-text-[19px] tw-font-medium tw-uppercase tw-leading-[1.2] tw-text-cream [letter-spacing:-0.01em]">
+                    {g.title}
+                </span>
+                <span className="tw-font-body tw-text-[13.5px] tw-leading-[1.45] tw-text-[#8590a6]">
+                    → {g.civilian}
+                </span>
+            </div>
+
+            {/* Salary + rank */}
+            <div className="tw-flex tw-items-center tw-justify-between tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                <span>
+                    <span className="tw-text-cream tw-tabular-nums">
+                        ${g.salaryLow}–{g.salaryHigh}
+                    </span>
+                    <span className="tw-ml-1 tw-text-[#5a6478]">K</span> civilian
+                </span>
+                <span>{g.rank}</span>
+            </div>
+
+            {/* Certs row + arrow */}
+            <div className="tw-mt-auto tw-flex tw-items-end tw-justify-between tw-gap-3">
+                <div className="tw-flex tw-flex-wrap tw-gap-1.5">
+                    {visibleCerts.map((c) => (
+                        <span
+                            key={c}
+                            className="tw-border tw-border-cream/10 tw-px-2 tw-py-1 tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-[0.08em] tw-text-[#c4cad6]"
+                        >
+                            {c}
+                        </span>
+                    ))}
+                    {extra > 0 && (
+                        <span className="tw-border tw-border-dashed tw-border-cream/[0.18] tw-px-2 tw-py-1 tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-[0.08em] tw-text-[#8590a6]">
+                            +{extra}
+                        </span>
+                    )}
+                </div>
+                <span
+                    aria-hidden
+                    className="tw-shrink-0 tw-font-mono tw-text-[16px] tw-text-[#8590a6] tw-transition-colors group-hover:tw-text-accent"
+                >
+                    →
+                </span>
+            </div>
+        </Link>
+    );
+};
+
+const GridView = ({ rows }: Props) => {
+    if (rows.length === 0) {
+        return (
+            <div className="tw-flex tw-flex-col tw-items-center tw-gap-2 tw-py-24 tw-text-center">
+                <span className="tw-font-heading tw-text-[28px] tw-font-semibold tw-uppercase tw-text-cream [letter-spacing:-0.02em]">
+                    No matches.
+                </span>
+                <span className="tw-font-body tw-text-[15px] tw-text-[#8590a6]">
+                    Try a different code, branch, or career family.
+                </span>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="tw-grid tw-border-r tw-border-b tw-border-cream/10"
+            style={{ gridTemplateColumns: "repeat(auto-fill, minmax(320px, 1fr))" }}
+        >
+            {rows.map((g) => (
+                <GuideCard key={`${g.branch}-${g.code}`} g={g} />
+            ))}
+        </div>
+    );
+};
+
+export default GridView;

--- a/src/containers/career-guides/hero.tsx
+++ b/src/containers/career-guides/hero.tsx
@@ -1,0 +1,101 @@
+import type { Branch } from "./types";
+
+interface Props {
+    total: number;
+    branchCount: number;
+    familiesCount: number;
+    certsCount: number;
+    branches: Branch[];
+}
+
+const Cell = ({ label, value, sub }: { label: string; value: string; sub: string }) => (
+    <div className="tw-flex tw-flex-col tw-gap-3 tw-px-6 tw-py-7 md:tw-border-l md:tw-border-cream/10 first:md:tw-border-l-0">
+        <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+            {label}
+        </span>
+        <span className="tw-font-heading tw-text-[30px] tw-font-semibold tw-leading-none tw-text-cream">
+            {value}
+        </span>
+        <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.08em] tw-text-[#8590a6]">
+            {sub}
+        </span>
+    </div>
+);
+
+const Hero = ({ total, branchCount, familiesCount, certsCount, branches }: Props) => {
+    const branchSub = branches.map((b) => b).join(" · ");
+
+    return (
+        <section className="tw-bg-secondary tw-pt-20 md:tw-pt-24">
+            <div className="tw-container">
+                {/* Breadcrumb */}
+                <div className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                    <span>Home</span>
+                    <span className="tw-mx-2 tw-text-[#5a6478]">/</span>
+                    <span className="tw-text-cream">Career Guides</span>
+                </div>
+
+                {/* Eyebrow */}
+                <div className="tw-mt-10 tw-flex tw-items-center tw-gap-3">
+                    <span className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-primary" />
+                    <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        Career Guides{" "}
+                        <span className="tw-text-[#5a6478]">/</span> Hashflag Index v1.0
+                    </span>
+                </div>
+
+                {/* H1 */}
+                <h1 className="tw-mt-6 tw-font-heading tw-font-semibold tw-uppercase tw-text-cream [letter-spacing:-0.025em] [line-height:0.98] [font-size:clamp(48px,8.5vw,124px)]">
+                    From job code
+                    <br />
+                    <span className="tw-text-[#8590a6]">to</span>{" "}
+                    <span className="tw-text-accent">civilian</span> career.
+                </h1>
+
+                {/* Lede */}
+                <p className="tw-mt-8 tw-max-w-[720px] tw-font-body tw-text-[#c4cad6] [font-size:clamp(18px,1.6vw,22px)] tw-leading-[1.5]">
+                    Every military job code{" "}
+                    <span className="tw-font-semibold tw-text-cream">maps to a civilian career</span>{" "}
+                    — search {total.toLocaleString()} guides across all five branches, see civilian
+                    salary bands sourced from Lightcast labor data, and find the certifications that
+                    translate your service into{" "}
+                    <span className="tw-font-semibold tw-text-cream">
+                        software engineering roles
+                    </span>{" "}
+                    that pay.
+                </p>
+
+                {/* Stat strip */}
+                <div className="tw-mt-14 tw-grid tw-grid-cols-2 md:tw-grid-cols-5 tw-border-t tw-border-cream/10">
+                    <Cell
+                        label="Total Guides"
+                        value={total.toLocaleString()}
+                        sub="across DoD job codes"
+                    />
+                    <Cell
+                        label="Branches"
+                        value={String(branchCount)}
+                        sub={branchSub}
+                    />
+                    <Cell
+                        label="Career Families"
+                        value={String(familiesCount)}
+                        sub="Cyber to Logistics"
+                    />
+                    <Cell
+                        label="Certifications"
+                        value={certsCount.toLocaleString()}
+                        sub="civilian equivalencies"
+                    />
+                    <Cell
+                        label="Salary Data"
+                        value="$45K–$280K"
+                        sub="via Lightcast"
+                    />
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Hero;

--- a/src/containers/career-guides/index.tsx
+++ b/src/containers/career-guides/index.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import CategoryShowcase from "./category-showcase";
+import CtaBand from "./cta-band";
+import Filters from "./filters";
+import GridView from "./grid-view";
+import Hero from "./hero";
+import SearchBar from "./search-bar";
+import StatusBar from "./status-bar";
+import type { Branch, Family, GuideEntry, Rank, SortKey } from "./types";
+
+interface Props {
+    guides: GuideEntry[];
+    branchCounts: Record<Branch, number>;
+    familiesCount: number;
+    certsCount: number;
+}
+
+const PAGE_SIZE = 60;
+const SCROLL_OFFSET = 96;
+
+const demandWeight = (g: GuideEntry) =>
+    g.demand === "Very High" ? 3 : g.demand === "High" ? 2 : 1;
+
+const CareerGuidesContainer = ({ guides, branchCounts, familiesCount, certsCount }: Props) => {
+    const [query, setQuery] = useState("");
+    const [branch, setBranch] = useState<"all" | Branch>("all");
+    const [rank, setRank] = useState<"all" | Rank>("all");
+    const [family, setFamily] = useState<"all" | Family>("all");
+    const [sort, setSort] = useState<SortKey>("code");
+    const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+    const filtered = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        let rows = guides;
+        if (branch !== "all") rows = rows.filter((g) => g.branch === branch);
+        if (rank !== "all") rows = rows.filter((g) => g.rank === rank);
+        if (family !== "all") rows = rows.filter((g) => g.family === family);
+        if (q) {
+            rows = rows.filter(
+                (g) =>
+                    g.code.toLowerCase().includes(q) ||
+                    g.title.toLowerCase().includes(q) ||
+                    g.civilian.toLowerCase().includes(q) ||
+                    g.certs.some((c) => c.toLowerCase().includes(q)),
+            );
+        }
+        const sorted = [...rows];
+        sorted.sort((a, b) => {
+            switch (sort) {
+                case "title":
+                    return a.title.localeCompare(b.title);
+                case "salaryHigh":
+                    return b.salaryHigh - a.salaryHigh;
+                case "salaryLow":
+                    return a.salaryLow - b.salaryLow;
+                case "demand":
+                    return demandWeight(b) - demandWeight(a);
+                default:
+                    return a.code.localeCompare(b.code);
+            }
+        });
+        return sorted;
+    }, [guides, query, branch, rank, family, sort]);
+
+    // Reset pagination whenever the filtered set changes shape.
+    useEffect(() => {
+        setVisibleCount(PAGE_SIZE);
+    }, [query, branch, rank, family, sort]);
+
+    const visible = filtered.slice(0, visibleCount);
+    const hasMore = visibleCount < filtered.length;
+
+    const scrollToDatabase = useCallback(() => {
+        if (typeof window === "undefined") return;
+        const el = document.getElementById("database");
+        if (!el) return;
+        const top = el.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET;
+        window.scrollTo({ top, behavior: "smooth" });
+    }, []);
+
+    const onPickCategory = useCallback(
+        (f: Family) => {
+            setFamily(f);
+            scrollToDatabase();
+        },
+        [scrollToDatabase],
+    );
+
+    return (
+        <>
+            <StatusBar total={guides.length} />
+            <Hero
+                total={guides.length}
+                branchCount={5}
+                familiesCount={familiesCount}
+                certsCount={certsCount}
+                branches={["Army", "Navy", "Air Force", "Marine Corps", "Coast Guard"]}
+            />
+            <CategoryShowcase guides={guides} onPick={onPickCategory} />
+
+            {/* Database */}
+            <section
+                id="database"
+                className="tw-bg-secondary tw-py-16 md:tw-py-20"
+            >
+                <div className="tw-container tw-flex tw-flex-col tw-gap-10">
+                    {/* Section title */}
+                    <div className="tw-flex tw-flex-col tw-gap-4 md:tw-flex-row md:tw-items-end md:tw-justify-between">
+                        <div className="tw-flex tw-flex-col tw-gap-3">
+                            <div className="tw-flex tw-items-center tw-gap-3">
+                                <span className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-primary" />
+                                <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                                    Database · {guides.length.toLocaleString()} Guides
+                                </span>
+                            </div>
+                            <h2 className="tw-font-heading tw-font-semibold tw-uppercase tw-text-cream [letter-spacing:-0.02em] [line-height:1] [font-size:clamp(32px,4.5vw,56px)]">
+                                Search the index.
+                            </h2>
+                        </div>
+                        <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                            Sourced · DoD · Validated · Lightcast
+                        </span>
+                    </div>
+
+                    <SearchBar guides={guides} query={query} onQuery={setQuery} />
+
+                    <Filters
+                        branchCounts={branchCounts}
+                        branch={branch}
+                        onBranch={setBranch}
+                        rank={rank}
+                        onRank={setRank}
+                        family={family}
+                        onFamily={setFamily}
+                        sort={sort}
+                        onSort={setSort}
+                        showing={filtered.length}
+                        total={guides.length}
+                    />
+
+                    <GridView rows={visible} />
+
+                    {hasMore && (
+                        <div className="tw-flex tw-justify-center">
+                            <button
+                                type="button"
+                                onClick={() => setVisibleCount((n) => n + PAGE_SIZE)}
+                                className="tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-cream/[0.18] tw-px-7 tw-py-4 tw-font-mono tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.1em] tw-text-cream tw-transition-colors hover:tw-border-accent hover:tw-text-accent active:tw-scale-[0.97]"
+                            >
+                                Load {Math.min(PAGE_SIZE, filtered.length - visibleCount)} more →
+                            </button>
+                        </div>
+                    )}
+                </div>
+            </section>
+
+            <CtaBand />
+        </>
+    );
+};
+
+export default CareerGuidesContainer;

--- a/src/containers/career-guides/search-bar.tsx
+++ b/src/containers/career-guides/search-bar.tsx
@@ -1,0 +1,159 @@
+import clsx from "clsx";
+import { type KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+import { BRANCH_META } from "./branch-meta";
+import type { GuideEntry } from "./types";
+
+interface Props {
+    guides: GuideEntry[];
+    query: string;
+    onQuery: (q: string) => void;
+    onPick?: (g: GuideEntry) => void;
+}
+
+const isMac = () => typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.platform);
+
+const SearchBar = ({ guides, query, onQuery, onPick }: Props) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [focused, setFocused] = useState(false);
+    const [activeIdx, setActiveIdx] = useState(0);
+    const [mod, setMod] = useState("Ctrl");
+
+    useEffect(() => {
+        setMod(isMac() ? "⌘" : "Ctrl");
+    }, []);
+
+    // ⌘K / Ctrl-K global focus
+    useEffect(() => {
+        const handler = (e: globalThis.KeyboardEvent) => {
+            if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+                e.preventDefault();
+                inputRef.current?.focus();
+            }
+            if (e.key === "Escape") {
+                inputRef.current?.blur();
+            }
+        };
+        window.addEventListener("keydown", handler);
+        return () => window.removeEventListener("keydown", handler);
+    }, []);
+
+    const matches = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (!q) return [];
+        const prefix = guides.filter((g) => g.code.toLowerCase().startsWith(q));
+        const sub = guides.filter(
+            (g) =>
+                !g.code.toLowerCase().startsWith(q) &&
+                (g.title.toLowerCase().includes(q) || g.civilian.toLowerCase().includes(q)),
+        );
+        return [...prefix, ...sub].slice(0, 8);
+    }, [guides, query]);
+
+    useEffect(() => {
+        setActiveIdx(0);
+    }, [query]);
+
+    const open = focused && query.trim().length > 0 && matches.length > 0;
+
+    const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+        if (!open) return;
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setActiveIdx((i) => Math.min(i + 1, matches.length - 1));
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setActiveIdx((i) => Math.max(i - 1, 0));
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            const pick = matches[activeIdx];
+            if (pick) {
+                onQuery(pick.code);
+                onPick?.(pick);
+                inputRef.current?.blur();
+            }
+        }
+    };
+
+    return (
+        <div className="tw-relative">
+            <div
+                className={clsx(
+                    "tw-flex tw-items-center tw-gap-3 tw-border tw-bg-[#0c2549] tw-px-5 tw-py-4 tw-transition-all tw-duration-150",
+                    focused
+                        ? "tw-border-accent tw-shadow-[0_0_0_4px_rgba(253,179,48,0.14)]"
+                        : "tw-border-cream/[0.18]",
+                )}
+            >
+                <span className="tw-font-mono tw-text-[14px] tw-text-accent">$ find ~/</span>
+                <input
+                    ref={inputRef}
+                    type="text"
+                    value={query}
+                    onChange={(e) => onQuery(e.target.value)}
+                    onFocus={() => setFocused(true)}
+                    onBlur={() => setTimeout(() => setFocused(false), 150)}
+                    onKeyDown={onKey}
+                    placeholder={'try "cyber", "11B", "intel", "pilot"…'}
+                    aria-label="Search career guides"
+                    className="tw-flex-1 tw-bg-transparent tw-font-body tw-text-[19px] tw-text-cream tw-outline-none placeholder:tw-text-[#5a6478]"
+                />
+                <span className="tw-flex tw-items-center tw-gap-2 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                    <kbd className="tw-border tw-border-cream/20 tw-bg-secondary tw-px-2 tw-py-1 tw-text-[10px] tw-text-cream">
+                        {mod}K
+                    </kbd>
+                    Search
+                </span>
+            </div>
+
+            {open && (
+                <div
+                    className="tw-absolute tw-left-0 tw-right-0 tw-top-full tw-z-30 tw-mt-1 tw-border tw-border-cream/[0.18] tw-bg-[#0c2549] tw-shadow-lg"
+                    role="listbox"
+                >
+                    {matches.map((m, i) => (
+                        <button
+                            key={m.code}
+                            type="button"
+                            role="option"
+                            aria-selected={i === activeIdx}
+                            onMouseEnter={() => setActiveIdx(i)}
+                            onMouseDown={(e) => {
+                                e.preventDefault();
+                                onQuery(m.code);
+                                onPick?.(m);
+                            }}
+                            className={clsx(
+                                "tw-flex tw-w-full tw-items-center tw-gap-4 tw-px-5 tw-py-3 tw-text-left tw-transition-colors",
+                                i === activeIdx ? "tw-bg-[#102c55]" : "tw-bg-transparent",
+                            )}
+                        >
+                            <span className="tw-w-20 tw-shrink-0 tw-font-mono tw-text-[13px] tw-text-cream">
+                                {m.code}
+                            </span>
+                            <span className="tw-flex tw-flex-1 tw-flex-col">
+                                <span className="tw-font-body tw-text-[14px] tw-text-cream">
+                                    {m.title}
+                                </span>
+                                <span className="tw-font-body tw-text-[12.5px] tw-text-[#8590a6]">
+                                    → {m.civilian}
+                                </span>
+                            </span>
+                            <span
+                                className="tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#c4cad6]"
+                            >
+                                <span
+                                    aria-hidden
+                                    className="tw-inline-block tw-h-2 tw-w-2"
+                                    style={{ backgroundColor: BRANCH_META[m.branch].color }}
+                                />
+                                {BRANCH_META[m.branch].short}
+                            </span>
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default SearchBar;

--- a/src/containers/career-guides/status-bar.tsx
+++ b/src/containers/career-guides/status-bar.tsx
@@ -1,0 +1,29 @@
+interface Props {
+    total: number;
+}
+
+const StatusBar = ({ total }: Props) => (
+    <div className="tw-w-full tw-border-b tw-border-cream/10 tw-bg-secondary tw-py-2.5">
+        <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-gap-x-6 tw-gap-y-2 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+            <span className="tw-flex tw-items-center tw-gap-2 tw-text-cream">
+                <span className="tw-relative tw-flex tw-h-[7px] tw-w-[7px]">
+                    <span className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-animate-ping tw-rounded-full tw-bg-primary tw-opacity-75" />
+                    <span className="tw-relative tw-inline-flex tw-h-[7px] tw-w-[7px] tw-rounded-full tw-bg-primary tw-shadow-[0_0_10px_#c5203e]" />
+                </span>
+                <span>Live · Database v2.1</span>
+            </span>
+            <span>
+                <span className="tw-text-cream">{total.toLocaleString()}</span> Guides · 5 Branches
+            </span>
+            <span>
+                Validated · <span className="tw-text-cream">Lightcast Labor Data</span>
+            </span>
+            <span>
+                Updated · <span className="tw-text-cream">Q2 2026</span>
+            </span>
+            <span className="tw-ml-auto tw-text-cream">2026 Cohort Active</span>
+        </div>
+    </div>
+);
+
+export default StatusBar;

--- a/src/containers/career-guides/types.ts
+++ b/src/containers/career-guides/types.ts
@@ -1,0 +1,43 @@
+export type Branch = "Army" | "Navy" | "Air Force" | "Marine Corps" | "Coast Guard";
+
+export type BranchShort = "ARMY" | "NAVY" | "USAF" | "USMC" | "USCG";
+
+export type Rank = "Enlisted" | "Warrant" | "Officer";
+
+export type Demand = "Steady" | "High" | "Very High";
+
+export type Family =
+    | "Cyber"
+    | "IT / Comms"
+    | "Aviation"
+    | "Intelligence"
+    | "Logistics"
+    | "Medical"
+    | "Engineering"
+    | "Operations"
+    | "Maintenance"
+    | "Administration"
+    | "Other";
+
+export interface GuideEntry {
+    code: string;
+    title: string;
+    branch: Branch;
+    rank: Rank;
+    family: Family;
+    civilian: string;
+    salaryLow: number;
+    salaryHigh: number;
+    certs: string[];
+    demand: Demand;
+    featured?: boolean;
+}
+
+export interface BranchMeta {
+    name: Branch;
+    short: BranchShort;
+    color: string;
+    count: number;
+}
+
+export type SortKey = "code" | "title" | "salaryHigh" | "salaryLow" | "demand";

--- a/src/lib/career-guides.ts
+++ b/src/lib/career-guides.ts
@@ -1,0 +1,185 @@
+import fs from "fs";
+import path from "path";
+import type { Branch, Demand, Family, GuideEntry, Rank } from "@containers/career-guides/types";
+
+type TrainingEntry = {
+    branch: string;
+    title: string;
+    program?: string;
+    hours?: number;
+    weeks?: number;
+    topics?: string[];
+    civilian_certs?: string[];
+    ace_credits?: string;
+};
+
+type PathwayEntry = {
+    role: string;
+    matchLevel: string;
+    avgSalary: number;
+    demand: string;
+    skillsToClose?: string[];
+    dataSource?: string;
+};
+
+const BRANCH_NORMAL: Record<string, Branch> = {
+    army: "Army",
+    navy: "Navy",
+    "air force": "Air Force",
+    air_force: "Air Force",
+    usaf: "Air Force",
+    "marine corps": "Marine Corps",
+    marine_corps: "Marine Corps",
+    usmc: "Marine Corps",
+    marines: "Marine Corps",
+    "coast guard": "Coast Guard",
+    coast_guard: "Coast Guard",
+    uscg: "Coast Guard",
+};
+
+const normaliseBranch = (raw: string): Branch => {
+    const key = raw.toLowerCase().trim();
+    return BRANCH_NORMAL[key] ?? "Army";
+};
+
+// Codes with a trailing W or starting W typically denote warrant officers in Army;
+// codes ending with O / starting 0x in air force = officer; numeric Navy designators
+// 1XXX = officer. Below 1000 / starts with letters that match known officer codes = officer.
+const detectRank = (code: string, branch: Branch): Rank => {
+    const c = code.toUpperCase();
+    if (branch === "Army") {
+        // Army warrant officers: numeric MOS in 1XXA range or ending W
+        if (/^\d{3}A$/.test(c)) return "Warrant";
+        // Officer branch codes are 2-letter: 11A, 13A, etc. — also use 2-char + A
+        if (/^\d{2}[A-HJ-Z]$/.test(c) && c.endsWith("A")) return "Officer";
+        return "Enlisted";
+    }
+    if (branch === "Navy") {
+        // Navy officer designators are 4-digit starting with 1, 2, 3, 4, 6
+        if (/^\d{4}$/.test(c) && /^[12346]/.test(c)) return "Officer";
+        // Navy warrant: 7xxx designators
+        if (/^7\d{3}$/.test(c)) return "Warrant";
+        return "Enlisted";
+    }
+    if (branch === "Air Force") {
+        // USAF officer AFSCs end in a letter and are 4 chars: 11FX, 14NX
+        if (/^\d{2}[A-Z]\d?[A-Z]?$/.test(c) && c.length >= 4 && /[A-Z]$/.test(c)) {
+            // Officer AFSCs usually start 11–63; enlisted 1–9. Heuristic.
+            const stem = parseInt(c.slice(0, 2), 10);
+            if (!Number.isNaN(stem) && stem >= 10) return "Officer";
+        }
+        return "Enlisted";
+    }
+    if (branch === "Marine Corps") {
+        // USMC officer MOS are 4 digits starting 0–3 in low ranges
+        if (/^\d{4}$/.test(c) && c.startsWith("0") && c[1] === "2") return "Officer";
+        return "Enlisted";
+    }
+    // Coast Guard
+    return "Enlisted";
+};
+
+// Map a free-text family/role string into our restricted Family taxonomy.
+const FAMILY_KEYWORDS: Array<[Family, RegExp]> = [
+    ["Cyber", /cyber|security|infosec|signal warfare|cryptolog|sigint|electronic warfare/i],
+    ["IT / Comms", /network|comm(unication)?|signal|it specialist|radio|satellite|telecom/i],
+    ["Aviation", /pilot|aviation|aircraft|aircrew|aerospace|flight|drone|uav/i],
+    ["Intelligence", /intel|intelligence|analyst|hum(int|n)|counter[- ]?intel/i],
+    ["Logistics", /logist|supply|transport|distribution|warehouse|materiel/i],
+    ["Medical", /medic|health|dental|nurse|corpsman|hospital|pharma/i],
+    ["Engineering", /engineer|construction|combat engineer|seabee|civil/i],
+    ["Operations", /operations|infantry|combat|special force|recon|gunner/i],
+    ["Maintenance", /mechanic|maintenance|repair|technician|electrician|machinist/i],
+    ["Administration", /admin|personnel|human resources|finance|legal|chaplain|public affairs/i],
+];
+
+const detectFamily = (title: string): Family => {
+    for (const [family, pattern] of FAMILY_KEYWORDS) {
+        if (pattern.test(title)) return family;
+    }
+    return "Other";
+};
+
+const mapDemand = (raw?: string): Demand => {
+    if (!raw) return "Steady";
+    const r = raw.toLowerCase();
+    if (r.includes("very high")) return "Very High";
+    if (r.includes("high") || r.includes("growing")) return "High";
+    return "Steady";
+};
+
+const stripBranchPrefix = (key: string): string => {
+    const idx = key.indexOf(":");
+    return idx === -1 ? key : key.slice(idx + 1);
+};
+
+export const loadCareerGuides = (): GuideEntry[] => {
+    const root = process.cwd();
+    const training = JSON.parse(
+        fs.readFileSync(path.join(root, "src/data/training-pipeline.json"), "utf-8")
+    ) as Record<string, TrainingEntry>;
+    const pathways = JSON.parse(
+        fs.readFileSync(path.join(root, "src/data/career-pathways-map.json"), "utf-8")
+    ) as Record<string, PathwayEntry[]>;
+
+    const guides: GuideEntry[] = [];
+
+    for (const [key, entry] of Object.entries(training)) {
+        const code = stripBranchPrefix(key).toUpperCase();
+        const branch = normaliseBranch(entry.branch);
+        const rank = detectRank(code, branch);
+        const family = detectFamily(entry.title);
+        const certs = entry.civilian_certs ?? [];
+
+        // Pathway lookup: try raw code first, then full key
+        const matches = pathways[code] ?? pathways[stripBranchPrefix(key)] ?? [];
+        const top = matches[0];
+        const civilian = top?.role ?? entry.title;
+        const salaries = matches.map((m) => m.avgSalary).filter((s) => typeof s === "number");
+        const salaryLow = salaries.length ? Math.min(...salaries) : 45000;
+        const salaryHigh = salaries.length ? Math.max(...salaries) : salaryLow + 30000;
+        const demand = mapDemand(top?.demand);
+
+        guides.push({
+            code,
+            title: entry.title,
+            branch,
+            rank,
+            family,
+            civilian,
+            salaryLow: Math.round(salaryLow / 1000),
+            salaryHigh: Math.round(salaryHigh / 1000),
+            certs,
+            demand,
+            featured: certs.length >= 3 && demand !== "Steady",
+        });
+    }
+
+    return guides.sort((a, b) => a.code.localeCompare(b.code));
+};
+
+export const computeBranchCounts = (guides: GuideEntry[]) => {
+    const counts: Record<Branch, number> = {
+        Army: 0,
+        Navy: 0,
+        "Air Force": 0,
+        "Marine Corps": 0,
+        "Coast Guard": 0,
+    };
+    for (const g of guides) counts[g.branch] += 1;
+    return counts;
+};
+
+export const FAMILIES: Family[] = [
+    "Cyber",
+    "IT / Comms",
+    "Aviation",
+    "Intelligence",
+    "Logistics",
+    "Medical",
+    "Engineering",
+    "Operations",
+    "Maintenance",
+    "Administration",
+    "Other",
+];

--- a/src/pages/career-guides/index.tsx
+++ b/src/pages/career-guides/index.tsx
@@ -1,207 +1,60 @@
-import Breadcrumb from "@components/breadcrumb";
 import SEO from "@components/seo/page-seo";
+import CareerGuidesContainer from "@containers/career-guides";
+import type { Branch, GuideEntry } from "@containers/career-guides/types";
 import Layout01 from "@layout/layout-01";
+import { FAMILIES, computeBranchCounts, loadCareerGuides } from "@lib/career-guides";
 import type { GetStaticProps, NextPage } from "next";
-import Link from "next/link";
-import fs from "fs";
-import path from "path";
-import { useMemo, useState } from "react";
-
-interface GuideEntry {
-    code: string;
-    title: string;
-    branch: string;
-}
 
 type TProps = {
     guides: GuideEntry[];
-    branches: string[];
+    branchCounts: Record<Branch, number>;
+    familiesCount: number;
+    certsCount: number;
 };
 
 type PageWithLayout = NextPage<TProps> & {
     Layout?: typeof Layout01;
 };
 
-const BRANCH_ORDER = ["Army", "Navy", "Air Force", "Marine Corps", "Coast Guard"];
-
-const CareerGuidesPage: PageWithLayout = ({ guides, branches }) => {
-    const [searchQuery, setSearchQuery] = useState("");
-    const [selectedBranch, setSelectedBranch] = useState("");
-
-    const filteredGuides = useMemo(() => {
-        let filtered = guides;
-        if (selectedBranch) {
-            filtered = filtered.filter((g) => g.branch === selectedBranch);
-        }
-        if (searchQuery) {
-            const q = searchQuery.toLowerCase();
-            filtered = filtered.filter(
-                (g) =>
-                    g.code.toLowerCase().includes(q) ||
-                    g.title.toLowerCase().includes(q)
-            );
-        }
-        return filtered;
-    }, [guides, searchQuery, selectedBranch]);
-
-    const sortedBranches = useMemo(
-        () => branches.sort((a, b) => BRANCH_ORDER.indexOf(a) - BRANCH_ORDER.indexOf(b)),
-        [branches]
-    );
-
-    return (
-        <>
-            <SEO
-                title="Military Career Guides by Job Code"
-                description="Browse career guides for every military job code. Find civilian career pathways, certification equivalencies, training data, and salary information for your MOS, rating, or AFSC."
-            />
-            <Breadcrumb
-                pages={[{ path: "/", label: "home" }]}
-                currentPage="Career Guides"
-                showTitle={false}
-            />
-
-            <div className="tw-container tw-py-16">
-                <div className="tw-mx-auto tw-max-w-5xl">
-                    <div className="tw-mb-10">
-                        <h1 className="tw-text-3xl md:tw-text-4xl tw-font-bold tw-text-[#091f40] tw-mb-2">
-                            Military Career Guides
-                        </h1>
-                        <p className="tw-text-lg tw-text-gray-600">
-                            Browse {guides.length.toLocaleString()} career guides across all branches. Each guide includes civilian career pathways, certification equivalencies, training data, and salary information.
-                        </p>
-                    </div>
-
-                    {/* Search and Filter */}
-                    <div className="tw-flex tw-flex-col sm:tw-flex-row tw-gap-3 tw-mb-8">
-                        <div className="tw-flex-1">
-                            <input
-                                type="text"
-                                placeholder="Search by job code or title..."
-                                value={searchQuery}
-                                onChange={(e) => setSearchQuery(e.target.value)}
-                                className="tw-w-full tw-px-4 tw-py-3 tw-border tw-border-gray-300 tw-rounded-lg tw-text-sm focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-[#091f40] focus:tw-border-transparent"
-                                aria-label="Search job codes"
-                            />
-                        </div>
-                        <div className="tw-flex tw-flex-wrap tw-gap-2">
-                            <button
-                                type="button"
-                                onClick={() => setSelectedBranch("")}
-                                className={`tw-px-4 tw-py-2 tw-rounded-lg tw-text-sm tw-font-medium tw-transition-colors ${
-                                    selectedBranch === ""
-                                        ? "tw-bg-[#091f40] tw-text-white"
-                                        : "tw-bg-gray-100 tw-text-gray-700 hover:tw-bg-gray-200"
-                                }`}
-                            >
-                                All
-                            </button>
-                            {sortedBranches.map((branch) => (
-                                <button
-                                    key={branch}
-                                    type="button"
-                                    onClick={() => setSelectedBranch(branch)}
-                                    className={`tw-px-4 tw-py-2 tw-rounded-lg tw-text-sm tw-font-medium tw-transition-colors ${
-                                        selectedBranch === branch
-                                            ? "tw-bg-[#091f40] tw-text-white"
-                                            : "tw-bg-gray-100 tw-text-gray-700 hover:tw-bg-gray-200"
-                                    }`}
-                                >
-                                    {branch}
-                                </button>
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Results count */}
-                    <p className="tw-text-sm tw-text-gray-500 tw-mb-4">
-                        Showing {filteredGuides.length.toLocaleString()} of {guides.length.toLocaleString()} guides
-                    </p>
-
-                    {/* Guide list */}
-                    {filteredGuides.length === 0 ? (
-                        <div className="tw-text-center tw-py-12">
-                            <p className="tw-text-gray-500 tw-text-lg">No guides found matching your search.</p>
-                            <button
-                                type="button"
-                                onClick={() => { setSearchQuery(""); setSelectedBranch(""); }}
-                                className="tw-mt-4 tw-text-[#091f40] tw-underline tw-text-sm"
-                            >
-                                Clear filters
-                            </button>
-                        </div>
-                    ) : (
-                        <div className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-3">
-                            {filteredGuides.map((guide) => (
-                                <Link
-                                    key={guide.code}
-                                    href={`/career-guides/${guide.code.toLowerCase()}`}
-                                    className="tw-block tw-border tw-border-gray-200 tw-rounded-lg tw-p-4 hover:tw-border-[#091f40] hover:tw-shadow-sm tw-transition-all"
-                                >
-                                    <div className="tw-flex tw-items-start tw-justify-between">
-                                        <div>
-                                            <span className="tw-font-bold tw-text-[#091f40] tw-text-sm">
-                                                {guide.code}
-                                            </span>
-                                            <p className="tw-text-sm tw-text-gray-700 tw-mt-0.5">
-                                                {guide.title}
-                                            </p>
-                                        </div>
-                                        <span className="tw-text-xs tw-bg-gray-100 tw-text-gray-500 tw-px-2 tw-py-0.5 tw-rounded tw-whitespace-nowrap tw-ml-2">
-                                            {guide.branch}
-                                        </span>
-                                    </div>
-                                </Link>
-                            ))}
-                        </div>
-                    )}
-                    {/* Resume Translator CTA */}
-                    <div className="tw-mt-12 tw-bg-gradient-to-r tw-from-[#091f40] tw-to-[#1a3a6b] tw-rounded-lg tw-p-8 tw-text-white">
-                        <h2 className="tw-text-2xl tw-font-bold tw-mb-2 tw-text-white">
-                            Translate Your Resume
-                        </h2>
-                        <p className="tw-text-white tw-mb-4">
-                            Use our AI-powered translator to convert your military experience into ATS-optimized civilian resume language.
-                        </p>
-                        <Link
-                            href="/resume-translator"
-                            className="tw-inline-block tw-bg-[#c5a44e] tw-text-[#091f40] tw-font-bold tw-px-6 tw-py-3 tw-rounded-lg hover:tw-bg-[#d4b55e] tw-transition-colors"
-                        >
-                            Start Free Translation
-                        </Link>
-                    </div>
-                </div>
-            </div>
-        </>
-    );
-};
+const CareerGuidesPage: PageWithLayout = ({
+    guides,
+    branchCounts,
+    familiesCount,
+    certsCount,
+}) => (
+    <>
+        <SEO
+            title="Career Guides — Military Job Code Translator"
+            description="From job code to civilian career. Search 4,201 military career guides across all five branches with civilian salary bands, certifications, and demand signals sourced from Lightcast labor data."
+        />
+        <CareerGuidesContainer
+            guides={guides}
+            branchCounts={branchCounts}
+            familiesCount={familiesCount}
+            certsCount={certsCount}
+        />
+    </>
+);
 
 CareerGuidesPage.Layout = Layout01;
 
-export const getStaticProps: GetStaticProps = async () => {
-    const trainingMap = JSON.parse(
-        fs.readFileSync(path.join(process.cwd(), "src/data/training-pipeline.json"), "utf-8")
-    ) as Record<string, { branch: string; title: string }>;
-
-    const guides: GuideEntry[] = Object.entries(trainingMap)
-        .map(([code, data]) => ({
-            code,
-            title: data.title,
-            branch: data.branch,
-        }))
-        .sort((a, b) => a.code.localeCompare(b.code));
-
-    const branches = [...new Set(guides.map((g) => g.branch))];
+export const getStaticProps: GetStaticProps = () => {
+    const guides = loadCareerGuides();
+    const branchCounts = computeBranchCounts(guides);
+    const certsCount = guides.reduce((sum, g) => sum + g.certs.length, 0);
 
     return {
         props: {
             layout: {
-                headerShadow: true,
+                headerShadow: false,
                 headerFluid: false,
-                footerMode: "light",
+                footerMode: "dark",
+                bodyClass: "tw-bg-secondary",
             },
             guides,
-            branches,
+            branchCounts,
+            familiesCount: FAMILIES.length,
+            certsCount,
         },
     };
 };


### PR DESCRIPTION
## Summary

- Replaces the flat list of 4,201 military job codes at `/career-guides` with an editorial database matching the design level of `/programs/core-curriculum`.
- New container at `src/containers/career-guides/` composed of: status bar (with LIVE pulse), editorial hero + 5-column stat strip, 4-pathway category showcase, search with ⌘K + autocomplete, branch chips + rank + family + sort filters, paginated grid view (60 per page), and Cohort 2027 CTA band.
- New data adapter `src/lib/career-guides.ts` merges `training-pipeline.json` + `career-pathways-map.json` at build time into the `GuideEntry` shape (code, title, branch, rank, family, civilian translation, salary band, certs, demand).
- Implements the `design_handoff_career_guides` prototype adapted to our brand system: VWC navy/red/gold tokens (not the prototype's gold), GothamPro + Gilroy fonts (not Geist), 0 border radius (not 2px), reused `Layout01` Header/Footer (drops the prototype's own nav/footer), and the signature 16×2px red eyebrow bar on every section title.

## Design decisions

- Shipped the single configuration the handoff itself recommends for production: `view: grid`, `hero: editorial`, distinct branch colors. Dropped the tweaks panel, table view, and list view.
- Pagination ("Load 60 more →") instead of virtualization — simpler, matches the existing `use-load-more` pattern.
- Heuristic family/rank detection via regex in `src/lib/career-guides.ts` — a curated mapping JSON would be more accurate as a follow-up.

## Known follow-ups

- `getStaticProps` payload is ~1.16 MB (Next warns at 128 kB) because all 4,201 guides ship to enable instant client-side filter/search. Options if needed: drop unused fields per row, paginate at build time, or move filtering server-side.
- Family/rank regex detection will mis-bucket some rows — replace with a curated map when one exists.
- `[mos].tsx` detail page is unchanged; cards link to it as-is.

## Test plan

- [ ] Visit `/career-guides`, verify all sections render (status bar, hero, categories, database, CTA)
- [ ] Search input: type "cyber", "11B", "intel" — confirm filter + autocomplete behavior
- [ ] Press ⌘K (or Ctrl-K) anywhere on the page → search focuses; Esc → blurs
- [ ] Autocomplete: type a partial code, use ↑↓ to navigate, Enter to pick
- [ ] Click a category card → family filter applies + smooth-scrolls to database
- [ ] Click each branch chip → list filters, count updates, gold active state
- [ ] Rank segmented control, Family dropdown, Sort dropdown — combine with AND logic
- [ ] "Load more" reveals next 60; resets to 60 when any filter changes
- [ ] Empty state ("No matches.") appears for impossible filter combinations
- [ ] Hover a card → gold border + bg lift + gold arrow
- [ ] Card click → routes to `/career-guides/<code>`