### PR TITLE
feat(career-guides): Redesign singular guide as hashflag detail view

### DIFF
--- a/src/containers/career-guide-detail/anchor-nav.tsx
+++ b/src/containers/career-guide-detail/anchor-nav.tsx
@@ -1,0 +1,82 @@
+import clsx from "clsx";
+import { useCallback, useEffect, useState } from "react";
+
+interface AnchorItem {
+    id: string;
+    label: string;
+}
+
+interface Props {
+    items: AnchorItem[];
+}
+
+const SCROLL_OFFSET = 80;
+
+const AnchorNav = ({ items }: Props) => {
+    const [active, setActive] = useState(items[0]?.id ?? "");
+
+    useEffect(() => {
+        const onScroll = () => {
+            const threshold = window.scrollY + window.innerHeight * 0.35;
+            let current = items[0]?.id ?? "";
+            for (const item of items) {
+                const el = document.getElementById(item.id);
+                if (el && el.offsetTop <= threshold) current = item.id;
+            }
+            setActive(current);
+        };
+        onScroll();
+        window.addEventListener("scroll", onScroll, { passive: true });
+        return () => window.removeEventListener("scroll", onScroll);
+    }, [items]);
+
+    const jump = useCallback((id: string) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const top = el.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET;
+        window.scrollTo({ top, behavior: "smooth" });
+    }, []);
+
+    return (
+        <nav
+            aria-label="Section navigation"
+            className="tw-fixed tw-right-6 tw-top-1/2 tw-z-20 tw--translate-y-1/2 tw-hidden xl:tw-block"
+        >
+            <ul className="tw-flex tw-flex-col tw-gap-3">
+                {items.map((item) => {
+                    const isActive = item.id === active;
+                    return (
+                        <li key={item.id}>
+                            <button
+                                type="button"
+                                onClick={() => jump(item.id)}
+                                className="tw-group tw-flex tw-items-center tw-gap-3"
+                            >
+                                <span
+                                    className={clsx(
+                                        "tw-h-[1px] tw-transition-all tw-duration-200",
+                                        isActive
+                                            ? "tw-w-8 tw-bg-accent"
+                                            : "tw-w-[18px] tw-bg-cream/30 group-hover:tw-w-8 group-hover:tw-bg-accent",
+                                    )}
+                                />
+                                <span
+                                    className={clsx(
+                                        "tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-transition-opacity",
+                                        isActive
+                                            ? "tw-text-cream tw-opacity-100"
+                                            : "tw-text-[#8590a6] tw-opacity-0 group-hover:tw-opacity-100",
+                                    )}
+                                >
+                                    {item.label}
+                                </span>
+                            </button>
+                        </li>
+                    );
+                })}
+            </ul>
+        </nav>
+    );
+};
+
+export default AnchorNav;

--- a/src/containers/career-guide-detail/branch-meta.ts
+++ b/src/containers/career-guide-detail/branch-meta.ts
@@ -1,0 +1,20 @@
+import type { Branch } from "./types";
+
+export const BRANCH_META: Record<Branch, { short: string; color: string }> = {
+    Army: { short: "ARMY", color: "#6b8050" },
+    Navy: { short: "NAVY", color: "#5b87c4" },
+    "Air Force": { short: "USAF", color: "#8eb4d8" },
+    "Marine Corps": { short: "USMC", color: "#d9514a" },
+    "Coast Guard": { short: "USCG", color: "#e89149" },
+};
+
+export const normaliseBranch = (raw: string): Branch => {
+    const k = raw.toLowerCase().trim();
+    if (k === "air force" || k === "air_force" || k === "usaf") return "Air Force";
+    if (k === "marine corps" || k === "marine_corps" || k === "usmc" || k === "marines") {
+        return "Marine Corps";
+    }
+    if (k === "coast guard" || k === "coast_guard" || k === "uscg") return "Coast Guard";
+    if (k === "navy") return "Navy";
+    return "Army";
+};

--- a/src/containers/career-guide-detail/cert-bar.tsx
+++ b/src/containers/career-guide-detail/cert-bar.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+    fill: number; // 0..100
+}
+
+const CertBar = ({ fill }: Props) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [width, setWidth] = useState(0);
+
+    useEffect(() => {
+        if (typeof IntersectionObserver === "undefined") {
+            setWidth(fill);
+            return;
+        }
+        const node = ref.current;
+        if (!node) return;
+        const obs = new IntersectionObserver(
+            (entries) => {
+                for (const e of entries) {
+                    if (e.isIntersecting) {
+                        setWidth(fill);
+                        obs.disconnect();
+                        break;
+                    }
+                }
+            },
+            { threshold: 0.3 },
+        );
+        obs.observe(node);
+        return () => obs.disconnect();
+    }, [fill]);
+
+    return (
+        <div ref={ref} className="tw-relative tw-h-[3px] tw-w-full tw-bg-cream/10">
+            <div
+                className="tw-absolute tw-left-0 tw-top-0 tw-h-full tw-bg-accent tw-transition-[width] tw-duration-[600ms] tw-ease-out"
+                style={{ width: `${width}%` }}
+            />
+        </div>
+    );
+};
+
+export default CertBar;

--- a/src/containers/career-guide-detail/cta-band.tsx
+++ b/src/containers/career-guide-detail/cta-band.tsx
@@ -1,0 +1,63 @@
+import Link from "next/link";
+
+interface Props {
+    code: string;
+}
+
+const CtaBand = ({ code }: Props) => (
+    <section className="tw-relative tw-overflow-hidden tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-24">
+        {/* Grid backdrop */}
+        <div
+            aria-hidden
+            className="tw-pointer-events-none tw-absolute tw-inset-0"
+            style={{
+                backgroundImage:
+                    "linear-gradient(to right, rgba(246,244,239,0.10) 1px, transparent 1px), linear-gradient(to bottom, rgba(246,244,239,0.10) 1px, transparent 1px)",
+                backgroundSize: "80px 80px",
+                maskImage: "radial-gradient(circle at 30% 50%, black, transparent 75%)",
+                WebkitMaskImage: "radial-gradient(circle at 30% 50%, black, transparent 75%)",
+            }}
+        />
+
+        <div className="tw-relative tw-container tw-flex tw-flex-col tw-gap-7">
+            <div className="tw-flex tw-items-center tw-gap-3">
+                <span className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-primary" />
+                <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                    / Translator · Live
+                </span>
+            </div>
+
+            <h2 className="tw-font-heading tw-font-semibold tw-uppercase tw-text-cream [letter-spacing:-0.02em] [line-height:1] [font-size:clamp(32px,4.5vw,56px)]">
+                Translate <span className="tw-text-primary">{code}</span> into a resume that ships.
+            </h2>
+
+            <p className="tw-max-w-[680px] tw-font-body tw-text-[17px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                Pair this guide with the VWC AI-powered translator: drop in your service record,
+                get back ATS-optimized civilian resume language tuned to the tech roles above.
+            </p>
+
+            <div className="tw-flex tw-flex-wrap tw-gap-4">
+                <Link
+                    href="/resume-translator"
+                    className="tw-inline-flex tw-items-center tw-gap-2 tw-bg-accent tw-px-7 tw-py-4 tw-font-mono tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.1em] tw-text-secondary tw-transition-colors hover:tw-bg-gold-bright active:tw-scale-[0.97]"
+                >
+                    Translate {code} →
+                </Link>
+                <Link
+                    href="/apply"
+                    className="tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-accent tw-px-7 tw-py-4 tw-font-mono tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.1em] tw-text-accent tw-transition-colors hover:tw-bg-accent hover:tw-text-secondary active:tw-scale-[0.97]"
+                >
+                    Apply for Cohort 2027
+                </Link>
+                <Link
+                    href="/career-guides"
+                    className="tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-cream/[0.18] tw-px-7 tw-py-4 tw-font-mono tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.1em] tw-text-cream tw-transition-colors hover:tw-border-cream hover:tw-bg-cream/5 active:tw-scale-[0.97]"
+                >
+                    Browse all guides
+                </Link>
+            </div>
+        </div>
+    </section>
+);
+
+export default CtaBand;

--- a/src/containers/career-guide-detail/derive.ts
+++ b/src/containers/career-guide-detail/derive.ts
@@ -1,0 +1,141 @@
+import type {
+    CareerGuideDetail,
+    CertData,
+    CognitiveProfile,
+    GuideStats,
+    GuideSummary,
+    PathwayEntry,
+    SystemsData,
+    TechPathway,
+    TrainingData,
+} from "./types";
+import { normaliseBranch } from "./branch-meta";
+
+const SALARY_BAND = (pathways: PathwayEntry[]): string => {
+    if (pathways.length === 0) return "$45K–$120K";
+    const salaries = pathways.map((p) => p.avgSalary).filter((s) => typeof s === "number");
+    if (salaries.length === 0) return "$45K–$120K";
+    const lo = Math.min(...salaries);
+    const hi = Math.max(...salaries);
+    return `$${Math.round(lo / 1000)}K–$${Math.round(hi / 1000)}K`;
+};
+
+const DEMAND_LABEL = (pathways: PathwayEntry[]): string => {
+    if (pathways.length === 0) return "Steady";
+    const counts: Record<string, number> = {};
+    for (const p of pathways) counts[p.demand] = (counts[p.demand] ?? 0) + 1;
+    const top = Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "Steady";
+    if (/very high/i.test(top)) return "Very High";
+    if (/high|growing/i.test(top)) return "High · Stable";
+    return "Steady";
+};
+
+const TECH_MATCH_SCORE = (techPathway: TechPathway | null): string => {
+    if (!techPathway || techPathway.roles.length === 0) return "—";
+    const w = { high: 1, good: 0.7, moderate: 0.45 } as const;
+    const total = techPathway.roles.reduce((s, r) => s + w[r.matchLevel], 0);
+    const avg = total / techPathway.roles.length;
+    return `${(avg * 10).toFixed(1)} / 10`;
+};
+
+const CERT_COVERAGE = (certs: CertData): string => {
+    const direct = certs.direct_qualifies.length;
+    const partial = certs.partial_coverage.length;
+    const next = certs.recommended_next.length;
+    const total = direct + partial + next;
+    if (total === 0) return "0";
+    return `${direct + partial}/${total}`;
+};
+
+// Map "Operations · Security" style — short, hand-tuned per branch when possible
+const FAMILY_FROM = (training: TrainingData): string => {
+    const t = training.title.toLowerCase();
+    if (/cyber|crypto|sigint|signal warfare/.test(t)) return "Cyber · Security";
+    if (/security forces|military police|infantry|combat/.test(t)) return "Operations · Security";
+    if (/network|comm|signal|telecom/.test(t)) return "IT · Comms";
+    if (/intel|analyst/.test(t)) return "Intelligence";
+    if (/pilot|aviation|aircrew/.test(t)) return "Aviation";
+    if (/medic|corpsman|nurse|health/.test(t)) return "Medical";
+    if (/logist|supply|transport/.test(t)) return "Logistics";
+    if (/mechanic|maintenance|repair/.test(t)) return "Maintenance";
+    if (/engineer|construction|seabee/.test(t)) return "Engineering";
+    if (/admin|personnel|finance|legal|chaplain/.test(t)) return "Administration";
+    return "Operations";
+};
+
+const RANK_FROM = (code: string, branch: ReturnType<typeof normaliseBranch>): "Enlisted" | "Warrant" | "Officer" => {
+    const c = code.toUpperCase();
+    if (branch === "Army") {
+        if (/^\d{3}A$/.test(c)) return "Warrant";
+        if (/^\d{2}[A-HJ-Z]$/.test(c) && c.endsWith("A")) return "Officer";
+        return "Enlisted";
+    }
+    if (branch === "Navy") {
+        if (/^\d{4}$/.test(c) && /^[12346]/.test(c)) return "Officer";
+        if (/^7\d{3}$/.test(c)) return "Warrant";
+        return "Enlisted";
+    }
+    if (branch === "Air Force") {
+        if (/^\d{2}[A-Z]\d?[A-Z]?$/.test(c) && c.length >= 4 && /[A-Z]$/.test(c)) {
+            const stem = parseInt(c.slice(0, 2), 10);
+            if (!Number.isNaN(stem) && stem >= 10) return "Officer";
+        }
+        return "Enlisted";
+    }
+    if (branch === "Marine Corps") {
+        if (/^\d{4}$/.test(c) && c.startsWith("02")) return "Officer";
+        return "Enlisted";
+    }
+    return "Enlisted";
+};
+
+export const buildSummary = (
+    pathways: PathwayEntry[],
+    techPathway: TechPathway | null,
+    code: string,
+): GuideSummary => ({
+    topMatch: pathways[0]?.role ?? techPathway?.roles[0]?.title ?? "—",
+    salaryBand: SALARY_BAND(pathways),
+    demand: DEMAND_LABEL(pathways),
+    techMatchScore: TECH_MATCH_SCORE(techPathway),
+    docId: `VWC.CG.${code.toUpperCase()}.R.04`,
+});
+
+export const buildStats = (
+    training: TrainingData,
+    certs: CertData,
+    pathways: PathwayEntry[],
+    techPathway: TechPathway | null,
+): GuideStats => ({
+    trainingHours: training.hours,
+    aceCredit: training.ace_credits ?? "—",
+    techRolesMapped: techPathway?.roles.length ?? 0,
+    civilianPathways: pathways.length,
+    certCoverage: CERT_COVERAGE(certs),
+});
+
+export const buildDetail = (input: {
+    code: string;
+    training: TrainingData;
+    certs: CertData;
+    systems: SystemsData;
+    pathways: PathwayEntry[];
+    cognitiveProfile: CognitiveProfile | null;
+    techPathway: TechPathway | null;
+}): CareerGuideDetail => {
+    const branch = normaliseBranch(input.training.branch);
+    return {
+        code: input.code.toUpperCase(),
+        branch,
+        rank: RANK_FROM(input.code, branch),
+        family: FAMILY_FROM(input.training),
+        training: input.training,
+        certs: input.certs,
+        systems: input.systems,
+        pathways: input.pathways,
+        cognitiveProfile: input.cognitiveProfile,
+        techPathway: input.techPathway,
+        summary: buildSummary(input.pathways, input.techPathway, input.code),
+        stats: buildStats(input.training, input.certs, input.pathways, input.techPathway),
+    };
+};

