### PR TITLE
fix(a11y): Resolve WCAG AA contrast failures across UI

### DIFF
--- a/src/assets/css/globals.css
+++ b/src/assets/css/globals.css
@@ -80,7 +80,7 @@
     --bg-dark: var(--navy);
     --fg-light: var(--white);
     --muted: #6c757d;
-    --muted-on-dark: rgba(185, 214, 242, 0.7);
+    --muted-on-dark: #f8f9fa;
     --border-subtle: rgba(185, 214, 242, 0.08);
     --accent: var(--red);
 
@@ -381,7 +381,7 @@ nav[aria-label="Main Menu"] a {
 footer .copyright {
     font-family: var(--font-mono);
     font-size: 10px;
-    color: rgba(185, 214, 242, 0.4);
+    color: #f8f9fa;
 }
 
 /* Global body styling */

--- a/src/components/admin-dashboard-components.tsx
+++ b/src/components/admin-dashboard-components.tsx
@@ -43,7 +43,7 @@ export const OverviewStats = () => {
                 <div key={stat.label} className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-md">
                     <h3 className="tw-text-lg tw-font-semibold tw-text-gray-400">{stat.label}</h3>
                     <p className="tw-mt-2 tw-text-3xl tw-font-bold tw-text-primary">{stat.value}</p>
-                    <p className="tw-mt-2 tw-text-sm tw-text-gold">{stat.change} from last month</p>
+                    <p className="tw-mt-2 tw-text-sm tw-text-navy-deep">{stat.change} from last month</p>
                 </div>
             ))}
         </div>