--- a/src/containers/career-guide-detail/hero.tsx
+++ b/src/containers/career-guide-detail/hero.tsx
@@ -1,0 +1,181 @@
+import { BRANCH_META } from "./branch-meta";
+import type { CareerGuideDetail } from "./types";
+
+interface Props {
+    detail: CareerGuideDetail;
+}
+
+const StatCell = ({
+    label,
+    value,
+    sub,
+    accent,
+}: {
+    label: string;
+    value: string;
+    sub: string;
+    accent?: boolean;
+}) => (
+    <div className="tw-flex tw-flex-col tw-gap-3 tw-px-6 tw-py-7 md:tw-border-l md:tw-border-cream/10 first:md:tw-border-l-0">
+        <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+            {label}
+        </span>
+        <span
+            className={`tw-font-heading tw-text-[30px] tw-font-semibold tw-leading-none [letter-spacing:-0.02em] ${
+                accent ? "tw-text-accent" : "tw-text-cream"
+            }`}
+        >
+            {value}
+        </span>
+        <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.08em] tw-text-[#8590a6]">
+            {sub}
+        </span>
+    </div>
+);
+
+const SummaryRow = ({
+    label,
+    value,
+    big = false,
+    mono = false,
+}: {
+    label: string;
+    value: string;
+    big?: boolean;
+    mono?: boolean;
+}) => (
+    <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-4 tw-border-b tw-border-dashed tw-border-cream/10 tw-py-3 last:tw-border-b-0">
+        <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+            {label}
+        </span>
+        <span
+            className={
+                big
+                    ? "tw-font-heading tw-text-[22px] tw-font-semibold tw-text-cream [letter-spacing:-0.02em]"
+                    : mono
+                      ? "tw-font-mono tw-text-[13px] tw-text-cream"
+                      : "tw-font-body tw-text-[15px] tw-text-cream"
+            }
+        >
+            {value}
+        </span>
+    </div>
+);
+
+const Hero = ({ detail }: Props) => {
+    const meta = BRANCH_META[detail.branch];
+    const titleWords = detail.training.title.trim().split(/\s+/);
+    const lastWord = titleWords.pop() ?? detail.training.title;
+    const leadWords = titleWords.join(" ");
+
+    return (
+        <section id="sec-overview" className="tw-bg-secondary tw-pt-16 md:tw-pt-20">
+            <div className="tw-container">
+                {/* Breadcrumb */}
+                <div className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                    <span>Home</span>
+                    <span className="tw-mx-2 tw-text-[#5a6478]">/</span>
+                    <span>Career Guides</span>
+                    <span className="tw-mx-2 tw-text-[#5a6478]">/</span>
+                    <span className="tw-text-cream">{detail.code}</span>
+                </div>
+
+                {/* Eyebrow row */}
+                <div className="tw-mt-10 tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+                    <span className="tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-accent tw-px-3 tw-py-1.5 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.12em] tw-text-cream">
+                        <span
+                            aria-hidden
+                            className="tw-h-2 tw-w-2"
+                            style={{ backgroundColor: meta.color }}
+                        />
+                        {meta.short} · {detail.code}
+                    </span>
+                    <span className="tw-flex tw-items-center tw-gap-3">
+                        <span className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-primary" />
+                        <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                            Career Guide · {detail.family} · {detail.summary.docId}
+                        </span>
+                    </span>
+                </div>
+
+                {/* Two-col grid */}
+                <div className="tw-mt-12 tw-grid tw-grid-cols-1 tw-gap-14 lg:tw-grid-cols-[1.5fr_1fr]">
+                    {/* Left — display title + lede */}
+                    <div className="tw-flex tw-flex-col tw-gap-6">
+                        <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#5a6478]">
+                            {detail.code} · {meta.short} · {detail.rank}
+                        </span>
+                        <h1 className="tw-font-heading tw-font-semibold tw-uppercase tw-text-cream [letter-spacing:-0.025em] [line-height:0.98] [font-size:clamp(48px,8.5vw,116px)]">
+                            {leadWords && <>{leadWords}<br /></>}
+                            <span className="tw-text-accent">{lastWord}.</span>
+                        </h1>
+                        <p className="tw-max-w-[640px] tw-font-body tw-text-[#c4cad6] [font-size:clamp(17px,1.4vw,20px)] tw-leading-[1.55]">
+                            <span className="tw-font-semibold tw-text-cream">
+                                {detail.training.branch} {detail.code} ({detail.training.title}).
+                            </span>{" "}
+                            {detail.training.hours.toLocaleString()} hours of formal training
+                            translate to{" "}
+                            <span className="tw-font-semibold tw-text-cream">
+                                {detail.pathways.length} validated civilian career pathways
+                            </span>{" "}
+                            with salary bands of {detail.summary.salaryBand}. Sourced from DoD
+                            training data and Lightcast labor signals.
+                        </p>
+                    </div>
+
+                    {/* Right — summary card */}
+                    <aside className="tw-border tw-border-cream/[0.18] tw-bg-[#0c2549]">
+                        <header className="tw-flex tw-items-center tw-justify-between tw-border-b tw-border-cream/10 tw-px-5 tw-py-4">
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                                Summary · Lightcast
+                            </span>
+                            <span className="tw-relative tw-flex tw-h-[7px] tw-w-[7px]">
+                                <span className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-animate-ping tw-rounded-full tw-bg-accent tw-opacity-75" />
+                                <span className="tw-relative tw-inline-flex tw-h-[7px] tw-w-[7px] tw-rounded-full tw-bg-accent tw-shadow-[0_0_8px_#FDB330]" />
+                            </span>
+                        </header>
+                        <div className="tw-flex tw-flex-col tw-px-5">
+                            <SummaryRow label="Top civilian match" value={detail.summary.topMatch} />
+                            <SummaryRow label="Civilian salary band" value={detail.summary.salaryBand} big />
+                            <SummaryRow label="Market demand" value={detail.summary.demand} />
+                            <SummaryRow label="Tech match score" value={detail.summary.techMatchScore} />
+                            <SummaryRow label="Doc ID" value={detail.summary.docId} mono />
+                        </div>
+                    </aside>
+                </div>
+
+                {/* Stat strip */}
+                <div className="tw-mt-14 tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 md:tw-grid-cols-5 tw-border-t tw-border-b tw-border-cream/10">
+                    <StatCell
+                        label="Training hours"
+                        value={detail.stats.trainingHours.toLocaleString()}
+                        sub="DoD pipeline"
+                    />
+                    <StatCell
+                        label="ACE credit"
+                        value={detail.stats.aceCredit !== "—" ? "ACE" : "—"}
+                        sub={detail.stats.aceCredit !== "—" ? detail.stats.aceCredit : "no recommendation"}
+                    />
+                    <StatCell
+                        label="Tech roles"
+                        value={String(detail.stats.techRolesMapped)}
+                        sub="mapped to your code"
+                        accent
+                    />
+                    <StatCell
+                        label="Civilian pathways"
+                        value={String(detail.stats.civilianPathways)}
+                        sub="validated"
+                    />
+                    <StatCell
+                        label="Cert coverage"
+                        value={detail.stats.certCoverage}
+                        sub="direct + partial"
+                    />
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Hero;

--- a/src/containers/career-guide-detail/index.tsx
+++ b/src/containers/career-guide-detail/index.tsx
@@ -1,0 +1,57 @@
+import AnchorNav from "./anchor-nav";
+import CtaBand from "./cta-band";
+import Hero from "./hero";
+import NonObviousMatches from "./non-obvious-matches";
+import PathwaysGrid from "./pathways-grid";
+import SkillBridgeSection from "./skill-bridge";
+import StatusBar from "./status-bar";
+import StrengthsGrid from "./strengths-grid";
+import SystemsTable from "./systems-table";
+import TechRolesSection from "./tech-roles";
+import TrainingSection from "./training-section";
+import type { CareerGuideDetail } from "./types";
+
+interface Props {
+    detail: CareerGuideDetail;
+}
+
+const ANCHORS = [
+    { id: "sec-overview", label: "Overview" },
+    { id: "sec-roles", label: "Tech roles" },
+    { id: "sec-skills", label: "Skills" },
+    { id: "sec-pathways", label: "Pathways" },
+    { id: "sec-strengths", label: "Strengths" },
+    { id: "sec-matches", label: "Matches" },
+    { id: "sec-training", label: "Training" },
+    { id: "sec-systems", label: "Systems" },
+];
+
+const CareerGuideDetailContainer = ({ detail }: Props) => (
+    <>
+        <StatusBar code={detail.code} />
+        <AnchorNav items={ANCHORS} />
+        <Hero detail={detail} />
+        {detail.techPathway && (
+            <TechRolesSection code={detail.code} roles={detail.techPathway.roles} />
+        )}
+        {detail.techPathway && (
+            <SkillBridgeSection
+                code={detail.code}
+                skillsYouHave={detail.techPathway.skillsYouHave}
+                skillsToLearn={detail.techPathway.skillsToLearn}
+            />
+        )}
+        <PathwaysGrid pathways={detail.pathways} />
+        {detail.cognitiveProfile && (
+            <StrengthsGrid code={detail.code} skills={detail.cognitiveProfile.cognitiveSkills} />
+        )}
+        {detail.cognitiveProfile && (
+            <NonObviousMatches matches={detail.cognitiveProfile.nonObviousCareers} />
+        )}
+        <TrainingSection training={detail.training} certs={detail.certs} />
+        <SystemsTable systems={detail.systems} />
+        <CtaBand code={detail.code} />
+    </>
+);
+
+export default CareerGuideDetailContainer;

--- a/src/containers/career-guide-detail/non-obvious-matches.tsx
+++ b/src/containers/career-guide-detail/non-obvious-matches.tsx
@@ -1,0 +1,52 @@
+import { SectionHeader } from "./section-helpers";
+import type { NonObviousCareer } from "./types";
+
+interface Props {
+    matches: NonObviousCareer[];
+}
+
+const NonObviousMatches = ({ matches }: Props) => {
+    if (matches.length === 0) return null;
+
+    return (
+        <section
+            id="sec-matches"
+            className="tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-20 md:tw-py-24"
+        >
+            <div className="tw-container tw-flex tw-flex-col tw-gap-10">
+                <SectionHeader
+                    number="/ 05"
+                    eyebrow="Non-Obvious Matches"
+                    title="Roles the recruiter won't suggest."
+                    lede="Adjacent civilian roles your training maps to that conventional military-to-civilian advice tends to miss."
+                />
+
+                <div className="tw-grid tw-grid-cols-1 tw-gap-0 md:tw-grid-cols-2 tw-border-t tw-border-l tw-border-cream/10">
+                    {matches.map((m) => (
+                        <article
+                            key={m.role}
+                            className="tw-flex tw-flex-col tw-gap-4 tw-border-b tw-border-r tw-border-cream/10 tw-p-8"
+                        >
+                            <header className="tw-flex tw-items-baseline tw-justify-between tw-gap-4 tw-border-b tw-border-dashed tw-border-cream/10 tw-pb-4">
+                                <h3 className="tw-font-heading tw-text-[22px] tw-font-medium tw-uppercase tw-leading-[1.2] tw-text-cream [letter-spacing:-0.01em]">
+                                    {m.role}
+                                </h3>
+                                <span className="tw-shrink-0 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                                    SOC {m.socCode}
+                                </span>
+                            </header>
+                            <p className="tw-font-body tw-text-[14.5px] tw-leading-[1.6] tw-text-[#c4cad6]">
+                                {m.whyItFits}
+                            </p>
+                            <span className="tw-mt-auto tw-inline-flex tw-self-start tw-border tw-border-accent tw-px-3 tw-py-1.5 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-accent">
+                                Adjacent · Match
+                            </span>
+                        </article>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default NonObviousMatches;

--- a/src/containers/career-guide-detail/pathways-grid.tsx
+++ b/src/containers/career-guide-detail/pathways-grid.tsx
@@ -1,0 +1,87 @@
+import { DemandBars, SectionHeader, demandLevel } from "./section-helpers";
+import type { PathwayEntry } from "./types";
+
+interface Props {
+    pathways: PathwayEntry[];
+}
+
+const matchClass = (m: string) => {
+    const l = m.toLowerCase();
+    if (l.includes("high")) return "#7ad395";
+    if (l.includes("good")) return "#5b87c4";
+    return "#c4cad6";
+};
+
+const formatSalary = (n: number) => `$${Math.round(n / 1000)}K`;
+
+const PathwaysGrid = ({ pathways }: Props) => {
+    if (pathways.length === 0) return null;
+
+    return (
+        <section
+            id="sec-pathways"
+            className="tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-20 md:tw-py-24"
+        >
+            <div className="tw-container tw-flex tw-flex-col tw-gap-10">
+                <SectionHeader
+                    number="/ 03"
+                    eyebrow="Civilian Pathways"
+                    title="Where your code lands."
+                    meta={`SOURCE · LIGHTCAST + CURATED\nPATHWAYS · ${pathways.length}`}
+                />
+
+                <div className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-5 tw-border-t tw-border-l tw-border-cream/10">
+                    {pathways.map((p, idx) => (
+                        <article
+                            key={p.role}
+                            className="tw-flex tw-flex-col tw-gap-4 tw-border-b tw-border-r tw-border-cream/10 tw-p-6 tw-min-h-[290px]"
+                        >
+                            <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                P.{String(idx + 1).padStart(2, "0")}
+                            </span>
+                            <h3 className="tw-font-heading tw-text-[21px] tw-font-medium tw-uppercase tw-leading-[1.2] tw-text-cream [letter-spacing:-0.01em]">
+                                {p.role}
+                            </h3>
+                            <span className="tw-font-mono tw-text-[18px] tw-text-cream">
+                                {formatSalary(p.avgSalary)}
+                            </span>
+                            <div className="tw-flex tw-flex-col tw-gap-2 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                <span className="tw-flex tw-items-center tw-gap-2 tw-text-[#c4cad6]">
+                                    <span
+                                        aria-hidden
+                                        className="tw-h-2 tw-w-2"
+                                        style={{ backgroundColor: matchClass(p.matchLevel) }}
+                                    />
+                                    {p.matchLevel}
+                                </span>
+                                <span className="tw-flex tw-items-center tw-gap-2 tw-text-[#c4cad6]">
+                                    <DemandBars level={demandLevel(p.demand)} />
+                                    {p.demand}
+                                </span>
+                            </div>
+                            {p.skillsToClose && p.skillsToClose.length > 0 && (
+                                <div className="tw-mt-auto tw-flex tw-flex-col tw-gap-2 tw-border-t tw-border-dashed tw-border-cream/10 tw-pt-3">
+                                    <span className="tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                                        Skills to develop
+                                    </span>
+                                    <ul className="tw-flex tw-flex-col tw-gap-1">
+                                        {p.skillsToClose.slice(0, 3).map((s) => (
+                                            <li
+                                                key={s}
+                                                className="tw-font-body tw-text-[11.5px] tw-leading-[1.4] tw-text-[#c4cad6]"
+                                            >
+                                                — {s}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+                        </article>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default PathwaysGrid;

--- a/src/containers/career-guide-detail/section-helpers.tsx
+++ b/src/containers/career-guide-detail/section-helpers.tsx
@@ -1,0 +1,64 @@
+import clsx from "clsx";
+
+export const SectionHeader = ({
+    number,
+    eyebrow,
+    title,
+    lede,
+    meta,
+}: {
+    number: string;
+    eyebrow: string;
+    title: string;
+    lede?: string;
+    meta?: string;
+}) => (
+    <header className="tw-flex tw-flex-col tw-gap-5">
+        <div className="tw-flex tw-items-start tw-justify-between tw-gap-6">
+            <div className="tw-flex tw-flex-col tw-gap-3">
+                <div className="tw-flex tw-items-center tw-gap-3">
+                    <span className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-primary" />
+                    <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        {number} · {eyebrow}
+                    </span>
+                </div>
+                <h2 className="tw-font-heading tw-font-semibold tw-uppercase tw-text-cream [letter-spacing:-0.02em] [line-height:1] [font-size:clamp(32px,4.5vw,56px)]">
+                    {title}
+                </h2>
+            </div>
+            {meta && (
+                <span className="tw-shrink-0 tw-pt-2 tw-text-right tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                    {meta}
+                </span>
+            )}
+        </div>
+        {lede && (
+            <p className="tw-max-w-[760px] tw-font-body tw-text-[16px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                {lede}
+            </p>
+        )}
+    </header>
+);
+
+export const DemandBars = ({ level }: { level: number }) => (
+    <div className="tw-flex tw-items-end tw-gap-1">
+        {[1, 2, 3, 4].map((b) => (
+            <span
+                key={b}
+                aria-hidden
+                className={clsx(
+                    "tw-h-[11px] tw-w-[3px]",
+                    b <= level ? "tw-bg-accent" : "tw-bg-[#5a6478]",
+                )}
+            />
+        ))}
+    </div>
+);
+
+export const demandLevel = (demand: string): number => {
+    const d = demand.toLowerCase();
+    if (d.includes("very high")) return 4;
+    if (d.includes("high") || d.includes("growing")) return 3;
+    if (d.includes("stable") || d.includes("steady")) return 2;
+    return 1;
+};

--- a/src/containers/career-guide-detail/skill-bridge.tsx
+++ b/src/containers/career-guide-detail/skill-bridge.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+import { SectionHeader } from "./section-helpers";
+
+interface Props {
+    code: string;
+    skillsYouHave: Array<{ from: string; to: string }>;
+    skillsToLearn: Array<{ skill: string; forRole: string }>;
+}
+
+const SkillBridgeSection = ({ code, skillsYouHave, skillsToLearn }: Props) => {
+    if (skillsYouHave.length === 0 && skillsToLearn.length === 0) return null;
+
+    return (
+        <section
+            id="sec-skills"
+            className="tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-20 md:tw-py-24"
+        >
+            <div className="tw-container tw-flex tw-flex-col tw-gap-12">
+                <SectionHeader
+                    number="/ 02"
+                    eyebrow="Skill Bridge"
+                    title="The gap, named."
+                    lede={`What ${code} training already gave you, and the specific gaps to close — not a generic checklist.`}
+                />
+
+                <div className="tw-grid tw-grid-cols-1 lg:tw-grid-cols-2 lg:tw-divide-x lg:tw-divide-cream/10">
+                    {/* Already have */}
+                    <div className="tw-flex tw-flex-col tw-gap-4 lg:tw-pr-10">
+                        <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-border-cream/10 tw-pb-4">
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                                Already have
+                            </span>
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-cream">
+                                {String(skillsYouHave.length).padStart(2, "0")}
+                            </span>
+                        </div>
+                        <ul className="tw-flex tw-flex-col">
+                            {skillsYouHave.map((s, idx) => (
+                                <li
+                                    key={`${s.from}-${idx}`}
+                                    className="tw-grid tw-grid-cols-[40px_1fr] tw-gap-4 tw-border-b tw-border-cream/10 tw-py-4 last:tw-border-b-0"
+                                >
+                                    <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                        {String(idx + 1).padStart(2, "0")}
+                                    </span>
+                                    <div className="tw-flex tw-flex-col tw-gap-1">
+                                        <span className="tw-font-body tw-text-[17px] tw-text-cream">
+                                            {s.from}
+                                        </span>
+                                        <span className="tw-font-body tw-text-[13px] tw-text-[#8590a6]">
+                                            → {s.to}
+                                        </span>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    {/* To learn */}
+                    <div className="tw-flex tw-flex-col tw-gap-6 tw-pt-12 lg:tw-pl-10 lg:tw-pt-0">
+                        <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-border-cream/10 tw-pb-4">
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                                To learn
+                            </span>
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-cream">
+                                {String(skillsToLearn.length).padStart(2, "0")}
+                            </span>
+                        </div>
+                        <p className="tw-font-body tw-text-[15px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                            The concrete gap to bridge — specific to the roles above, not a generic
+                            checklist.
+                        </p>
+                        <div className="tw-flex tw-flex-wrap tw-gap-2">
+                            {skillsToLearn.map((s, idx) => (
+                                <span
+                                    key={`${s.skill}-${idx}`}
+                                    className="tw-group tw-flex tw-items-center tw-gap-1.5 tw-border tw-border-cream/[0.18] tw-px-3 tw-py-1.5 tw-font-mono tw-text-[11.5px] tw-uppercase tw-tracking-[0.06em] tw-text-cream tw-transition-colors hover:tw-border-accent"
+                                >
+                                    <span className="tw-text-accent">+</span>
+                                    {s.skill}
+                                </span>
+                            ))}
+                        </div>
+
+                        {/* How VWC fits */}
+                        <div className="tw-mt-2 tw-border tw-border-cream/[0.18] tw-bg-secondary tw-p-7">
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-accent">
+                                How VWC fits
+                            </span>
+                            <p className="tw-mt-3 tw-font-body tw-text-[15px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                                Vets Who Code is a free, full-time software engineering accelerator
+                                for veterans, active duty, and military spouses. We close the
+                                fundamentals — terminal, web platform, AI tooling, portfolio
+                                projects — so the rest of this list becomes specialization, not
+                                square one.
+                            </p>
+                            <Link
+                                href="/programs/core-curriculum"
+                                className="tw-mt-5 tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-accent tw-px-5 tw-py-3 tw-font-mono tw-text-[11.5px] tw-font-bold tw-uppercase tw-tracking-[0.1em] tw-text-accent tw-transition-colors hover:tw-bg-accent hover:tw-text-secondary active:tw-scale-[0.97]"
+                            >
+                                See VWC Programs →
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default SkillBridgeSection;

--- a/src/containers/career-guide-detail/status-bar.tsx
+++ b/src/containers/career-guide-detail/status-bar.tsx
@@ -1,0 +1,29 @@
+interface Props {
+    code: string;
+}
+
+const StatusBar = ({ code }: Props) => (
+    <div className="tw-w-full tw-border-b tw-border-cream/10 tw-bg-secondary tw-py-2.5">
+        <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-gap-x-6 tw-gap-y-2 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+            <span className="tw-flex tw-items-center tw-gap-2 tw-text-cream">
+                <span className="tw-relative tw-flex tw-h-[7px] tw-w-[7px]">
+                    <span className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-animate-ping tw-rounded-full tw-bg-primary tw-opacity-75" />
+                    <span className="tw-relative tw-inline-flex tw-h-[7px] tw-w-[7px] tw-rounded-full tw-bg-primary tw-shadow-[0_0_10px_#c5203e]" />
+                </span>
+                <span>Live · Guide v1.0</span>
+            </span>
+            <span>
+                <span className="tw-text-cream">{code}</span> · Career Guide
+            </span>
+            <span>
+                Validated · <span className="tw-text-cream">Lightcast Labor Data</span>
+            </span>
+            <span>
+                Updated · <span className="tw-text-cream">Q2 2026</span>
+            </span>
+            <span className="tw-ml-auto tw-text-cream">2026 Cohort Active</span>
+        </div>
+    </div>
+);
+
+export default StatusBar;

--- a/src/containers/career-guide-detail/strengths-grid.tsx
+++ b/src/containers/career-guide-detail/strengths-grid.tsx
@@ -1,0 +1,56 @@
+import { SectionHeader } from "./section-helpers";
+import type { CognitiveSkill } from "./types";
+
+interface Props {
+    code: string;
+    skills: CognitiveSkill[];
+}
+
+const StrengthsGrid = ({ code, skills }: Props) => {
+    if (skills.length === 0) return null;
+
+    return (
+        <section
+            id="sec-strengths"
+            className="tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-20 md:tw-py-24"
+        >
+            <div className="tw-container tw-flex tw-flex-col tw-gap-10">
+                <SectionHeader
+                    number="/ 04"
+                    eyebrow="Hidden Strengths"
+                    title="What the code built."
+                    lede={`Cognitive skills your ${code} training built — and where they transfer in civilian work.`}
+                />
+
+                <div className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-5 tw-border-t tw-border-l tw-border-cream/10">
+                    {skills.map((s, idx) => (
+                        <article
+                            key={s.skill}
+                            className="tw-flex tw-flex-col tw-gap-4 tw-border-b tw-border-r tw-border-cream/10 tw-p-6 tw-min-h-[290px]"
+                        >
+                            <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-accent">
+                                S.{String(idx + 1).padStart(2, "0")}
+                            </span>
+                            <h3 className="tw-font-heading tw-text-[21px] tw-font-medium tw-uppercase tw-leading-[1.2] tw-text-cream [letter-spacing:-0.01em]">
+                                {s.skill}
+                            </h3>
+                            <p className="tw-font-body tw-text-[13px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                                {s.militaryContext}
+                            </p>
+                            <div className="tw-mt-auto tw-flex tw-flex-col tw-gap-2 tw-border-t tw-border-dashed tw-border-cream/10 tw-pt-3">
+                                <span className="tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                                    Transfers to
+                                </span>
+                                <p className="tw-font-body tw-text-[12px] tw-leading-[1.5] tw-text-[#c4cad6]">
+                                    {s.civilianTranslation}
+                                </p>
+                            </div>
+                        </article>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default StrengthsGrid;

--- a/src/containers/career-guide-detail/systems-table.tsx
+++ b/src/containers/career-guide-detail/systems-table.tsx
@@ -1,0 +1,76 @@
+import { SectionHeader } from "./section-helpers";
+import type { SystemsData } from "./types";
+
+interface Props {
+    systems: SystemsData;
+}
+
+const DOMAIN_FOR = (military: string): string => {
+    const m = military.toLowerCase();
+    if (/network|router|switch|firewall|comm/.test(m)) return "Networking";
+    if (/radar|sensor|sonar|signal/.test(m)) return "Signals";
+    if (/database|sql|record/.test(m)) return "Data";
+    if (/weapon|missile|gun|fire control/.test(m)) return "Weapons";
+    if (/aircraft|drone|uav/.test(m)) return "Aviation";
+    if (/medical|treat/.test(m)) return "Medical";
+    if (/vehicle|engine|hull|chassis/.test(m)) return "Platform";
+    return "Operations";
+};
+
+const SystemsTable = ({ systems }: Props) => {
+    if (systems.systems.length === 0) return null;
+
+    return (
+        <section
+            id="sec-systems"
+            className="tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-20 md:tw-py-24"
+        >
+            <div className="tw-container tw-flex tw-flex-col tw-gap-10">
+                <SectionHeader
+                    number="/ 07"
+                    eyebrow="Systems Translation"
+                    title="What you ran, in their words."
+                    lede="Military systems you operated and their civilian equivalents for your resume."
+                />
+
+                <div className="tw-overflow-x-auto tw-border-t tw-border-cream/10">
+                    <table className="tw-w-full">
+                        <thead>
+                            <tr className="tw-bg-secondary">
+                                <th className="tw-w-[35%] tw-px-4 tw-py-4 tw-text-left tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                                    Military System
+                                </th>
+                                <th className="tw-w-[50%] tw-px-4 tw-py-4 tw-text-left tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                                    Civilian Equivalent
+                                </th>
+                                <th className="tw-px-4 tw-py-4 tw-text-right tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                                    Domain
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {systems.systems.map((sys) => (
+                                <tr
+                                    key={sys.military}
+                                    className="tw-border-t tw-border-cream/10 tw-transition-colors hover:tw-bg-[#0c2549]"
+                                >
+                                    <td className="tw-px-4 tw-py-4 tw-font-mono tw-text-[13.5px] tw-text-cream">
+                                        {sys.military}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-4 tw-font-body tw-text-[15px] tw-text-[#c4cad6]">
+                                        {sys.civilian}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-4 tw-text-right tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-accent">
+                                        {DOMAIN_FOR(sys.military)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default SystemsTable;

--- a/src/containers/career-guide-detail/tech-roles.tsx
+++ b/src/containers/career-guide-detail/tech-roles.tsx
@@ -1,0 +1,177 @@
+import clsx from "clsx";
+import { useMemo, useState } from "react";
+import { DemandBars, SectionHeader } from "./section-helpers";
+import type { ResolvedTechRole } from "./types";
+
+interface Props {
+    code: string;
+    roles: ResolvedTechRole[];
+}
+
+const matchSwatch = (level: ResolvedTechRole["matchLevel"]) =>
+    level === "high"
+        ? { color: "#7ad395", label: "High match" }
+        : level === "good"
+          ? { color: "#5b87c4", label: "Good match" }
+          : { color: "#c4cad6", label: "Moderate match" };
+
+const matchDemand = (level: ResolvedTechRole["matchLevel"]) =>
+    level === "high" ? 4 : level === "good" ? 3 : 2;
+
+const TechRolesSection = ({ code, roles }: Props) => {
+    const [filter, setFilter] = useState<string>("all");
+    const [open, setOpen] = useState<Set<string>>(new Set());
+
+    const tracks = useMemo(() => {
+        const set = new Set<string>();
+        for (const r of roles) set.add(r.track);
+        return ["all", ...Array.from(set)];
+    }, [roles]);
+
+    const filtered = filter === "all" ? roles : roles.filter((r) => r.track === filter);
+
+    if (roles.length === 0) return null;
+
+    return (
+        <section id="sec-roles" className="tw-bg-secondary tw-py-20 md:tw-py-24">
+            <div className="tw-container tw-flex tw-flex-col tw-gap-10">
+                <SectionHeader
+                    number="/ 01"
+                    eyebrow="Tech Roles"
+                    title="Roles your code maps to."
+                    lede={`Industry tech roles your ${code} background maps to — picked from BLS-anchored occupations using your training, cognitive skills, and systems experience.`}
+                    meta={`SOURCE · BLS + LIGHTCAST\nROLES · ${roles.length}`}
+                />
+
+                {/* Filter bar */}
+                <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-4 tw-border-t tw-border-b tw-border-cream/10 tw-py-4">
+                    <div className="tw-flex tw-border tw-border-cream/[0.18]">
+                        {tracks.map((t) => {
+                            const active = filter === t;
+                            return (
+                                <button
+                                    key={t}
+                                    type="button"
+                                    onClick={() => setFilter(t)}
+                                    className={clsx(
+                                        "tw-px-3 tw-py-1.5 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-transition-colors",
+                                        active
+                                            ? "tw-bg-accent tw-text-secondary"
+                                            : "tw-bg-secondary tw-text-[#c4cad6] hover:tw-text-cream",
+                                    )}
+                                >
+                                    {t === "all" ? "All" : t}
+                                </button>
+                            );
+                        })}
+                    </div>
+                    <span className="tw-ml-auto tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em] tw-text-[#8590a6]">
+                        Sort · Match descending
+                    </span>
+                </div>
+
+                {/* Role list */}
+                <ul className="tw-flex tw-flex-col tw-border-t tw-border-cream/10">
+                    {filtered.map((role, idx) => {
+                        const isOpen = open.has(role.roleKey);
+                        const swatch = matchSwatch(role.matchLevel);
+                        const idxLabel = `R.${String(idx + 1).padStart(2, "0")}`;
+                        return (
+                            <li
+                                key={role.roleKey}
+                                className={clsx(
+                                    "tw-border-b tw-border-cream/10 tw-transition-colors",
+                                    isOpen && "tw-bg-[#0c2549]",
+                                )}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        setOpen((p) => {
+                                            const n = new Set(p);
+                                            if (n.has(role.roleKey)) n.delete(role.roleKey);
+                                            else n.add(role.roleKey);
+                                            return n;
+                                        })
+                                    }
+                                    aria-expanded={isOpen}
+                                    className="tw-grid tw-w-full tw-grid-cols-[60px_1fr_36px] tw-gap-4 tw-px-2 tw-py-5 tw-text-left tw-transition-colors hover:tw-bg-[#0c2549] md:tw-grid-cols-[60px_1fr_220px_140px_130px_36px]"
+                                >
+                                    <span className="tw-font-mono tw-text-[12px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                        {idxLabel}
+                                    </span>
+                                    <div className="tw-flex tw-flex-col tw-gap-1">
+                                        <span className="tw-font-heading tw-text-[20px] tw-font-medium tw-uppercase tw-leading-[1.15] tw-text-cream [letter-spacing:-0.01em]">
+                                            {role.title}
+                                        </span>
+                                        <span className="tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                            SOC {role.socCode} · {role.track}
+                                        </span>
+                                    </div>
+                                    <span
+                                        className="tw-hidden tw-items-center tw-gap-2 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[#c4cad6] md:tw-flex"
+                                    >
+                                        <span
+                                            aria-hidden
+                                            className="tw-h-2 tw-w-2"
+                                            style={{ backgroundColor: swatch.color }}
+                                        />
+                                        {swatch.label}
+                                    </span>
+                                    <span className="tw-hidden md:tw-flex tw-items-center tw-gap-3">
+                                        <DemandBars level={matchDemand(role.matchLevel)} />
+                                        <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                            Demand
+                                        </span>
+                                    </span>
+                                    <span className="tw-hidden md:tw-block tw-font-mono tw-text-[13px] tw-text-cream tw-text-right">
+                                        See pathways
+                                        <span className="tw-block tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                            typical · civilian
+                                        </span>
+                                    </span>
+                                    <span
+                                        aria-hidden
+                                        className={clsx(
+                                            "tw-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-border tw-transition-colors",
+                                            isOpen
+                                                ? "tw-border-accent tw-text-accent"
+                                                : "tw-border-cream/[0.18] tw-text-cream group-hover:tw-border-accent",
+                                        )}
+                                    >
+                                        {isOpen ? "−" : "+"}
+                                    </span>
+                                </button>
+
+                                {isOpen && (
+                                    <div className="tw-grid tw-grid-cols-1 tw-gap-4 tw-px-2 tw-pb-6 md:tw-grid-cols-[60px_1fr] md:tw-pl-2">
+                                        <span />
+                                        <div className="tw-flex tw-flex-col tw-gap-4">
+                                            <p className="tw-max-w-[720px] tw-font-body tw-text-[15px] tw-leading-[1.55] tw-text-[#c4cad6]">
+                                                {role.whyItFits || role.description}
+                                            </p>
+                                            {role.stack.length > 0 && (
+                                                <div className="tw-flex tw-flex-wrap tw-gap-1.5">
+                                                    {role.stack.map((s) => (
+                                                        <span
+                                                            key={s}
+                                                            className="tw-border tw-border-cream/10 tw-px-2 tw-py-1 tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.08em] tw-text-[#c4cad6]"
+                                                        >
+                                                            {s}
+                                                        </span>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        </section>
+    );
+};
+
+export default TechRolesSection;

--- a/src/containers/career-guide-detail/training-section.tsx
+++ b/src/containers/career-guide-detail/training-section.tsx
@@ -1,0 +1,152 @@
+import CertBar from "./cert-bar";
+import { SectionHeader } from "./section-helpers";
+import type { CertData, TrainingData } from "./types";
+
+interface Props {
+    training: TrainingData;
+    certs: CertData;
+}
+
+const TrainingSection = ({ training, certs }: Props) => (
+    <section
+        id="sec-training"
+        className="tw-border-t tw-border-cream/10 tw-bg-secondary tw-py-20 md:tw-py-24"
+    >
+        <div className="tw-container tw-flex tw-flex-col tw-gap-10">
+            <SectionHeader
+                number="/ 06"
+                eyebrow="Training & Certs"
+                title="What you trained on."
+                meta="SOURCE · DOD + ACE\nVALIDATED"
+            />
+
+            <div className="tw-grid tw-grid-cols-1 lg:tw-grid-cols-[1fr_1.1fr_1.4fr] lg:tw-divide-x lg:tw-divide-cream/10">
+                {/* Academy */}
+                <div className="tw-flex tw-flex-col tw-gap-4 lg:tw-pr-8">
+                    <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        Academy
+                    </span>
+                    <h3 className="tw-font-heading tw-text-[26px] tw-font-medium tw-uppercase tw-leading-[1.15] tw-text-cream [letter-spacing:-0.01em]">
+                        {training.program.split(",")[0]}
+                    </h3>
+                    {training.program.includes(",") && (
+                        <span className="tw-font-mono tw-text-[11.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                            {training.program.split(",").slice(1).join(",").trim()}
+                        </span>
+                    )}
+                    <div className="tw-mt-4 tw-grid tw-grid-cols-3 tw-gap-4 tw-border-t tw-border-dashed tw-border-cream/10 tw-pt-4">
+                        <div className="tw-flex tw-flex-col tw-gap-1">
+                            <span className="tw-font-heading tw-text-[22px] tw-font-semibold tw-text-cream [letter-spacing:-0.02em]">
+                                {training.hours.toLocaleString()}h
+                            </span>
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                Hours
+                            </span>
+                        </div>
+                        {training.weeks && (
+                            <div className="tw-flex tw-flex-col tw-gap-1">
+                                <span className="tw-font-heading tw-text-[22px] tw-font-semibold tw-text-cream [letter-spacing:-0.02em]">
+                                    {training.weeks}wk
+                                </span>
+                                <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                    Weeks
+                                </span>
+                            </div>
+                        )}
+                        {training.ace_credits && (
+                            <div className="tw-flex tw-flex-col tw-gap-1">
+                                <span className="tw-font-heading tw-text-[22px] tw-font-semibold tw-text-accent [letter-spacing:-0.02em]">
+                                    ACE
+                                </span>
+                                <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                    Credit
+                                </span>
+                            </div>
+                        )}
+                    </div>
+                    {training.ace_credits && (
+                        <p className="tw-font-body tw-text-[13px] tw-leading-[1.55] tw-text-[#8590a6]">
+                            {training.ace_credits}
+                        </p>
+                    )}
+                </div>
+
+                {/* Topics */}
+                <div className="tw-flex tw-flex-col tw-gap-4 tw-pt-10 lg:tw-px-8 lg:tw-pt-0">
+                    <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                        Topics · {training.topics.length}
+                    </span>
+                    <ul className="tw-flex tw-flex-col">
+                        {training.topics.map((topic) => (
+                            <li
+                                key={topic}
+                                className="tw-flex tw-items-center tw-gap-3 tw-border-b tw-border-cream/10 tw-py-3 last:tw-border-b-0"
+                            >
+                                <span aria-hidden className="tw-text-accent">
+                                    ▸
+                                </span>
+                                <span className="tw-font-body tw-text-[14.5px] tw-text-cream">
+                                    {topic}
+                                </span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+
+                {/* Certs */}
+                <div className="tw-flex tw-flex-col tw-gap-6 tw-pt-10 lg:tw-pl-8 lg:tw-pt-0">
+                    {certs.partial_coverage.length > 0 && (
+                        <>
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                                Partial coverage · {certs.partial_coverage.length}
+                            </span>
+                            <ul className="tw-flex tw-flex-col tw-gap-5">
+                                {certs.partial_coverage.slice(0, 3).map((c) => (
+                                    <li key={c.cert} className="tw-flex tw-flex-col tw-gap-2">
+                                        <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-4">
+                                            <span className="tw-font-body tw-text-[17px] tw-text-cream">
+                                                {c.cert}
+                                            </span>
+                                            <span className="tw-font-heading tw-text-[20px] tw-font-semibold tw-text-accent [letter-spacing:-0.02em] tw-tabular-nums">
+                                                {c.coverage}%
+                                            </span>
+                                        </div>
+                                        <CertBar fill={c.coverage} />
+                                        <p className="tw-font-body tw-text-[12.5px] tw-leading-[1.5] tw-text-[#8590a6]">
+                                            {c.gaps}
+                                        </p>
+                                    </li>
+                                ))}
+                            </ul>
+                        </>
+                    )}
+
+                    {certs.recommended_next.length > 0 && (
+                        <div className="tw-mt-2 tw-flex tw-flex-col tw-gap-3 tw-border-t tw-border-dashed tw-border-cream/10 tw-pt-4">
+                            <span className="tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.14em] tw-text-[#8590a6]">
+                                Recommended next · {String(certs.recommended_next.length).padStart(2, "0")}
+                            </span>
+                            <ul className="tw-flex tw-flex-col tw-gap-2">
+                                {certs.recommended_next.slice(0, 6).map((c) => (
+                                    <li
+                                        key={c}
+                                        className="tw-flex tw-items-center tw-justify-between tw-gap-3 tw-border-b tw-border-cream/10 tw-py-2 last:tw-border-b-0"
+                                    >
+                                        <span className="tw-font-body tw-text-[14px] tw-text-cream">
+                                            {c}
+                                        </span>
+                                        <span className="tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-[0.1em] tw-text-[#8590a6]">
+                                            Adjacent
+                                        </span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    </section>
+);
+
+export default TrainingSection;

--- a/src/containers/career-guide-detail/types.ts
+++ b/src/containers/career-guide-detail/types.ts
@@ -1,0 +1,106 @@
+export type Branch = "Army" | "Navy" | "Air Force" | "Marine Corps" | "Coast Guard";
+
+export type Rank = "Enlisted" | "Warrant" | "Officer";
+
+export interface TrainingData {
+    branch: string;
+    title: string;
+    program: string;
+    hours: number;
+    weeks?: number;
+    topics: string[];
+    civilian_certs: string[];
+    ace_credits?: string;
+}
+
+export interface CertData {
+    direct_qualifies: string[];
+    partial_coverage: Array<{ cert: string; coverage: number; gaps: string }>;
+    recommended_next: string[];
+}
+
+export interface SystemEntry {
+    military: string;
+    civilian: string;
+}
+
+export interface SystemsData {
+    branch: string;
+    title: string;
+    systems: SystemEntry[];
+}
+
+export interface ResolvedTechRole {
+    roleKey: string;
+    matchLevel: "high" | "good" | "moderate";
+    whyItFits: string;
+    title: string;
+    track: string;
+    socCode: string;
+    description: string;
+    stack: string[];
+}
+
+export interface TechPathway {
+    roles: ResolvedTechRole[];
+    skillsYouHave: Array<{ from: string; to: string }>;
+    skillsToLearn: Array<{ skill: string; forRole: string }>;
+}
+
+export interface PathwayEntry {
+    role: string;
+    matchLevel: string;
+    avgSalary: number;
+    demand: string;
+    skillsToClose?: string[];
+    dataSource?: string;
+    salaryRange?: { p25: number; p75: number };
+}
+
+export interface CognitiveSkill {
+    skill: string;
+    militaryContext: string;
+    civilianTranslation: string;
+}
+
+export interface NonObviousCareer {
+    role: string;
+    socCode: string;
+    whyItFits: string;
+}
+
+export interface CognitiveProfile {
+    cognitiveSkills: CognitiveSkill[];
+    nonObviousCareers: NonObviousCareer[];
+}
+
+export interface GuideSummary {
+    topMatch: string;
+    salaryBand: string;
+    demand: string;
+    techMatchScore: string;
+    docId: string;
+}
+
+export interface GuideStats {
+    trainingHours: number;
+    aceCredit: string;
+    techRolesMapped: number;
+    civilianPathways: number;
+    certCoverage: string;
+}
+
+export interface CareerGuideDetail {
+    code: string;
+    branch: Branch;
+    rank: Rank;
+    family: string;
+    training: TrainingData;
+    certs: CertData;
+    systems: SystemsData;
+    pathways: PathwayEntry[];
+    cognitiveProfile: CognitiveProfile | null;
+    techPathway: TechPathway | null;
+    summary: GuideSummary;
+    stats: GuideStats;
+}

--- a/src/pages/career-guides/[mos].tsx
+++ b/src/pages/career-guides/[mos].tsx
@@ -1,46 +1,25 @@
-import Breadcrumb from "@components/breadcrumb";
 import SEO from "@components/seo/page-seo";
+import CareerGuideDetailContainer from "@containers/career-guide-detail";
+import { buildDetail } from "@containers/career-guide-detail/derive";
+import type {
+    CareerGuideDetail,
+    CertData,
+    CognitiveProfile,
+    PathwayEntry,
+    SystemsData,
+    TechPathway,
+    TrainingData,
+} from "@containers/career-guide-detail/types";
 import Layout01 from "@layout/layout-01";
 import type { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Head from "next/head";
-import Link from "next/link";
 import fs from "fs";
 import path from "path";
-import type { CareerPathway, CognitiveProfile } from "@/lib/military-translator";
 
-/** MOS codes with data across all 4 sources — highest-quality pages */
 const SEO_MOS_CODES = [
     "11B", "25B", "35F", "68W", "31B", "42A", "92Y",
     "88M", "91B", "3P0X1", "HM", "CTN", "0311", "2651",
 ] as const;
-
-interface TrainingData {
-    branch: string;
-    title: string;
-    program: string;
-    hours: number;
-    weeks?: number;
-    topics: string[];
-    civilian_certs: string[];
-    ace_credits?: string;
-}
-
-interface CertData {
-    direct_qualifies: string[];
-    partial_coverage: Array<{ cert: string; coverage: number; gaps: string }>;
-    recommended_next: string[];
-}
-
-interface SystemEntry {
-    military: string;
-    civilian: string;
-}
-
-interface SystemsData {
-    branch: string;
-    title: string;
-    systems: SystemEntry[];
-}
 
 interface TechRoleSeed {
     key: string;
@@ -61,56 +40,17 @@ interface TechPathwayBundle {
     skillsToLearn: Array<{ skill: string; forRole: string }>;
 }
 
-interface ResolvedTechRole {
-    roleKey: string;
-    matchLevel: "high" | "good" | "moderate";
-    whyItFits: string;
-    title: string;
-    track: string;
-    socCode: string;
-    description: string;
-    stack: string[];
-}
-
 interface MosPageProps {
-    mosCode: string;
-    training: TrainingData;
-    certs: CertData;
-    systems: SystemsData;
-    pathways: CareerPathway[];
-    cognitiveProfile: CognitiveProfile | null;
-    techPathway: {
-        roles: ResolvedTechRole[];
-        skillsYouHave: Array<{ from: string; to: string }>;
-        skillsToLearn: Array<{ skill: string; forRole: string }>;
-    } | null;
+    detail: CareerGuideDetail;
 }
 
 type PageWithLayout = NextPage<MosPageProps> & {
     Layout?: typeof Layout01;
 };
 
-function formatSalary(salary: number): string {
-    return `$${(salary / 1000).toFixed(0)}K`;
-}
-
-const DATA_SOURCE_LABELS: Record<string, string> = {
-    lightcast: "Salary data powered by Lightcast",
-    census_acs: "Source: US Census Bureau ACS",
-    curated: "Salary estimates from VWC career data",
-};
-
-const MosPage: PageWithLayout = ({
-    mosCode,
-    training,
-    certs,
-    systems,
-    pathways,
-    cognitiveProfile,
-    techPathway,
-}) => {
-    const pageTitle = `${mosCode} ${training.title} — Military-to-Civilian Career Guide`;
-    const pageDescription = `Free career guide for ${training.branch} ${mosCode} (${training.title}). Discover civilian job matches, salary data, certification pathways, and training equivalencies. Built by veterans, for veterans.`;
+const MosPage: PageWithLayout = ({ detail }) => {
+    const pageTitle = `${detail.code} ${detail.training.title} — Military-to-Civilian Career Guide`;
+    const pageDescription = `Free career guide for ${detail.training.branch} ${detail.code} (${detail.training.title}). Civilian career pathways, salary data, certification pathways, and training equivalencies. Built by veterans, for veterans.`;
 
     return (
         <>
@@ -124,7 +64,7 @@ const MosPage: PageWithLayout = ({
                             "@type": "WebPage",
                             "name": pageTitle,
                             "description": pageDescription,
-                            "url": `https://vetswhocode.io/career-guides/${mosCode.toLowerCase()}`,
+                            "url": `https://vetswhocode.io/career-guides/${detail.code.toLowerCase()}`,
                             "isPartOf": {
                                 "@type": "WebSite",
                                 "name": "Military Career Guides",
@@ -139,423 +79,7 @@ const MosPage: PageWithLayout = ({
                     }}
                 />
             </Head>
-
-            <Breadcrumb
-                pages={[
-                    { path: "/", label: "home" },
-                    { path: "/career-guides", label: "Career Guides" },
-                ]}
-                currentPage={`${mosCode} Career Guide`}
-                showTitle={false}
-            />
-
-            <div className="tw-container tw-py-16">
-                <div className="tw-mx-auto tw-max-w-5xl">
-                    {/* Header */}
-                    <div className="tw-mb-10">
-                        <span className="tw-inline-block tw-bg-[#091f40] tw-text-white tw-text-xs tw-font-semibold tw-px-3 tw-py-1 tw-rounded-full tw-mb-3">
-                            {training.branch}
-                        </span>
-                        <h1 className="tw-text-3xl md:tw-text-4xl tw-font-bold tw-text-[#091f40] tw-mb-2">
-                            {mosCode}: {training.title}
-                        </h1>
-                        <p className="tw-text-lg tw-text-gray-600">
-                            Career transition guide for {training.branch} {training.title} ({mosCode})
-                        </p>
-                    </div>
-
-                    {/* CTA to translator */}
-                    <div className="tw-bg-gradient-to-r tw-from-[#091f40] tw-to-[#1a3a6b] tw-rounded-lg tw-p-6 tw-mb-10 tw-text-white">
-                        <h2 className="tw-text-xl tw-font-bold tw-mb-2 tw-text-white">
-                            Translate Your {mosCode} Experience Now
-                        </h2>
-                        <p className="tw-text-white tw-mb-4">
-                            Get a personalized AI-powered translation of your military experience into civilian resume language.
-                        </p>
-                        <Link
-                            href="/resume-translator"
-                            className="tw-inline-block tw-bg-[#c5a44e] tw-text-[#091f40] tw-font-bold tw-px-6 tw-py-3 tw-rounded-lg hover:tw-bg-[#d4b55e] tw-transition-colors"
-                        >
-                            Start Free Translation
-                        </Link>
-                    </div>
-
-                    {/* Tech Roles You Could Aim For */}
-                    {techPathway && techPathway.roles.length > 0 && (
-                        <section className="tw-mb-10">
-                            <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-2">
-                                <i className="fas fa-microchip tw-mr-2 tw-text-[#c5203e]" />
-                                Tech Roles You Could Aim For
-                            </h2>
-                            <p className="tw-text-gray-600 tw-mb-6">
-                                Real industry tech roles your {mosCode} background maps to — picked from BLS-anchored occupations using your training, cognitive skills, and systems experience.
-                            </p>
-                            <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-4 tw-mb-8">
-                                {techPathway.roles.map((role) => (
-                                    <div key={role.roleKey} className="tw-border tw-border-gray-200 tw-rounded-lg tw-p-5">
-                                        <div className="tw-flex tw-items-start tw-justify-between tw-mb-2 tw-gap-2">
-                                            <div>
-                                                <h3 className="tw-font-semibold tw-text-[#091f40]">{role.title}</h3>
-                                                <p className="tw-text-xs tw-text-gray-500 tw-mt-0.5">{role.track}</p>
-                                            </div>
-                                            <span className="tw-text-xs tw-bg-gray-100 tw-text-gray-500 tw-px-2 tw-py-0.5 tw-rounded tw-font-mono tw-whitespace-nowrap">
-                                                SOC {role.socCode}
-                                            </span>
-                                        </div>
-                                        <span
-                                            className={`tw-inline-block tw-text-xs tw-px-2 tw-py-0.5 tw-rounded tw-mb-3 ${
-                                                role.matchLevel === "high"
-                                                    ? "tw-bg-green-50 tw-text-green-700"
-                                                    : role.matchLevel === "good"
-                                                      ? "tw-bg-blue-50 tw-text-blue-700"
-                                                      : "tw-bg-gray-50 tw-text-gray-600"
-                                            }`}
-                                        >
-                                            {role.matchLevel === "high"
-                                                ? "High match"
-                                                : role.matchLevel === "good"
-                                                  ? "Good match"
-                                                  : "Moderate match"}
-                                        </span>
-                                        <p className="tw-text-sm tw-text-gray-700 tw-mb-3">{role.whyItFits}</p>
-                                        {role.stack.length > 0 && (
-                                            <div>
-                                                <p className="tw-text-xs tw-text-gray-500 tw-mb-1">Typical stack:</p>
-                                                <div className="tw-flex tw-flex-wrap tw-gap-1">
-                                                    {role.stack.map((s) => (
-                                                        <span
-                                                            key={s}
-                                                            className="tw-text-xs tw-bg-gray-100 tw-text-gray-600 tw-px-2 tw-py-0.5 tw-rounded"
-                                                        >
-                                                            {s}
-                                                        </span>
-                                                    ))}
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
-                                ))}
-                            </div>
-
-                            {techPathway.skillsYouHave.length > 0 && (
-                                <div className="tw-mb-8">
-                                    <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-3">
-                                        Skills You Already Have
-                                    </h3>
-                                    <p className="tw-text-sm tw-text-gray-600 tw-mb-4">
-                                        Concrete bridges from {mosCode} experience to tech-industry practice.
-                                    </p>
-                                    <ul className="tw-space-y-2">
-                                        {techPathway.skillsYouHave.map((s, idx) => (
-                                            <li
-                                                key={`${s.from}-${idx}`}
-                                                className="tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-baseline tw-gap-2 tw-bg-gray-50 tw-rounded-lg tw-p-3"
-                                            >
-                                                <span className="tw-text-sm tw-font-medium tw-text-[#091f40] sm:tw-min-w-[40%]">
-                                                    {s.from}
-                                                </span>
-                                                <span className="tw-text-sm tw-text-gray-700">→ {s.to}</span>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </div>
-                            )}
-
-                            {techPathway.skillsToLearn.length > 0 && (
-                                <div className="tw-mb-2">
-                                    <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-3">
-                                        Skills to Learn
-                                    </h3>
-                                    <p className="tw-text-sm tw-text-gray-600 tw-mb-4">
-                                        The concrete gap to bridge — specific to the roles above, not generic.
-                                    </p>
-                                    <div className="tw-flex tw-flex-wrap tw-gap-2">
-                                        {techPathway.skillsToLearn.map((s, idx) => (
-                                            <span
-                                                key={`${s.skill}-${idx}`}
-                                                className="tw-text-sm tw-bg-[#091f40] tw-text-white tw-px-3 tw-py-1 tw-rounded"
-                                            >
-                                                {s.skill}
-                                            </span>
-                                        ))}
-                                    </div>
-                                </div>
-                            )}
-
-                            <div className="tw-mt-8 tw-bg-gradient-to-r tw-from-[#091f40] tw-to-[#1a3a6b] tw-rounded-lg tw-p-6 tw-text-white">
-                                <h3 className="tw-text-lg tw-font-bold tw-mb-2 tw-text-white">How VWC fits</h3>
-                                <p className="tw-text-sm tw-text-white tw-mb-3">
-                                    Vets Who Code accelerates the parts we teach — software engineering fundamentals, web development, AI tooling. For everything else above, the path is doable independently with the resources we link to.
-                                </p>
-                                <Link
-                                    href="/programs"
-                                    className="tw-inline-block tw-bg-[#c5a44e] tw-text-[#091f40] tw-font-bold tw-px-5 tw-py-2 tw-rounded hover:tw-bg-[#d4b55e] tw-transition-colors"
-                                >
-                                    See VWC Programs
-                                </Link>
-                            </div>
-                        </section>
-                    )}
-
-                    {/* Career Pathways */}
-                    {pathways.length > 0 && (
-                        <section className="tw-mb-10">
-                            <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-4">
-                                Civilian Career Pathways
-                            </h2>
-                            <p className="tw-text-gray-600 tw-mb-6">
-                                Top civilian roles for {mosCode} veterans, with average salary and market demand data.
-                            </p>
-                            <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-4">
-                                {pathways.map((pathway) => (
-                                    <div
-                                        key={pathway.role}
-                                        className="tw-border tw-border-gray-200 tw-rounded-lg tw-p-5"
-                                    >
-                                        <div className="tw-flex tw-items-start tw-justify-between tw-mb-2">
-                                            <h3 className="tw-font-semibold tw-text-[#091f40]">
-                                                {pathway.role}
-                                            </h3>
-                                            <div className="tw-text-right">
-                                                <span className="tw-text-lg tw-font-bold tw-text-[#c5a44e]">
-                                                    {formatSalary(pathway.avgSalary)}
-                                                </span>
-                                                {pathway.salaryRange && (
-                                                    <p className="tw-text-xs tw-text-gray-500">
-                                                        {formatSalary(pathway.salaryRange.p25)}&ndash;{formatSalary(pathway.salaryRange.p75)} range
-                                                    </p>
-                                                )}
-                                            </div>
-                                        </div>
-                                        <div className="tw-flex tw-gap-2 tw-mb-3">
-                                            <span className="tw-text-xs tw-bg-blue-50 tw-text-blue-700 tw-px-2 tw-py-0.5 tw-rounded">
-                                                {pathway.matchLevel}
-                                            </span>
-                                            <span className="tw-text-xs tw-bg-green-50 tw-text-green-700 tw-px-2 tw-py-0.5 tw-rounded">
-                                                {pathway.demand}
-                                            </span>
-                                        </div>
-                                        {pathway.skillsToClose && pathway.skillsToClose.length > 0 && (
-                                            <div>
-                                                <p className="tw-text-xs tw-text-gray-500 tw-mb-1">Skills to develop:</p>
-                                                <div className="tw-flex tw-flex-wrap tw-gap-1">
-                                                    {pathway.skillsToClose.map((skill) => (
-                                                        <span
-                                                            key={skill}
-                                                            className="tw-text-xs tw-bg-gray-100 tw-text-gray-600 tw-px-2 tw-py-0.5 tw-rounded"
-                                                        >
-                                                            {skill}
-                                                        </span>
-                                                    ))}
-                                                </div>
-                                            </div>
-                                        )}
-                                    </div>
-                                ))}
-                            </div>
-                            {pathways.length > 0 && (
-                                <p className="tw-text-xs tw-text-gray-400 tw-text-right tw-mt-3">
-                                    {DATA_SOURCE_LABELS[pathways[0]?.dataSource || "curated"]}
-                                </p>
-                            )}
-                        </section>
-                    )}
-
-                    {/* Hidden Strengths / Cognitive Skills */}
-                    {cognitiveProfile && (
-                        <section className="tw-mb-10">
-                            <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-2">
-                                <i className="fas fa-brain tw-mr-2 tw-text-[#c5203e]" />
-                                Hidden Strengths
-                            </h2>
-                            <p className="tw-text-gray-600 tw-mb-6">
-                                Cognitive skills your {mosCode} training built — and where they transfer.
-                            </p>
-
-                            <div className="tw-space-y-3 tw-mb-8">
-                                {cognitiveProfile.cognitiveSkills.map((cs) => (
-                                    <div key={cs.skill} className="tw-bg-gray-50 tw-rounded-lg tw-p-4">
-                                        <h3 className="tw-font-semibold tw-text-[#091f40] tw-mb-1">{cs.skill}</h3>
-                                        <p className="tw-text-sm tw-text-gray-500 tw-italic tw-mb-2">{cs.militaryContext}</p>
-                                        <p className="tw-text-sm tw-text-gray-700">{cs.civilianTranslation}</p>
-                                    </div>
-                                ))}
-                            </div>
-
-                            <h3 className="tw-text-lg tw-font-semibold tw-text-[#091f40] tw-mb-3">
-                                Non-Obvious Career Matches
-                            </h3>
-                            <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-4">
-                                {cognitiveProfile.nonObviousCareers.map((career) => (
-                                    <div key={career.role} className="tw-border tw-border-gray-200 tw-rounded-lg tw-p-5">
-                                        <div className="tw-flex tw-items-center tw-justify-between tw-mb-2">
-                                            <h4 className="tw-font-semibold tw-text-[#091f40]">{career.role}</h4>
-                                            <span className="tw-text-xs tw-bg-gray-100 tw-text-gray-500 tw-px-2 tw-py-0.5 tw-rounded tw-font-mono">
-                                                SOC {career.socCode}
-                                            </span>
-                                        </div>
-                                        <p className="tw-text-sm tw-text-gray-700">{career.whyItFits}</p>
-                                    </div>
-                                ))}
-                            </div>
-                        </section>
-                    )}
-
-                    {/* Training & Education */}
-                    <section className="tw-mb-10">
-                        <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-4">
-                            Training & Education Equivalencies
-                        </h2>
-                        <div className="tw-bg-gray-50 tw-rounded-lg tw-p-6">
-                            <h3 className="tw-font-semibold tw-text-[#091f40] tw-mb-1">
-                                {training.program}
-                            </h3>
-                            <div className="tw-flex tw-flex-wrap tw-gap-4 tw-text-sm tw-text-gray-600 tw-mb-4">
-                                <span>{training.hours.toLocaleString()} training hours</span>
-                                {training.weeks && <span>{training.weeks} weeks</span>}
-                                {training.ace_credits && (
-                                    <span className="tw-text-[#c5a44e] tw-font-medium">
-                                        {training.ace_credits}
-                                    </span>
-                                )}
-                            </div>
-                            <h4 className="tw-font-medium tw-text-[#091f40] tw-mb-2">
-                                Topics Covered
-                            </h4>
-                            <ul className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-1 tw-text-sm tw-text-gray-700">
-                                {training.topics.map((topic) => (
-                                    <li key={topic} className="tw-flex tw-items-start">
-                                        <span className="tw-mr-2 tw-text-[#c5a44e]">&bull;</span>
-                                        {topic}
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                    </section>
-
-                    {/* Certifications */}
-                    <section className="tw-mb-10">
-                        <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-4">
-                            Certification Pathways
-                        </h2>
-                        {certs.direct_qualifies.length > 0 && (
-                            <div className="tw-mb-4">
-                                <h3 className="tw-font-semibold tw-text-green-700 tw-mb-2">
-                                    <i className="fas fa-check-circle tw-mr-1" />
-                                    Ready to Certify
-                                </h3>
-                                <div className="tw-flex tw-flex-wrap tw-gap-2">
-                                    {certs.direct_qualifies.map((cert) => (
-                                        <span
-                                            key={cert}
-                                            className="tw-bg-green-50 tw-text-green-800 tw-px-3 tw-py-1 tw-rounded-full tw-text-sm tw-font-medium"
-                                        >
-                                            {cert}
-                                        </span>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-                        {certs.partial_coverage.length > 0 && (
-                            <div className="tw-mb-4">
-                                <h3 className="tw-font-semibold tw-text-[#091f40] tw-mb-2">
-                                    Partial Coverage
-                                </h3>
-                                <div className="tw-space-y-3">
-                                    {certs.partial_coverage.map((item) => (
-                                        <div key={item.cert} className="tw-bg-gray-50 tw-rounded-lg tw-p-4">
-                                            <div className="tw-flex tw-items-center tw-justify-between tw-mb-1">
-                                                <span className="tw-font-medium tw-text-sm">{item.cert}</span>
-                                                <span className="tw-text-sm tw-font-bold tw-text-[#c5a44e]">
-                                                    {item.coverage}% covered
-                                                </span>
-                                            </div>
-                                            <div className="tw-w-full tw-bg-gray-200 tw-rounded-full tw-h-2 tw-mb-2">
-                                                <div
-                                                    className="tw-bg-[#c5a44e] tw-h-2 tw-rounded-full"
-                                                    style={{ width: `${item.coverage}%` }}
-                                                />
-                                            </div>
-                                            <p className="tw-text-xs tw-text-gray-500">{item.gaps}</p>
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-                        {certs.recommended_next.length > 0 && (
-                            <div>
-                                <h3 className="tw-font-semibold tw-text-[#091f40] tw-mb-2">
-                                    Recommended Next Certifications
-                                </h3>
-                                <div className="tw-flex tw-flex-wrap tw-gap-2">
-                                    {certs.recommended_next.map((cert) => (
-                                        <span
-                                            key={cert}
-                                            className="tw-bg-blue-50 tw-text-blue-800 tw-px-3 tw-py-1 tw-rounded-full tw-text-sm"
-                                        >
-                                            {cert}
-                                        </span>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-                    </section>
-
-                    {/* Technical Systems */}
-                    {systems.systems.length > 0 && (
-                        <section className="tw-mb-10">
-                            <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-4">
-                                Technical Systems Translation
-                            </h2>
-                            <p className="tw-text-gray-600 tw-mb-4">
-                                Military systems you&apos;ve used and their civilian equivalents for your resume.
-                            </p>
-                            <div className="tw-overflow-x-auto">
-                                <table className="tw-w-full tw-text-sm">
-                                    <thead>
-                                        <tr className="tw-bg-gray-50">
-                                            <th className="tw-text-left tw-p-3 tw-font-semibold tw-text-[#091f40]">
-                                                Military System
-                                            </th>
-                                            <th className="tw-text-left tw-p-3 tw-font-semibold tw-text-[#091f40]">
-                                                Civilian Equivalent
-                                            </th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {systems.systems.map((sys) => (
-                                            <tr key={sys.military} className="tw-border-b tw-border-gray-100">
-                                                <td className="tw-p-3 tw-text-gray-700 tw-font-medium">
-                                                    {sys.military}
-                                                </td>
-                                                <td className="tw-p-3 tw-text-gray-600">
-                                                    {sys.civilian}
-                                                </td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </div>
-                        </section>
-                    )}
-
-                    {/* Bottom CTA */}
-                    <div className="tw-bg-gray-50 tw-rounded-lg tw-p-8 tw-text-center">
-                        <h2 className="tw-text-2xl tw-font-bold tw-text-[#091f40] tw-mb-2">
-                            Ready to Translate Your Experience?
-                        </h2>
-                        <p className="tw-text-gray-600 tw-mb-6">
-                            Our AI-powered translator converts your {mosCode} experience into ATS-optimized civilian resume language.
-                        </p>
-                        <Link
-                            href="/resume-translator"
-                            className="tw-inline-block tw-bg-[#091f40] tw-text-white tw-font-bold tw-px-8 tw-py-3 tw-rounded-lg hover:tw-bg-[#0d2a54] tw-transition-colors"
-                        >
-                            Translate My Resume — Free
-                        </Link>
-                    </div>
-                </div>
-            </div>
+            <CareerGuideDetailContainer detail={detail} />
         </>
     );
 };
@@ -563,8 +87,6 @@ const MosPage: PageWithLayout = ({
 MosPage.Layout = Layout01;
 
 export const getStaticPaths: GetStaticPaths = async () => {
-    // Pre-render the highest-quality pages at build time; all other valid
-    // MOS codes are generated on-demand via fallback: "blocking"
     const paths = SEO_MOS_CODES.map((mos) => ({
         params: { mos: mos.toLowerCase() },
     }));
@@ -573,26 +95,24 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
     const mosParam = (params?.mos as string).toUpperCase();
-
     const dataDir = path.join(process.cwd(), "src/data");
+
     const trainingMap = JSON.parse(
-        fs.readFileSync(path.join(dataDir, "training-pipeline.json"), "utf-8")
+        fs.readFileSync(path.join(dataDir, "training-pipeline.json"), "utf-8"),
     ) as Record<string, TrainingData>;
     const certsMap = JSON.parse(
-        fs.readFileSync(path.join(dataDir, "cert-equivalencies.json"), "utf-8")
+        fs.readFileSync(path.join(dataDir, "cert-equivalencies.json"), "utf-8"),
     ) as Record<string, CertData>;
     const systemsMap = JSON.parse(
-        fs.readFileSync(path.join(dataDir, "military-systems-map.json"), "utf-8")
+        fs.readFileSync(path.join(dataDir, "military-systems-map.json"), "utf-8"),
     ) as Record<string, SystemsData>;
     const pathwaysMap = JSON.parse(
-        fs.readFileSync(path.join(dataDir, "career-pathways-map.json"), "utf-8")
-    ) as Record<string, CareerPathway[]>;
+        fs.readFileSync(path.join(dataDir, "career-pathways-map.json"), "utf-8"),
+    ) as Record<string, PathwayEntry[]>;
     const cognitiveMap = JSON.parse(
-        fs.readFileSync(path.join(dataDir, "cognitive-skills-map.json"), "utf-8")
+        fs.readFileSync(path.join(dataDir, "cognitive-skills-map.json"), "utf-8"),
     ) as Record<string, CognitiveProfile>;
 
-    // Tech pathways are optional — file may not exist on a fresh checkout
-    // before the generation script has been run.
     const techPathwaysPath = path.join(dataDir, "tech-pathways-map.json");
     const techTaxonomyPath = path.join(dataDir, "tech-roles-taxonomy.json");
     const techPathwaysMap: Record<string, TechPathwayBundle> = fs.existsSync(techPathwaysPath)
@@ -603,20 +123,16 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         : { roles: [] };
     const taxonomyByKey = new Map(techTaxonomy.roles.map((r) => [r.key, r]));
 
-    // Resolve the canonical MOS key: check SEO list first, then match
-    // against training data keys (handles mixed-case codes like IT_NAVY)
     const mosCode =
         SEO_MOS_CODES.find((c) => c.toUpperCase() === mosParam) ||
         Object.keys(trainingMap).find((k) => k.toUpperCase() === mosParam) ||
         mosParam;
 
     const training = trainingMap[mosCode];
-    if (!training) {
-        return { notFound: true };
-    }
+    if (!training) return { notFound: true };
 
     const techBundle = techPathwaysMap[mosCode];
-    const resolvedTech = techBundle
+    const techPathway: TechPathway | null = techBundle
         ? {
               roles: techBundle.techRoles
                   .map((r) => {
@@ -633,26 +149,39 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
                           stack: seed.stack,
                       };
                   })
-                  .filter((r): r is ResolvedTechRole => r !== null),
+                  .filter((r): r is NonNullable<typeof r> => r !== null),
               skillsYouHave: techBundle.skillsYouHave,
               skillsToLearn: techBundle.skillsToLearn,
           }
         : null;
 
+    const detail = buildDetail({
+        code: mosCode,
+        training,
+        certs: certsMap[mosCode] || {
+            direct_qualifies: [],
+            partial_coverage: [],
+            recommended_next: [],
+        },
+        systems: systemsMap[mosCode] || {
+            branch: training.branch,
+            title: training.title,
+            systems: [],
+        },
+        pathways: pathwaysMap[mosCode] || [],
+        cognitiveProfile: cognitiveMap[mosCode] || null,
+        techPathway,
+    });
+
     return {
         props: {
             layout: {
-                headerShadow: true,
+                headerShadow: false,
                 headerFluid: false,
-                footerMode: "light",
+                footerMode: "dark",
+                bodyClass: "tw-bg-secondary",
             },
-            mosCode,
-            training,
-            certs: certsMap[mosCode] || { direct_qualifies: [], partial_coverage: [], recommended_next: [] },
-            systems: systemsMap[mosCode] || { branch: training.branch, title: training.title, systems: [] },
-            pathways: pathwaysMap[mosCode] || [],
-            cognitiveProfile: cognitiveMap[mosCode] || null,
-            techPathway: resolvedTech,
+            detail,
         },
     };
 };


### PR DESCRIPTION
## Summary

- Replaces the per-MOS detail page at `/career-guides/[mos]` with an editorial layout that matches the visual design of the redesigned index page (see #1125).
- New container at `src/containers/career-guide-detail/` composed of: status bar (LIVE pulse), fixed-right anchor nav with scroll-spy, editorial hero (display H1 + summary card + 5-cell stat strip), and 7 numbered sections — Tech Roles (filter + expand), Skill Bridge (have/learn + VWC fit card), Pathways grid (5-col), Strengths grid (5-col), Non-Obvious Matches (2-col), Training (3-col academy/topics/certs with `IntersectionObserver`-animated progress bars), Systems Table (full-width), and a translator CTA band with grid backdrop.
- New `buildDetail` helper (`src/containers/career-guide-detail/derive.ts`) derives summary fields (top match, salary band, demand, tech-match score, doc ID), stats, family, and rank from the existing `training-pipeline` / `career-pathways` / `cognitive-skills` / `tech-pathways` data — no new data files needed.
- Implements the `design_handoff_singular_career_guide` prototype adapted to our brand system: VWC navy/red/gold tokens (not the prototype's slight variants), GothamPro + Gilroy fonts (not Geist), **0 border radius** (not 2px), reused `Layout01` Header/Footer (drops the prototype's own nav/footer), signature 16×2px red eyebrow bar on every section title.

## Design decisions

- Anchor nav hides below `xl` breakpoint — same constraint the handoff specified at 1180px.
- Cert progress bars use `IntersectionObserver` with `threshold: 0.3` and 600ms ease-out fill, matching the handoff timing.
- Title's last word becomes the gold-accent word (e.g. "Security Forces **Specialist.**"); generalized for any MOS.
- `Family` (e.g., "Operations · Security") and `DOMAIN_FOR` system bucket are regex-derived heuristics — a curated mapping JSON would be more accurate as a follow-up.
- `Tech match score` formula is `(weighted_avg × 10).toFixed(1)` where high=1.0 / good=0.7 / moderate=0.45 — placeholder until a real validated formula exists.
- Page background is set via `layout.bodyClass: \"tw-bg-secondary\"` so the dark navy extends edge-to-edge.

## Known follow-ups

- Family/rank/domain detection regex will misbucket some rows — replace with curated maps.
- Tech match score formula is placeholder.
- This PR is independent of #1125 (the index redesign) and can land in either order.

## Test plan

- [ ] `/career-guides/11b` and `/career-guides/3p0x1` render with 200 status; all 8 anchors resolve to sections
- [ ] Status bar LIVE dot pulses; summary card gold dot pulses
- [ ] Right-rail anchor nav: scroll the page, watch the active dash grow to 32px gold; click a label, page smooth-scrolls
- [ ] Tech roles: click a row → expands with stack chips; click again → collapses; track filter chips reduce the list
- [ ] Skill bridge: \"Already have\" numbered list renders left, \"To learn\" gold-\`+\` chips right with VWC fit card
- [ ] Pathways grid: 5 cards on desktop, each shows \`P.0X\`, salary, match, demand bars, skills-to-develop list
- [ ] Strengths grid: 5 cards on desktop, each with \`S.0X\` (gold), militaryContext, \"Transfers to\" footer
- [ ] Training section: cert progress bars start at 0% and animate to their \`data-fill\` value when scrolled into view
- [ ] Systems table: hover row → bg lifts to \`#0c2549\`; domain column shows gold mono labels
- [ ] CTA band: gold \"Translate {code} →\" + outline \"Apply\" + ghost \"Browse all guides\"; grid backdrop fades with radial mask
- [ ] Below \`xl\`: anchor nav hidden, hero stacks to single column, stat strip + grids collapse to 2 cols, then 1 col below \`sm\`