@@ -251,7 +251,7 @@ export const UserManagement = () => {
                                     <span
                                         className={`tw-inline-flex tw-rounded-full tw-px-2 tw-text-xs tw-font-semibold ${
                                             user.status === "Active"
-                                                ? "tw-bg-gold-light/30 tw-text-gold-deep"
+                                                ? "tw-bg-gold-light/30 tw-text-ink"
                                                 : "tw-bg-cream tw-text-red-dark"
                                         }`}
                                     >

--- a/src/components/forms/apply-form.tsx
+++ b/src/components/forms/apply-form.tsx
@@ -171,7 +171,7 @@ const ApplyForm = () => {
                                             currentStep > index + 1
                                                 ? "tw-bg-primary tw-text-white"
                                                 : currentStep === index + 1
-                                                  ? "tw-bg-secondary tw-text-white tw-ring-4 tw-ring-secondary-200"
+                                                  ? "tw-bg-secondary tw-text-white tw-ring-4 tw-ring-navy-sky"
                                                   : "tw-bg-gray-50 tw-text-gray-500"
                                         }`}
                                     >

--- a/src/components/game/GameArea.tsx
+++ b/src/components/game/GameArea.tsx
@@ -45,7 +45,7 @@ const GameArea: React.FC<GameAreaProps> = ({
             {showFeedback && feedbackMessage && (
                 <p
                     className={`tw-mt-6 tw-text-center tw-text-2xl tw-font-bold ${
-                        isAnswerCorrect ? "tw-text-gold" : "tw-text-primary"
+                        isAnswerCorrect ? "tw-text-navy-deep" : "tw-text-primary"
                     }`}
                 >
                     {feedbackMessage}

--- a/src/components/jobs/JobMatch.tsx
+++ b/src/components/jobs/JobMatch.tsx
@@ -100,8 +100,8 @@ export default function JobMatch() {
 
 function JobMatchCard({ job }: { job: MatchedJob }) {
     const fitColor = (pct: number) => {
-        if (pct >= 80) return "tw-bg-gold-light tw-text-gold-deep";
-        if (pct >= 60) return "tw-bg-gold-light tw-text-gold-rich";
+        if (pct >= 80) return "tw-bg-gold-light tw-text-ink";
+        if (pct >= 60) return "tw-bg-gold-light tw-text-ink";
         return "tw-bg-cream tw-text-red-dark";
     };
     return (
@@ -136,7 +136,7 @@ function JobMatchCard({ job }: { job: MatchedJob }) {
                         {job.matched_skills.map((s) => (
                             <span
                                 key={`m-${s}`}
-                                className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-text-gold-deep"
+                                className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-text-ink"
                             >
                                 {s}
                             </span>
@@ -154,7 +154,7 @@ function JobMatchCard({ job }: { job: MatchedJob }) {
                         {job.gap_skills.map((s) => (
                             <span
                                 key={`g-${s}`}
-                                className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-text-gold-rich"
+                                className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-text-ink"
                             >
                                 {s}
                             </span>

--- a/src/components/jobs/MockInterview.tsx
+++ b/src/components/jobs/MockInterview.tsx
@@ -131,8 +131,8 @@ export default function MockInterview() {
     };
 
     const scoreColor = (score: number) => {
-        if (score >= 8) return "tw-text-gold-deep";
-        if (score >= 5) return "tw-text-gold-rich";
+        if (score >= 8) return "tw-text-ink";
+        if (score >= 5) return "tw-text-navy-deep";
         return "tw-text-red-dark";
     };
 
@@ -229,12 +229,12 @@ export default function MockInterview() {
                                     {item.feedback}
                                 </p>
                                 {item.what_landed && (
-                                    <p className="tw-text-sm tw-text-gold-deep">
+                                    <p className="tw-text-sm tw-text-navy-deep">
                                         <i className="fas fa-check tw-mr-1" /> {item.what_landed}
                                     </p>
                                 )}
                                 {item.what_to_improve && (
-                                    <p className="tw-text-sm tw-text-gold-rich">
+                                    <p className="tw-text-sm tw-text-red-dark">
                                         <i className="fas fa-arrow-up tw-mr-1" />{" "}
                                         {item.what_to_improve}
                                     </p>
@@ -287,7 +287,7 @@ export default function MockInterview() {
                     <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-sm">
                         <div className="tw-flex tw-items-center tw-gap-4 tw-mb-6">
                             <div
-                                className={`tw-text-5xl tw-font-bold ${avgScore >= 70 ? "tw-text-gold-deep" : avgScore >= 50 ? "tw-text-gold-rich" : "tw-text-red-dark"}`}
+                                className={`tw-text-5xl tw-font-bold ${avgScore >= 70 ? "tw-text-ink" : avgScore >= 50 ? "tw-text-navy-deep" : "tw-text-red-dark"}`}
                             >
                                 {avgScore}
                             </div>

--- a/src/components/jobs/ResumeScorer.tsx
+++ b/src/components/jobs/ResumeScorer.tsx
@@ -292,15 +292,15 @@ export default function ResumeScorer() {
     };
 
     const scoreTextColor = (score: number) => {
-        if (score >= 80) return "tw-text-gold-deep";
-        if (score >= 60) return "tw-text-gold-rich";
-        if (score >= 40) return "tw-text-gold-rich";
+        if (score >= 80) return "tw-text-ink";
+        if (score >= 60) return "tw-text-navy-deep";
+        if (score >= 40) return "tw-text-red-dark";
         return "tw-text-red-dark";
     };
 
     const passFailColor = (pf: string) => {
         return pf === "PASS"
-            ? "tw-bg-gold-light tw-text-gold-deep"
+            ? "tw-bg-gold-light tw-text-ink"
             : "tw-bg-cream tw-text-red-dark";
     };
 
@@ -364,8 +364,8 @@ export default function ResumeScorer() {
                             </div>
                         ) : fileName && resumeText ? (
                             <div>
-                                <i className="fas fa-check-circle tw-text-gold tw-text-xl tw-mb-1" />
-                                <p className="tw-text-sm tw-text-gold-deep tw-font-medium">
+                                <i className="fas fa-check-circle tw-text-navy-deep tw-text-xl tw-mb-1" />
+                                <p className="tw-text-sm tw-text-navy-deep tw-font-medium">
                                     {fileName} loaded
                                 </p>
                                 <button
@@ -631,7 +631,7 @@ export default function ResumeScorer() {
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-sm">
                             <h3 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-3 tw-flex tw-items-center tw-gap-2">
                                 <span className="tw-w-6 tw-h-6 tw-rounded-full tw-bg-gold-light tw-flex tw-items-center tw-justify-center">
-                                    <i className="fas fa-check tw-text-gold-deep tw-text-xs" />
+                                    <i className="fas fa-check tw-text-ink tw-text-xs" />
                                 </span>
                                 Strengths
                             </h3>
@@ -642,7 +642,7 @@ export default function ResumeScorer() {
                                             key={i}
                                             className="tw-flex tw-gap-2 tw-text-sm tw-text-ink/80"
                                         >
-                                            <i className="fas fa-check tw-text-gold tw-mt-0.5 tw-flex-shrink-0" />
+                                            <i className="fas fa-check tw-text-navy-deep tw-mt-0.5 tw-flex-shrink-0" />
                                             {renderText(s)}
                                         </li>
                                     ))}
@@ -654,7 +654,7 @@ export default function ResumeScorer() {
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-sm">
                             <h3 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-3 tw-flex tw-items-center tw-gap-2">
                                 <span className="tw-w-6 tw-h-6 tw-rounded-full tw-bg-gold-light tw-flex tw-items-center tw-justify-center">
-                                    <i className="fas fa-exclamation tw-text-gold-rich tw-text-xs" />
+                                    <i className="fas fa-exclamation tw-text-ink tw-text-xs" />
                                 </span>
                                 Improvements
                             </h3>
@@ -665,7 +665,7 @@ export default function ResumeScorer() {
                                             key={i}
                                             className="tw-flex tw-gap-2 tw-text-sm tw-text-ink/80"
                                         >
-                                            <i className="fas fa-arrow-up tw-text-gold-rich tw-mt-0.5 tw-flex-shrink-0" />
+                                            <i className="fas fa-arrow-up tw-text-red-dark tw-mt-0.5 tw-flex-shrink-0" />
                                             {renderText(s)}
                                         </li>
                                     ))}
@@ -695,7 +695,7 @@ export default function ResumeScorer() {
                                             {r.detected_technologies.map((t, i) => (
                                                 <span
                                                     key={i}
-                                                    className="tw-rounded-full tw-bg-gold-light tw-text-gold-deep tw-px-2.5 tw-py-0.5 tw-text-xs tw-font-medium"
+                                                    className="tw-rounded-full tw-bg-gold-light tw-text-ink tw-px-2.5 tw-py-0.5 tw-text-xs tw-font-medium"
                                                 >
                                                     {renderText(t)}
                                                 </span>
@@ -792,7 +792,7 @@ export default function ResumeScorer() {
                     {r.weak_verbs.length > 0 && (
                         <div className="tw-rounded-lg tw-bg-white tw-p-6 tw-shadow-sm">
                             <h3 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-3">
-                                <i className="fas fa-pen tw-mr-2 tw-text-gold-rich" />
+                                <i className="fas fa-pen tw-mr-2 tw-text-red-dark" />
                                 Weak Verb Detection
                             </h3>
                             <div className="tw-space-y-2">
@@ -807,7 +807,7 @@ export default function ResumeScorer() {
                                         {wv.suggestion && (
                                             <>
                                                 <i className="fas fa-arrow-right tw-text-ink/60" />
-                                                <span className="tw-font-mono tw-text-gold-deep tw-font-medium">
+                                                <span className="tw-font-mono tw-text-ink tw-font-medium">
                                                     {wv.suggestion}
                                                 </span>
                                             </>
@@ -879,7 +879,7 @@ export default function ResumeScorer() {
                                         className={`tw-text-center tw-p-2 tw-rounded ${f.val ? "tw-bg-cream" : "tw-bg-gold-light"}`}
                                     >
                                         <i
-                                            className={`fas ${f.val ? "fa-exclamation-triangle tw-text-red" : "fa-check tw-text-gold"} tw-mb-1`}
+                                            className={`fas ${f.val ? "fa-exclamation-triangle tw-text-red" : "fa-check tw-text-ink"} tw-mb-1`}
                                         />
                                         <p className="tw-text-xs tw-font-medium">{f.label}</p>
                                     </div>
@@ -898,27 +898,27 @@ export default function ResumeScorer() {
                         r.employment_red_flags.job_hopping ||
                         r.employment_red_flags.career_regression) && (
                         <div className="tw-rounded-lg tw-bg-gold-light tw-border tw-border-gold tw-p-6">
-                            <h3 className="tw-font-bold tw-text-gold-deep tw-mb-3">
+                            <h3 className="tw-font-bold tw-text-ink tw-mb-3">
                                 <i className="fas fa-flag tw-mr-2" />
                                 Employment Red Flags
                             </h3>
                             <div className="tw-space-y-2 tw-text-sm">
                                 {r.employment_red_flags.gaps_over_6_months.length > 0 && (
-                                    <p className="tw-text-gold-rich">
+                                    <p className="tw-text-ink">
                                         <i className="fas fa-calendar-times tw-mr-2" />
                                         Gaps over 6 months:{" "}
                                         {r.employment_red_flags.gaps_over_6_months.join(", ")}
                                     </p>
                                 )}
                                 {r.employment_red_flags.job_hopping && (
-                                    <p className="tw-text-gold-rich">
+                                    <p className="tw-text-ink">
                                         <i className="fas fa-running tw-mr-2" />
                                         Job hopping detected.{" "}
                                         {r.employment_red_flags.job_hopping_details}
                                     </p>
                                 )}
                                 {r.employment_red_flags.career_regression && (
-                                    <p className="tw-text-gold-rich">
+                                    <p className="tw-text-ink">
                                         <i className="fas fa-arrow-down tw-mr-2" />
                                         Career regression.{" "}
                                         {r.employment_red_flags.career_regression_details}
@@ -948,14 +948,14 @@ export default function ResumeScorer() {
                             <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 tw-gap-4 tw-mb-4">
                                 {r.jd_match.matched_skills.length > 0 && (
                                     <div>
-                                        <h4 className="tw-text-xs tw-font-bold tw-text-gold-deep tw-uppercase tw-mb-2">
+                                        <h4 className="tw-text-xs tw-font-bold tw-text-navy-deep tw-uppercase tw-mb-2">
                                             Matched Skills
                                         </h4>
                                         <div className="tw-flex tw-flex-wrap tw-gap-1.5">
                                             {r.jd_match.matched_skills.map((s: any, i: number) => (
                                                 <span
                                                     key={i}
-                                                    className="tw-rounded-full tw-bg-gold-light tw-text-gold-deep tw-px-2.5 tw-py-0.5 tw-text-xs tw-font-medium"
+                                                    className="tw-rounded-full tw-bg-gold-light tw-text-ink tw-px-2.5 tw-py-0.5 tw-text-xs tw-font-medium"
                                                 >
                                                     {renderText(s)}
                                                 </span>
@@ -992,7 +992,7 @@ export default function ResumeScorer() {
                                                 key={i}
                                                 className="tw-flex tw-gap-2 tw-text-sm tw-text-ink/80"
                                             >
-                                                <i className="fas fa-lightbulb tw-text-gold-bright tw-mt-0.5" />
+                                                <i className="fas fa-lightbulb tw-text-red tw-mt-0.5" />
                                                 {renderText(rec)}
                                             </li>
                                         ))}
@@ -1026,16 +1026,16 @@ export default function ResumeScorer() {
                                             </p>
                                         </div>
                                         <div className="tw-bg-gold-light tw-px-4 tw-py-3 tw-border-b tw-border-navy/10">
-                                            <span className="tw-text-xs tw-font-bold tw-text-gold-deep tw-uppercase">
+                                            <span className="tw-text-xs tw-font-bold tw-text-ink tw-uppercase">
                                                 After
                                             </span>
-                                            <p className="tw-text-sm tw-text-gold-deep tw-font-medium tw-mt-1">
+                                            <p className="tw-text-sm tw-text-ink tw-font-medium tw-mt-1">
                                                 {rw.suggested_bullet}
                                             </p>
                                         </div>
                                         <div className="tw-px-4 tw-py-3 tw-bg-navy/5">
                                             <p className="tw-text-xs tw-text-ink/60 tw-italic">
-                                                <i className="fas fa-lightbulb tw-text-gold-bright tw-mr-1" />
+                                                <i className="fas fa-lightbulb tw-text-red tw-mr-1" />
                                                 {rw.reason}
                                             </p>
                                         </div>
@@ -1087,7 +1087,7 @@ export default function ResumeScorer() {
                                         key={i}
                                         className="tw-flex tw-gap-2 tw-text-sm tw-text-ink/80"
                                     >
-                                        <i className="fas fa-check tw-text-gold tw-mt-0.5 tw-flex-shrink-0" />
+                                        <i className="fas fa-check tw-text-navy-deep tw-mt-0.5 tw-flex-shrink-0" />
                                         {renderText(c)}
                                     </li>
                                 ))}

--- a/src/components/profile/LearningProgress.tsx
+++ b/src/components/profile/LearningProgress.tsx
@@ -97,7 +97,7 @@ const LearningProgress = ({ data, isLoading, error }: LearningProgressProps) => 
                                     <span
                                         className={`tw-rounded-full tw-px-2.5 tw-py-0.5 tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-wider ${
                                             enrollment.status === "COMPLETED"
-                                                ? "tw-bg-gold/10 tw-text-gold-deep"
+                                                ? "tw-bg-gold/10 tw-text-ink"
                                                 : enrollment.status === "ACTIVE"
                                                   ? "tw-bg-navy/5 tw-text-navy"
                                                   : "tw-bg-gray-50 tw-text-gray-300"
@@ -141,7 +141,7 @@ const LearningProgress = ({ data, isLoading, error }: LearningProgressProps) => 
                                 className="tw-flex tw-items-center tw-gap-4 tw-rounded-lg tw-border tw-border-gold/20 tw-bg-gradient-to-r tw-from-gold/5 tw-to-transparent tw-p-4"
                             >
                                 <div className="tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-gold/10">
-                                    <i className="fas fa-certificate tw-text-gold" />
+                                    <i className="fas fa-certificate tw-text-navy-deep" />
                                 </div>
                                 <div>
                                     <div className="tw-font-mono tw-text-sm tw-font-bold tw-text-navy">
@@ -170,7 +170,7 @@ const LearningProgress = ({ data, isLoading, error }: LearningProgressProps) => 
                                 key={i}
                                 className="tw-flex tw-items-center tw-gap-3 tw-rounded tw-py-2 tw-px-3 hover:tw-bg-navy/3"
                             >
-                                <div className="tw-h-1.5 tw-w-1.5 tw-rounded-full tw-bg-gold tw-flex-shrink-0" />
+                                <div className="tw-h-1.5 tw-w-1.5 tw-rounded-full tw-bg-navy tw-flex-shrink-0" />
                                 <div className="tw-flex-1 tw-min-w-0">
                                     <span className="tw-font-mono tw-text-xs tw-text-ink tw-truncate tw-block">
                                         {activity.lessonTitle}
@@ -198,7 +198,7 @@ const LearningProgress = ({ data, isLoading, error }: LearningProgressProps) => 
 function StatCard({ label, value, icon }: { label: string; value: string; icon: string }) {
     return (
         <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-5 tw-text-center tw-shadow-sm">
-            <i className={`${icon} tw-text-gold/60 tw-mb-1`} />
+            <i className={`${icon} tw-text-navy-deep tw-mb-1`} />
             <div className="tw-font-mono tw-text-2xl tw-font-bold tw-text-navy">{value}</div>
             <div className="tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-widest tw-text-ink/60">
                 {label}

--- a/src/components/profile/TroopDashboard.tsx
+++ b/src/components/profile/TroopDashboard.tsx
@@ -186,7 +186,7 @@ export default function TroopDashboard() {
                         label: "Pass Rate",
                         value: `${passRate}%`,
                         icon: "fa-chart-line",
-                        color: passRate >= 70 ? "tw-text-gold-deep" : "tw-text-gold-rich",
+                        color: passRate >= 70 ? "tw-text-navy-deep" : "tw-text-red-dark",
                     },
                     {
                         label: "Conversations",
@@ -405,7 +405,7 @@ function RepsTray({ warmups, loading }: { warmups: WarmupChallenge[]; loading: b
                                     <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-navy-deep">
                                         {w.topic}
                                     </span>
-                                    <span className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-gold-deep">
+                                    <span className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-ink">
                                         warmup
                                     </span>
                                 </div>

--- a/src/components/social-share/layout-03.tsx
+++ b/src/components/social-share/layout-03.tsx
@@ -32,7 +32,7 @@ const SocialShare = ({ label, className }: TProps) => {
         >
             <p className="tw-mb-0 tw-mr-3.8 tw-hidden tw-font-medium sm:tw-block">{label}</p>
 
-            <i className="fas fa-share-alt tw-h-14 tw-w-14 tw-rounded-full tw-border-2 tw-border-gray-550 tw-text-center tw-text-lg tw-leading-[52px] tw-text-primary tw-transition-colors tw-duration-300 group-hover:tw-border-primary group-hover:tw-bg-primary group-hover:tw-text-white" />
+            <i className="fas fa-share-alt tw-h-14 tw-w-14 tw-rounded-full tw-border-2 tw-border-gray-300 tw-text-center tw-text-lg tw-leading-[52px] tw-text-primary tw-transition-colors tw-duration-300 group-hover:tw-border-primary group-hover:tw-bg-primary group-hover:tw-text-white" />
             <Social color="light" tooltip={true} flyout={true}>
                 <SocialLink
                     label="Facebook"

--- a/src/components/translator/CareerPathwaysCard.tsx
+++ b/src/components/translator/CareerPathwaysCard.tsx
@@ -6,16 +6,16 @@ interface CareerPathwaysCardProps {
 }
 
 const DEMAND_COLORS: Record<string, string> = {
-    "Very high demand": "tw-text-gold-deep tw-bg-gold-light",
-    "High demand": "tw-text-gold-deep tw-bg-gold-light",
+    "Very high demand": "tw-text-ink tw-bg-gold-light",
+    "High demand": "tw-text-ink tw-bg-gold-light",
     "Growing demand": "tw-text-navy-deep tw-bg-navy-sky",
-    "Stable demand": "tw-text-gray-600 tw-bg-gray-100",
+    "Stable demand": "tw-text-gray-400 tw-bg-gray-100",
 };
 
 const MATCH_COLORS: Record<string, string> = {
-    "High match": "tw-text-gold-deep",
+    "High match": "tw-text-red",
     "Good match": "tw-text-navy-deep",
-    "Moderate match": "tw-text-gray-600",
+    "Moderate match": "tw-text-gray-400",
 };
 
 const DATA_SOURCE_LABELS: Record<string, string> = {
@@ -50,7 +50,7 @@ const CareerPathwaysCard: React.FC<CareerPathwaysCardProps> = ({ careerPathways 
                 <i className="fas fa-route tw-mr-2 tw-text-[#c5203e]" />
                 Career Pathways
             </h3>
-            <p className="tw-text-sm tw-text-gray-500">
+            <p className="tw-text-sm tw-text-gray-300">
                 Your military experience maps to these civilian roles.
             </p>
 
@@ -100,7 +100,7 @@ const CareerPathwaysCard: React.FC<CareerPathwaysCardProps> = ({ careerPathways 
 
             {trendingSkills.length > 0 && (
                 <div className="tw-rounded-lg tw-bg-gold-light tw-px-4 tw-py-3">
-                    <p className="tw-text-xs tw-font-semibold tw-text-gold-deep tw-uppercase tw-tracking-wide tw-mb-2">
+                    <p className="tw-text-xs tw-font-semibold tw-text-ink tw-uppercase tw-tracking-wide tw-mb-2">
                         <i className="fas fa-chart-line tw-mr-1" />
                         Skills in Demand
                     </p>
@@ -108,7 +108,7 @@ const CareerPathwaysCard: React.FC<CareerPathwaysCardProps> = ({ careerPathways 
                         {trendingSkills.map((skill) => (
                             <span
                                 key={skill}
-                                className="tw-inline-block tw-rounded-full tw-border tw-border-gold tw-bg-white tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-gold-deep"
+                                className="tw-inline-block tw-rounded-full tw-border tw-border-gold tw-bg-white tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-ink"
                             >
                                 {skill}
                             </span>

--- a/src/components/translator/CertPathwaysCard.tsx
+++ b/src/components/translator/CertPathwaysCard.tsx
@@ -28,7 +28,7 @@ const CertPathwaysCard: React.FC<CertPathwaysCardProps> = ({ certPathways }) => 
 
             {directQualifies.length > 0 && (
                 <div className="tw-space-y-2">
-                    <p className="tw-text-xs tw-font-semibold tw-text-gold-deep tw-uppercase tw-tracking-wide">
+                    <p className="tw-text-xs tw-font-semibold tw-text-ink tw-uppercase tw-tracking-wide">
                         Ready to Certify
                     </p>
                     {directQualifies.map((cert) => (
@@ -36,12 +36,10 @@ const CertPathwaysCard: React.FC<CertPathwaysCardProps> = ({ certPathways }) => 
                             key={cert}
                             className="tw-flex tw-items-center tw-gap-3 tw-rounded-lg tw-bg-gold-light tw-border tw-border-gold tw-px-4 tw-py-3"
                         >
-                            <i className="fas fa-check-circle tw-text-gold-deep" />
+                            <i className="fas fa-check-circle tw-text-ink" />
                             <div>
-                                <p className="tw-text-sm tw-font-medium tw-text-gold-deep">
-                                    {cert}
-                                </p>
-                                <p className="tw-text-xs tw-text-gold-rich">
+                                <p className="tw-text-sm tw-font-medium tw-text-ink">{cert}</p>
+                                <p className="tw-text-xs tw-text-ink/70">
                                     Your training likely qualifies you to sit for this exam now
                                 </p>
                             </div>

--- a/src/components/translator/CognitiveSkillsCard.tsx
+++ b/src/components/translator/CognitiveSkillsCard.tsx
@@ -44,7 +44,7 @@ const CognitiveSkillsCard: React.FC<CognitiveSkillsCardProps> = ({ cognitiveProf
             {nonObviousCareers.length > 0 && (
                 <div>
                     <p className="tw-text-xs tw-font-semibold tw-text-[#091f40] tw-uppercase tw-tracking-wide tw-mb-2">
-                        <i className="fas fa-lightbulb tw-mr-1 tw-text-gold-rich" />
+                        <i className="fas fa-lightbulb tw-mr-1 tw-text-red" />
                         Careers You Might Not Have Considered
                     </p>
                     <div className="tw-space-y-3">
@@ -57,7 +57,7 @@ const CognitiveSkillsCard: React.FC<CognitiveSkillsCardProps> = ({ cognitiveProf
                                     <p className="tw-text-sm tw-font-medium tw-text-[#091f40]">
                                         {career.role}
                                     </p>
-                                    <span className="tw-text-[10px] tw-bg-gray-200 tw-text-gray-500 tw-px-2 tw-py-0.5 tw-rounded tw-font-mono">
+                                    <span className="tw-text-[10px] tw-bg-gray-100 tw-text-ink tw-px-2 tw-py-0.5 tw-rounded tw-font-mono">
                                         SOC {career.socCode}
                                     </span>
                                 </div>

--- a/src/components/translator/TrainingSection.tsx
+++ b/src/components/translator/TrainingSection.tsx
@@ -54,7 +54,7 @@ const TrainingSection: React.FC<TrainingSectionProps> = ({ training, leadershipC
                                     key={cert}
                                     className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-gray-700"
                                 >
-                                    <i className="fas fa-check tw-text-gold tw-text-xs" />
+                                    <i className="fas fa-check tw-text-navy-deep tw-text-xs" />
                                     {cert}
                                 </li>
                             ))}

--- a/src/components/translator/TranslatorForm.tsx
+++ b/src/components/translator/TranslatorForm.tsx
@@ -480,7 +480,7 @@ const TranslatorForm: React.FC<TranslatorFormProps> = ({
 
                 {pdfFileName && !pdfUploading && !pdfError && (
                     <div className="tw-space-y-3">
-                        <div className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-gold-deep">
+                        <div className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-text-navy-deep">
                             <i className="fas fa-check-circle" />
                             Extracted text from {pdfFileName}
                         </div>
@@ -525,7 +525,7 @@ const TranslatorForm: React.FC<TranslatorFormProps> = ({
                         : "List each duty on a new line. Be specific about what you did."}
                 </p>
                 {dutiesAutoFilled && (
-                    <p className="tw-text-xs tw-font-medium tw-text-gold-deep">
+                    <p className="tw-text-xs tw-font-medium tw-text-navy-deep">
                         <i className="fas fa-check-circle tw-mr-1" />
                         Auto-filled from MOS database. Edit as needed.
                     </p>

--- a/src/components/translator/TranslatorResults.tsx
+++ b/src/components/translator/TranslatorResults.tsx
@@ -193,10 +193,8 @@ const TranslatorResults: React.FC<TranslatorResultsProps> = ({
 
             {resultSource === "ai" && (
                 <div className="tw-flex tw-items-center tw-gap-3 tw-rounded-lg tw-border tw-border-gold tw-bg-gold-light tw-px-4 tw-py-3">
-                    <i className="fas fa-check-circle tw-text-gold-deep" />
-                    <p className="tw-text-sm tw-text-gold-deep">
-                        AI-enhanced translation complete.
-                    </p>
+                    <i className="fas fa-check-circle tw-text-ink" />
+                    <p className="tw-text-sm tw-text-ink">AI-enhanced translation complete.</p>
                 </div>
             )}
 
@@ -348,7 +346,7 @@ const TranslatorResults: React.FC<TranslatorResultsProps> = ({
                 >
                     {linkedInCopied ? (
                         <>
-                            <i className="fas fa-check tw-mr-2 tw-text-gold" />
+                            <i className="fas fa-check tw-mr-2 tw-text-navy-deep" />
                             Copied!
                         </>
                     ) : (

--- a/src/components/ui/alert/index.tsx
+++ b/src/components/ui/alert/index.tsx
@@ -12,7 +12,7 @@ const Alert = ({ className, children, color }: TProps) => {
             className={clsx(
                 "alert tw-rounded tw-py-2.5 tw-pl-3 tw-pr-3 nextIcon:tw-mr-2",
                 color === "light" && "tw-bg-gray-50 nextIcon:tw-text-navy-ocean",
-                color === "warning" && "tw-bg-warning-100 tw-text-heading",
+                color === "warning" && "tw-bg-warning-light tw-text-heading",
                 color === "secondary" && "tw-bg-secondary tw-text-white",
                 className
             )}

--- a/src/components/ui/close-button/index.tsx
+++ b/src/components/ui/close-button/index.tsx
@@ -8,10 +8,10 @@ const CloseButton = ({ onClose }: { onClose: () => void }) => {
     const afterClass =
         "after:tw-absolute after:tw-inset-0 after:tw-content-[''] after:tw-bg-dark after:tw-origin-left after:tw-scale-x-0 after:tw-transition-transform after:tw-duration-600 after:tw-ease-in-expo";
     const beforeHoverClass =
-        "group-hover:before:tw-bg-dark-50 group-hover:before:tw-scale-x-0 group-hover:before:tw-transition-transform group-hover:before:tw-duration-600 group-hover:before:tw-ease-in-expo group-hover:before:tw-delay-0";
+        "group-hover:before:tw-bg-dark/50 group-hover:before:tw-scale-x-0 group-hover:before:tw-transition-transform group-hover:before:tw-duration-600 group-hover:before:tw-ease-in-expo group-hover:before:tw-delay-0";
 
     const afterHoverClass =
-        "group-hover:after:tw-bg-dark-50 group-hover:after:tw-scale-x-[1px] group-hover:after:tw-transition-transform group-hover:after:tw-duration-600 group-hover:after:tw-ease-in-expo group-hover:after:tw-delay-200";
+        "group-hover:after:tw-bg-dark/50 group-hover:after:tw-scale-x-[1px] group-hover:after:tw-transition-transform group-hover:after:tw-duration-600 group-hover:after:tw-ease-in-expo group-hover:after:tw-delay-200";
 
     return (
         <button

--- a/src/components/ui/hero-code-snippet/index.tsx
+++ b/src/components/ui/hero-code-snippet/index.tsx
@@ -16,14 +16,14 @@ const codeBody = {
     lineHeight: "1.75",
 };
 
-const COMMENT = "rgba(185, 214, 242, 0.55)";
+const COMMENT = "rgba(185, 214, 242, 0.85)";
 const KEYWORD = "#FDB330";
 const TYPE = "#FFE169";
 const METHOD = "#84C1FF";
-const PUNCT = "rgba(248, 249, 250, 0.7)";
+const PUNCT = "#F8F9FA";
 const IDENT = "#F8F9FA";
 const PROMPT = "#FDB330";
-const HINT = "rgba(185, 214, 242, 0.55)";
+const HINT = "rgba(185, 214, 242, 0.85)";
 
 type HistoryEntry = {
     cmd: string;
@@ -217,7 +217,7 @@ const HeroCodeSnippet = () => {
                         {/* Terminal title bar */}
                         <div
                             className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-border-[rgba(185,214,242,0.08)] tw-bg-[#061a40] tw-px-5 tw-py-3"
-                            style={{ ...monoLabel, color: "rgba(185, 214, 242, 0.65)" }}
+                            style={{ ...monoLabel, color: "#F8F9FA" }}
                         >
                             <span>vwc-engineer — train.ts — zsh</span>
                             <span className="tw-flex tw-items-center tw-gap-2">

--- a/src/components/ui/social/social-link.tsx
+++ b/src/components/ui/social/social-link.tsx
@@ -51,7 +51,7 @@ const SocialLink = ({
                     "tw-text-center",
                     size === "md" && "tw-h-10 tw-w-10 tw-leading-10",
                     color === "light" &&
-                        "tw-border-gray-550 hover:tw-border-primary hover:tw-bg-primary hover:tw-text-white",
+                        "tw-border-gray-300 hover:tw-border-primary hover:tw-bg-primary hover:tw-text-white",
                 ],
                 variant === "outlined" && "tw-border tw-bg-transparent",
                 shape === "rounded" && "tw-rounded",

--- a/src/components/ui/stat-belt/index.tsx
+++ b/src/components/ui/stat-belt/index.tsx
@@ -81,7 +81,7 @@ const StatBelt = () => {
                                 className="tw-flex tw-items-center tw-gap-2.5"
                                 style={{
                                     ...monoLabel,
-                                    color: "rgba(185, 214, 242, 0.7)",
+                                    color: "#F8F9FA",
                                 }}
                             >
                                 <span
@@ -115,7 +115,7 @@ const StatBelt = () => {
                                         fontFamily: "var(--font-body)",
                                         fontSize: "13px",
                                         lineHeight: 1.5,
-                                        color: "rgba(185, 214, 242, 0.55)",
+                                        color: "#F8F9FA",
                                     }}
                                 >
                                     {stat.sub}

--- a/src/containers/curriculum/curriculum.module.css
+++ b/src/containers/curriculum/curriculum.module.css
@@ -28,7 +28,7 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .briefBar .live {
@@ -81,7 +81,7 @@
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .eyebrow::before {
@@ -111,7 +111,7 @@
     font-family: var(--font-body);
     font-size: 18px;
     line-height: 1.6;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     max-width: 60ch;
     margin: 24px 0 0;
 }
@@ -139,7 +139,7 @@
 }
 
 .heroMetaKey {
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .heroMetaVal {
@@ -202,7 +202,7 @@
 .btnOutlineLight {
     background: transparent;
     color: #ffffff;
-    border-color: rgba(185, 214, 242, 0.3);
+    border-color: #f8f9fa;
 }
 
 .btnOutlineLight:hover {
@@ -301,7 +301,7 @@
     font-family: var(--font-body);
     font-size: 15px;
     line-height: 1.65;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 /* ========== PHASE NAV ========== */
@@ -328,7 +328,7 @@
     font-family: var(--font-mono);
     font-size: 11px;
     font-weight: 500;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     text-transform: uppercase;
     letter-spacing: 0.1em;
 }
@@ -346,7 +346,7 @@
     padding: 10px 16px;
     background: transparent;
     border: 1px solid rgba(185, 214, 242, 0.08);
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     font-family: var(--font-mono);
     font-size: 11px;
     font-weight: 500;
@@ -358,7 +358,7 @@
 }
 
 .pnPill:hover {
-    border-color: rgba(185, 214, 242, 0.4);
+    border-color: #f8f9fa;
     color: #ffffff;
 }
 
@@ -432,7 +432,7 @@
     font-family: var(--font-body);
     font-size: 18px;
     line-height: 1.55;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     max-width: 50ch;
     margin: 18px 0 0;
 }
@@ -458,7 +458,7 @@
     font-family: var(--font-body);
     font-size: 16px;
     line-height: 1.65;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 /* ========== MODULE LIST + ROW ========== */
@@ -549,7 +549,7 @@
     font-family: var(--font-body);
     font-size: 13px;
     line-height: 1.55;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     max-width: 70ch;
 }
 
@@ -571,7 +571,7 @@
     display: inline-block;
     padding: 5px 10px;
     background: rgba(255, 255, 255, 0.06);
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     font-family: var(--font-mono);
     font-size: 10px;
     font-weight: 500;
@@ -584,7 +584,7 @@
     font-family: var(--font-mono);
     font-size: 22px;
     font-weight: 300;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     line-height: 1;
     transition: color 0.18s;
 }
@@ -651,7 +651,7 @@
     font-family: var(--font-body);
     font-size: 14px;
     line-height: 1.55;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .topicMarker {
@@ -933,7 +933,7 @@
     font-family: var(--font-body);
     font-size: 18px;
     line-height: 1.6;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     max-width: 60ch;
     margin: 24px 0 0;
 }
@@ -974,7 +974,7 @@
 }
 
 .ctaAsideKey {
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .ctaAsideVal {
@@ -987,5 +987,5 @@
     font-family: var(--font-body);
     font-size: 13px;
     line-height: 1.6;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }

--- a/src/containers/home/curriculum-columns/curriculum-columns.module.css
+++ b/src/containers/home/curriculum-columns/curriculum-columns.module.css
@@ -41,7 +41,7 @@
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .eyebrow::before {
@@ -67,7 +67,7 @@
     font-family: var(--font-body);
     font-size: 17px;
     line-height: 1.6;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     max-width: 50ch;
     margin: 0;
 }
@@ -178,7 +178,7 @@
     font-family: var(--font-body);
     font-size: 14px;
     line-height: 1.55;
-    color: rgba(185, 214, 242, 0.85);
+    color: #f8f9fa;
     margin: 0;
     flex-grow: 1;
 }
@@ -195,7 +195,7 @@
     font-family: var(--font-mono);
     font-size: 11px;
     font-weight: 500;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     text-transform: uppercase;
     letter-spacing: 0.08em;
 }
@@ -204,7 +204,7 @@
     font-family: var(--font-body);
     font-size: 12px;
     line-height: 1.5;
-    color: rgba(185, 214, 242, 0.55);
+    color: #f8f9fa;
     margin: 0;
 }
 

--- a/src/containers/software-factory/capabilities/capabilities.module.css
+++ b/src/containers/software-factory/capabilities/capabilities.module.css
@@ -77,7 +77,7 @@
     margin: 10px 0 0;
     font-size: 14px;
     line-height: 1.6;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/containers/software-factory/capabilities/index.tsx
+++ b/src/containers/software-factory/capabilities/index.tsx
@@ -55,7 +55,7 @@ const CapabilitiesSection = () => {
                         style={{
                             ...monoLabel,
                             fontSize: "11px",
-                            color: "rgba(185, 214, 242, 0.7)",
+                            color: "#F8F9FA",
                         }}
                     >
                         8 capability areas · led by staff engineers

--- a/src/containers/software-factory/cta/cta.module.css
+++ b/src/containers/software-factory/cta/cta.module.css
@@ -37,7 +37,7 @@
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .bullets a {
@@ -65,11 +65,11 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .statusReady {
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .statusDone {
@@ -107,7 +107,7 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .field input,
@@ -142,7 +142,7 @@
 .chip {
     background: transparent;
     border: 1px solid rgba(185, 214, 242, 0.3);
-    color: rgba(185, 214, 242, 0.8);
+    color: #f8f9fa;
     padding: 8px 14px;
     font-family: var(--font-mono);
     font-size: 11px;
@@ -194,7 +194,7 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.5);
+    color: #f8f9fa;
 }
 
 .btnPrimary,
@@ -275,7 +275,7 @@
 .successBody {
     margin: 12px auto 24px;
     max-width: 360px;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     font-size: 14px;
     line-height: 1.7;
 }

--- a/src/containers/software-factory/cta/index.tsx
+++ b/src/containers/software-factory/cta/index.tsx
@@ -115,7 +115,7 @@ const CtaSection = () => {
                             style={{
                                 fontSize: "18px",
                                 lineHeight: 1.6,
-                                color: "rgba(185, 214, 242, 0.7)",
+                                color: "#F8F9FA",
                                 maxWidth: "520px",
                             }}
                         >

--- a/src/containers/software-factory/differentiators/differentiators.module.css
+++ b/src/containers/software-factory/differentiators/differentiators.module.css
@@ -42,6 +42,6 @@
     margin: 12px 0 0;
     font-size: 14px;
     line-height: 1.7;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 

--- a/src/containers/software-factory/engagements/engagements.module.css
+++ b/src/containers/software-factory/engagements/engagements.module.css
@@ -61,7 +61,7 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.5);
+    color: #f8f9fa;
 }
 
 .title {
@@ -78,7 +78,7 @@
     margin: 12px 0 0;
     font-size: 14px;
     line-height: 1.6;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .foot {
@@ -95,7 +95,7 @@
 .stack {
     font-family: var(--font-mono);
     font-size: 11px;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }
 
 .aar {

--- a/src/containers/software-factory/engagements/index.tsx
+++ b/src/containers/software-factory/engagements/index.tsx
@@ -51,7 +51,7 @@ const EngagementsSection = () => {
                         style={{
                             fontSize: "18px",
                             lineHeight: 1.6,
-                            color: "rgba(185, 214, 242, 0.7)",
+                            color: "#F8F9FA",
                             maxWidth: "480px",
                         }}
                     >

--- a/src/containers/software-factory/hero/index.tsx
+++ b/src/containers/software-factory/hero/index.tsx
@@ -20,7 +20,7 @@ const HeroSection = () => {
                     className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-3 tw-border-b tw-border-[rgba(185,214,242,0.08)] tw-pb-4"
                     style={{
                         ...monoLabel,
-                        color: "rgba(185, 214, 242, 0.65)",
+                        color: "#F8F9FA",
                     }}
                 >
                     <span>OPERATIONS BRIEF · 26-04 / SOFTWARE FACTORY</span>
@@ -56,7 +56,7 @@ const HeroSection = () => {
                                 fontFamily: "var(--font-mono)",
                                 fontSize: "13px",
                                 lineHeight: 1.8,
-                                color: "rgba(185, 214, 242, 0.7)",
+                                color: "#F8F9FA",
                                 maxWidth: "420px",
                             }}
                         >
@@ -72,7 +72,7 @@ const HeroSection = () => {
                                         style={{
                                             ...monoLabel,
                                             fontSize: "11px",
-                                            color: "rgba(185, 214, 242, 0.7)",
+                                            color: "#F8F9FA",
                                         }}
                                     >
                                         {k}
@@ -120,7 +120,7 @@ const HeroSection = () => {
                             style={{
                                 fontSize: "22px",
                                 lineHeight: 1.5,
-                                color: "rgba(185, 214, 242, 0.7)",
+                                color: "#F8F9FA",
                                 maxWidth: "600px",
                             }}
                         >

--- a/src/containers/software-factory/team/index.tsx
+++ b/src/containers/software-factory/team/index.tsx
@@ -52,7 +52,7 @@ const TeamSection = () => {
                         style={{
                             fontSize: "18px",
                             lineHeight: 1.6,
-                            color: "rgba(185, 214, 242, 0.7)",
+                            color: "#F8F9FA",
                             maxWidth: "480px",
                         }}
                     >

--- a/src/containers/software-factory/team/team.module.css
+++ b/src/containers/software-factory/team/team.module.css
@@ -38,7 +38,7 @@
         #091f40;
     display: grid;
     place-items: center;
-    color: rgba(185, 214, 242, 0.5);
+    color: #f8f9fa;
     font-family: var(--font-mono);
     font-size: 10px;
     text-transform: uppercase;
@@ -84,7 +84,7 @@
     font-size: 10px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
     line-height: 1.7;
 }
 
@@ -102,5 +102,5 @@
     margin: 16px 0 0;
     font-size: 14px;
     line-height: 1.7;
-    color: rgba(185, 214, 242, 0.7);
+    color: #f8f9fa;
 }

--- a/src/containers/video/layout-02/index.tsx
+++ b/src/containers/video/layout-02/index.tsx
@@ -51,7 +51,7 @@ const VideoArea = ({
                             y: trans1().y,
                         }}
                     >
-                        <Shape2 className="tw-h-full tw-w-full tw-fill-gray-750" />
+                        <Shape2 className="tw-h-full tw-w-full tw-fill-gray-700" />
                     </motion.div>
                     <motion.div
                         className="tw-absolute tw-left-[-65px] tw-top-2 tw-z-1 tw-h-[90px] tw-w-[90px] md:tw-h-auto md:tw-w-auto"

--- a/src/containers/video/layout-03/index.tsx
+++ b/src/containers/video/layout-03/index.tsx
@@ -50,7 +50,7 @@ const VideoArea = ({
                             y: trans1().y,
                         }}
                     >
-                        <Shape2 className="tw-h-full tw-w-full tw-fill-gray-750" />
+                        <Shape2 className="tw-h-full tw-w-full tw-fill-gray-700" />
                     </motion.div>
                     <motion.div
                         className="tw-absolute tw-left-[-65px] tw-top-2 tw-z-1 tw-h-[90px] tw-w-[90px] md:tw-h-auto md:tw-w-auto"

--- a/src/containers/video/layout-06/index.tsx
+++ b/src/containers/video/layout-06/index.tsx
@@ -44,7 +44,7 @@ const VideoArea = ({ data: { section_title, motto, images, video }, titleSize }:
                             y: trans1().y,
                         }}
                     >
-                        <Shape2 className="tw-h-full tw-w-full tw-fill-gray-750" />
+                        <Shape2 className="tw-h-full tw-w-full tw-fill-gray-700" />
                     </motion.div>
                     <motion.div
                         className="tw-absolute tw-left-[-65px] tw-top-2 tw-z-1 tw-h-[90px] tw-w-[90px] md:tw-h-auto md:tw-w-auto"

--- a/src/layouts/footers/footer-01.tsx
+++ b/src/layouts/footers/footer-01.tsx
@@ -43,7 +43,7 @@ const Footer01 = ({ mode }: TProps) => {
                                 fontSize: "10px",
                                 color:
                                     mode === "dark"
-                                        ? "rgba(185, 214, 242, 0.4)"
+                                        ? "#F8F9FA"
                                         : "var(--navy, #091f40)",
                                 letterSpacing: "0.08em",
                                 textTransform: "uppercase",
@@ -56,7 +56,7 @@ const Footer01 = ({ mode }: TProps) => {
                             style={{
                                 fontFamily: "var(--font-mono)",
                                 fontSize: "10px",
-                                color: mode === "dark" ? "rgba(185, 214, 242, 0.4)" : "#495057",
+                                color: mode === "dark" ? "#F8F9FA" : "#495057",
                                 letterSpacing: "0.06em",
                                 margin: 0,
                             }}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -41,7 +41,7 @@ const Error404Page = () => {
 };
 
 export function getStaticProps() {
-    return { props: { className: "error-404 tw-bg-dark-50" } };
+    return { props: { className: "error-404 tw-bg-dark" } };
 }
 
 export default Error404Page;

--- a/src/pages/admin/courses.tsx
+++ b/src/pages/admin/courses.tsx
@@ -58,7 +58,7 @@ const AdminCoursesPage: PageWithLayout = ({ courses: initialCourses }) => {
     const getStatusBadge = (isPublished: boolean) => {
         if (isPublished) {
             return (
-                <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-text-gold-deep">
+                <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-text-ink">
                     Published
                 </span>
             );
@@ -72,8 +72,8 @@ const AdminCoursesPage: PageWithLayout = ({ courses: initialCourses }) => {
 
     const getDifficultyBadge = (difficulty: string) => {
         const styles = {
-            BEGINNER: "tw-bg-gold-light tw-text-gold-deep",
-            INTERMEDIATE: "tw-bg-gold-light tw-text-gold-rich",
+            BEGINNER: "tw-bg-gold-light tw-text-ink",
+            INTERMEDIATE: "tw-bg-gold-light tw-text-ink",
             ADVANCED: "tw-bg-cream tw-text-red-dark",
         };
         return (
@@ -223,7 +223,7 @@ const AdminCoursesPage: PageWithLayout = ({ courses: initialCourses }) => {
                                     </button>
                                     <button
                                         type="button"
-                                        className="tw-text-gold hover:tw-text-gold-deep"
+                                        className="tw-text-navy hover:tw-text-navy-deep"
                                         title="View Course"
                                     >
                                         <i className="fas fa-eye" />

--- a/src/pages/admin/users.tsx
+++ b/src/pages/admin/users.tsx
@@ -66,7 +66,7 @@ const AdminUsersPage: PageWithLayout = ({ users: initialUsers }) => {
     const getStatusBadge = (isActive: boolean) => {
         if (isActive) {
             return (
-                <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-text-gold-deep">
+                <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-2 tw-py-1 tw-text-xs tw-font-medium tw-text-ink">
                     Active
                 </span>
             );
@@ -82,8 +82,8 @@ const AdminUsersPage: PageWithLayout = ({ users: initialUsers }) => {
         const styles = {
             ADMIN: "tw-bg-cream tw-text-red-dark",
             INSTRUCTOR: "tw-bg-navy-sky tw-text-navy-deep",
-            MENTOR: "tw-bg-gold-light tw-text-gold-rich",
-            STUDENT: "tw-bg-gold-light tw-text-gold-deep",
+            MENTOR: "tw-bg-gold-light tw-text-ink",
+            STUDENT: "tw-bg-gold-light tw-text-ink",
         };
         return (
             <span
@@ -294,7 +294,7 @@ const AdminUsersPage: PageWithLayout = ({ users: initialUsers }) => {
                                                 </button>
                                                 <button
                                                     type="button"
-                                                    className="tw-text-gold hover:tw-text-gold-deep"
+                                                    className="tw-text-navy hover:tw-text-navy-deep"
                                                     title="Send Message"
                                                 >
                                                     <i className="fas fa-envelope" />

--- a/src/pages/assessment.tsx
+++ b/src/pages/assessment.tsx
@@ -316,7 +316,7 @@ const Assessment: PageWithLayout = () => {
                 <div
                     className={`tw-fixed tw-right-4 tw-top-4 tw-z-50 tw-rounded-lg tw-p-4 tw-shadow-lg tw-duration-300 tw-animate-in tw-fade-in tw-slide-in-from-top-5 ${
                         notification.type === "success"
-                            ? "tw-border tw-border-gold tw-bg-gold-light/20 tw-text-gold-deep"
+                            ? "tw-border tw-border-gold tw-bg-gold-light/20 tw-text-ink"
                             : notification.type === "error"
                               ? "tw-border tw-border-red tw-bg-cream tw-text-red-dark"
                               : "tw-border tw-border-navy-sky tw-bg-navy-sky/20 tw-text-navy-deep"
@@ -424,14 +424,14 @@ const Assessment: PageWithLayout = () => {
                                     <i
                                         className={`fas ${
                                             testResults.passed === testResults.total
-                                                ? "fa-check-circle tw-text-gold"
+                                                ? "fa-check-circle tw-text-navy-deep"
                                                 : "fa-times-circle tw-text-red-dark"
                                         }`}
                                     />
                                     <span
                                         className={
                                             testResults.passed === testResults.total
-                                                ? "tw-text-gold-deep"
+                                                ? "tw-text-navy-deep"
                                                 : "tw-text-red-dark"
                                         }
                                     >
@@ -447,7 +447,7 @@ const Assessment: PageWithLayout = () => {
                                 Est. {currentQuestion.timeEstimate} min
                             </span>
                             <span>
-                                <i className="fas fa-star tw-mr-1 tw-text-gold-light/200" />
+                                <i className="fas fa-star tw-mr-1 tw-text-navy-deep" />
                                 {currentQuestion.points} points
                             </span>
                         </div>

--- a/src/pages/assignments/submit/[assignmentId].tsx
+++ b/src/pages/assignments/submit/[assignmentId].tsx
@@ -132,7 +132,7 @@ const AssignmentSubmissionPage: PageWithLayout = ({ assignment }) => {
                     <div className="tw-mx-auto tw-max-w-2xl tw-text-center">
                         <div className="tw-mb-8">
                             <div className="tw-mx-auto tw-mb-4 tw-flex tw-h-20 tw-w-20 tw-items-center tw-justify-center tw-rounded-full tw-bg-gold-light/30">
-                                <i className="fas fa-check tw-text-3xl tw-text-gold" />
+                                <i className="fas fa-check tw-text-3xl tw-text-ink" />
                             </div>
                             <h1 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-ink">
                                 Assignment Submitted Successfully!

--- a/src/pages/challenges/[id].tsx
+++ b/src/pages/challenges/[id].tsx
@@ -160,11 +160,11 @@ const ChallengeDetailPage: PageWithLayout = () => {
     const difficultyColor = (d: string) => {
         switch (d.toLowerCase()) {
             case "warmup":
-                return "tw-bg-gold-light tw-text-gold-deep";
+                return "tw-bg-gold-light tw-text-ink";
             case "easy":
-                return "tw-bg-gold-light tw-text-gold-deep";
+                return "tw-bg-gold-light tw-text-ink";
             case "medium":
-                return "tw-bg-gold-light tw-text-gold-rich";
+                return "tw-bg-gold-light tw-text-ink";
             case "hard":
                 return "tw-bg-cream tw-text-red-dark";
             default:
@@ -323,10 +323,10 @@ const ChallengeDetailPage: PageWithLayout = () => {
 
                         {showSolution && solutionText && (
                             <div className="tw-mb-4 tw-rounded-md tw-bg-gold-light tw-border tw-border-gold tw-p-4">
-                                <span className="tw-text-xs tw-font-semibold tw-text-gold-rich tw-uppercase">
+                                <span className="tw-text-xs tw-font-semibold tw-text-ink tw-uppercase">
                                     Solution
                                 </span>
-                                <pre className="tw-mt-2 tw-text-sm tw-font-mono tw-text-gold-deep tw-whitespace-pre-wrap">
+                                <pre className="tw-mt-2 tw-text-sm tw-font-mono tw-text-ink tw-whitespace-pre-wrap">
                                     {solutionText}
                                 </pre>
                             </div>
@@ -352,14 +352,14 @@ const ChallengeDetailPage: PageWithLayout = () => {
                                             <i
                                                 className={`fas ${
                                                     passed
-                                                        ? "fa-check-circle tw-text-gold-deep"
+                                                        ? "fa-check-circle tw-text-ink"
                                                         : "fa-times-circle tw-text-red-dark"
                                                 }`}
                                             />
                                             <span
                                                 className={`tw-font-semibold ${
                                                     passed
-                                                        ? "tw-text-gold-deep"
+                                                        ? "tw-text-ink"
                                                         : "tw-text-red-dark"
                                                 }`}
                                             >
@@ -399,13 +399,13 @@ function TestResultsPanel({ results }: { results: ClientResults }) {
                 <i
                     className={`fas ${
                         results.all_passed
-                            ? "fa-check-circle tw-text-gold-deep"
+                            ? "fa-check-circle tw-text-ink"
                             : "fa-times-circle tw-text-red-dark"
                     }`}
                 />
                 <span
                     className={`tw-font-semibold ${
-                        results.all_passed ? "tw-text-gold-deep" : "tw-text-red-dark"
+                        results.all_passed ? "tw-text-ink" : "tw-text-red-dark"
                     }`}
                 >
                     {passedCount} / {total} tests passing
@@ -432,7 +432,7 @@ function TestResultRow({ result }: { result: ClientTestResult }) {
             <div className="tw-flex tw-items-center tw-gap-2 tw-mb-1">
                 <i
                     className={`fas ${
-                        result.passed ? "fa-check tw-text-gold-deep" : "fa-times tw-text-red-dark"
+                        result.passed ? "fa-check tw-text-navy-deep" : "fa-times tw-text-red-dark"
                     }`}
                 />
                 <span className="tw-font-semibold tw-text-ink">

--- a/src/pages/challenges/browse.tsx
+++ b/src/pages/challenges/browse.tsx
@@ -126,11 +126,11 @@ const BrowseChallengesPage: PageWithLayout = () => {
     const difficultyColor = (d: Difficulty) => {
         switch (d) {
             case "warmup":
-                return "tw-bg-gold-light tw-text-gold-deep";
+                return "tw-bg-gold-light tw-text-ink";
             case "easy":
-                return "tw-bg-gold-light tw-text-gold-deep";
+                return "tw-bg-gold-light tw-text-ink";
             case "medium":
-                return "tw-bg-gold-light tw-text-gold-rich";
+                return "tw-bg-gold-light tw-text-ink";
             case "hard":
                 return "tw-bg-cream tw-text-red-dark";
         }

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -261,9 +261,9 @@ const ChallengesPage: PageWithLayout = () => {
     const difficultyColor = (d: string) => {
         switch (d.toLowerCase()) {
             case "easy":
-                return "tw-bg-gold-light tw-text-gold-deep";
+                return "tw-bg-gold-light tw-text-ink";
             case "medium":
-                return "tw-bg-gold-light tw-text-gold-rich";
+                return "tw-bg-gold-light tw-text-ink";
             case "hard":
                 return "tw-bg-cream tw-text-red-dark";
             default:
@@ -556,10 +556,10 @@ const ChallengesPage: PageWithLayout = () => {
                                 {/* Solution */}
                                 {showSolution && solution && (
                                     <div className="tw-mb-4 tw-rounded-md tw-bg-gold-light tw-border tw-border-gold tw-p-4">
-                                        <span className="tw-text-xs tw-font-semibold tw-text-gold-rich tw-uppercase">
+                                        <span className="tw-text-xs tw-font-semibold tw-text-ink tw-uppercase">
                                             Solution
                                         </span>
-                                        <pre className="tw-mt-2 tw-text-sm tw-font-mono tw-text-gold-deep tw-whitespace-pre-wrap">
+                                        <pre className="tw-mt-2 tw-text-sm tw-font-mono tw-text-ink tw-whitespace-pre-wrap">
                                             {solution}
                                         </pre>
                                     </div>
@@ -590,14 +590,14 @@ const ChallengesPage: PageWithLayout = () => {
                                                     <i
                                                         className={`fas ${
                                                             passed
-                                                                ? "fa-check-circle tw-text-gold-deep"
+                                                                ? "fa-check-circle tw-text-ink"
                                                                 : "fa-times-circle tw-text-red-dark"
                                                         }`}
                                                     />
                                                     <span
                                                         className={`tw-font-semibold ${
                                                             passed
-                                                                ? "tw-text-gold-deep"
+                                                                ? "tw-text-ink"
                                                                 : "tw-text-red-dark"
                                                         }`}
                                                     >
@@ -691,13 +691,13 @@ function TestResultsPanel({ results }: { results: ClientResults }) {
                 <i
                     className={`fas ${
                         results.all_passed
-                            ? "fa-check-circle tw-text-gold-deep"
+                            ? "fa-check-circle tw-text-ink"
                             : "fa-times-circle tw-text-red-dark"
                     }`}
                 />
                 <span
                     className={`tw-font-semibold ${
-                        results.all_passed ? "tw-text-gold-deep" : "tw-text-red-dark"
+                        results.all_passed ? "tw-text-ink" : "tw-text-red-dark"
                     }`}
                 >
                     {passedCount} / {total} tests passing
@@ -724,7 +724,7 @@ function TestResultRow({ result }: { result: ClientTestResult }) {
             <div className="tw-flex tw-items-center tw-gap-2 tw-mb-1">
                 <i
                     className={`fas ${
-                        result.passed ? "fa-check tw-text-gold-deep" : "fa-times tw-text-red-dark"
+                        result.passed ? "fa-check tw-text-navy-deep" : "fa-times tw-text-red-dark"
                     }`}
                 />
                 <span className="tw-font-semibold tw-text-ink">

--- a/src/pages/jobs/index.tsx
+++ b/src/pages/jobs/index.tsx
@@ -94,7 +94,7 @@ const JobsPage: PageWithLayout = ({ jobs, categories, jobTypes, user }) => {
                     <div className="tw-mb-4 tw-flex tw-items-center tw-justify-between">
                         <h1 className="tw-text-4xl tw-font-bold tw-text-ink">Career Hub</h1>
                         {user.hasEnrollment && (
-                            <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-gold-deep">
+                            <span className="tw-rounded-full tw-bg-gold-light/30 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-ink">
                                 <i className="fas fa-check-circle tw-mr-2" />
                                 VWC Alumni
                             </span>

--- a/src/pages/orders/index.tsx
+++ b/src/pages/orders/index.tsx
@@ -86,11 +86,11 @@ const OrderHistoryPage = () => {
 
     const getStatusBadge = (status: string) => {
         const statusMap: Record<string, { color: string; label: string }> = {
-            paid: { color: "tw-bg-gold-light tw-text-gold-deep", label: "Paid" },
-            pending: { color: "tw-bg-gold-light tw-text-gold-rich", label: "Pending" },
+            paid: { color: "tw-bg-gold-light tw-text-ink", label: "Paid" },
+            pending: { color: "tw-bg-gold-light tw-text-ink", label: "Pending" },
             refunded: { color: "tw-bg-cream tw-text-red-dark", label: "Refunded" },
             partially_refunded: {
-                color: "tw-bg-gold-light tw-text-gold-rich",
+                color: "tw-bg-gold-light tw-text-ink",
                 label: "Partially Refunded",
             },
             voided: { color: "tw-bg-gray-100 tw-text-gray-800", label: "Voided" },
@@ -120,8 +120,8 @@ const OrderHistoryPage = () => {
         }
 
         const statusMap: Record<string, { color: string; label: string }> = {
-            fulfilled: { color: "tw-bg-gold-light tw-text-gold-deep", label: "Fulfilled" },
-            partial: { color: "tw-bg-gold-light tw-text-gold-rich", label: "Partially Fulfilled" },
+            fulfilled: { color: "tw-bg-gold-light tw-text-ink", label: "Fulfilled" },
+            partial: { color: "tw-bg-gold-light tw-text-ink", label: "Partially Fulfilled" },
             unfulfilled: { color: "tw-bg-gray-100 tw-text-gray-800", label: "Unfulfilled" },
         };
 

--- a/src/pages/store/products/[handle].tsx
+++ b/src/pages/store/products/[handle].tsx
@@ -232,7 +232,7 @@ const ProductDetailPage: React.FC<ProductDetailPageProps> = ({ product }) => {
                         {/* Availability */}
                         <div className="tw-mb-6">
                             {product.availableForSale ? (
-                                <span className="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-bg-gold-light/30 tw-text-gold-deep tw-rounded-full tw-font-medium">
+                                <span className="tw-inline-flex tw-items-center tw-gap-2 tw-px-4 tw-py-2 tw-bg-gold-light/30 tw-text-ink tw-rounded-full tw-font-medium">
                                     <svg
                                         className="tw-w-5 tw-h-5"
                                         fill="currentColor"

--- a/src/pages/submissions/index.tsx
+++ b/src/pages/submissions/index.tsx
@@ -74,8 +74,8 @@ const SubmissionsPage: PageWithLayout = () => {
     const getStatusBadge = (status: string) => {
         const styles = {
             SUBMITTED: "tw-bg-navy-sky tw-text-navy-deep",
-            GRADED: "tw-bg-gold-light tw-text-gold-deep",
-            RETURNED: "tw-bg-gold-light tw-text-gold-rich",
+            GRADED: "tw-bg-gold-light tw-text-ink",
+            RETURNED: "tw-bg-gold-light tw-text-ink",
         };
         return (
             <span

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -115,6 +115,10 @@ module.exports = {
                 ink: "#1A1823",
 
                 // ===== UI GRAYS (Light Mode) =====
+                // Brand neutrals (per docs/brand-style-guide.md). The 500-900 stops
+                // alias the same brand hex values to match conventional Tailwind
+                // scale expectations and ensure all `tw-*-gray-{n}` tokens render a
+                // valid brand color (avoids invisible/cascading text).
                 gray: {
                     DEFAULT: "#6C757D", // Slate - secondary text
                     50: "#F8F9FA", // Off White - light cards
@@ -122,6 +126,11 @@ module.exports = {
                     200: "#6C757D", // Slate - secondary text, captions
                     300: "#495057", // Charcoal - muted labels
                     400: "#343A40", // Dark Gray - softer text blocks
+                    500: "#6C757D", // Slate (alias of 200) — secondary text
+                    600: "#495057", // Charcoal (alias of 300) — muted labels
+                    700: "#343A40", // Dark Gray (alias of 400) — body text blocks
+                    800: "#212529", // Charcoal (dark.surface) — deeper text
+                    900: "#1A1823", // Ink — strongest neutral text
                 },
 
                 // ===== SEMANTIC COLORS (Mapped to Brand Colors) =====


### PR DESCRIPTION
## Summary
- Audited text/background color pairings sitewide and fixed every combination that failed WCAG AA (4.5:1 normal text, 3:1 for UI components and large text).
- Extended the gray scale in `tailwind.config.js` with the 500/600/700/800/900 stops aliased to existing brand neutrals so the ~96 occurrences of `tw-text-gray-{500..900}` (previously undefined → cascading) resolve to valid brand colors.
- Replaced failing gold-on-light text (1.4–2.4:1) with brand tokens that pass — `ink`, `navy-deep`, or `red-dark` per semantic intent. Gold backgrounds preserved per brand guide; only the text/icon color shifted.
- Fixed five undefined Tailwind tokens at their call sites: `gray-550`, `gray-750`, `dark-50`, `warning-100`, `secondary-200`.

## Scope
- 34 files: components, containers, pages — covers admin dashboard, profile, translator suite, challenges, resume scorer, mock interview, job match, order/submission state pills, assessment, and assignment submit.
- No design system additions outside what already exists in `docs/brand-style-guide.md`. All replacements use canonical brand tokens.

## Out of scope (verified passing as-is)
- Gold accents on navy/red backgrounds — Stat Belt, Donate Form, Profile Header (gold on navy passes ~9.5:1).
- Red text on light backgrounds — already brand-compliant.

## Test plan
- [ ] `npm run typecheck` — passes for changed files (pre-existing j0di3 / swagger errors are unrelated to this branch).
- [ ] `npm run lint` — passes for changed files (pre-existing test-file lint errors unrelated).
- [ ] Smoke a representative set of pages in a browser at `/admin`, `/admin/users`, `/admin/courses`, `/challenges`, `/challenges/[id]`, `/orders`, `/submissions`, `/jobs`, `/resume-translator`, `/assessment`, `/profile`, `/store/products/[handle]`, `/404` — confirm status pills, score gradients, success icons render with the new colors.
- [ ] Spot-check dark sections (Stat Belt, Donate Form red panel, Profile Header) — confirm gold accents still appear unchanged.
- [ ] Run `npx playwright test` if visual specs are in place — screenshots may shift.