### PR TITLE
feat(design): Visual coherence pass — sharp aesthetic site-wide

### DIFF
--- a/src/assets/css/globals.css
+++ b/src/assets/css/globals.css
@@ -63,31 +63,143 @@
 :root {
     /* Brand Colors */
     --navy: #091f40;
+    --navy-midnight: #061a40;
     --navy-deep: #003559;
     --navy-royal: #0353a4;
     --navy-ocean: #006daa;
     --navy-sky: #b9d6f2;
     --red: #c5203e;
+    --red-signal: #c52233;
     --red-crimson: #a51c30;
     --red-dark: #74121d;
+    --red-maroon: #580c1f;
     --gold: #fdb330;
     --gold-light: #ffe169;
+    --gold-bright: #fad643;
+    --gold-rich: #dbb42c;
+    --gold-deep: #c9a227;
     --cream: #eeede9;
     --ink: #1a1823;
     --white: #ffffff;
+    --black: #000000;
+
+    /* Neutrals (UI grays, light mode) */
+    --off-white: #f8f9fa;
+    --silver: #dee2e6;
+    --slate: #6c757d;
+    --charcoal: #495057;
+    --dark-gray: #343a40;
+
+    /* Dark surface scale */
+    --dark-bg: #1a1823;
+    --dark-surface: #212529;
+    --dark-elevated: #343a40;
+
+    /* Dark-mode text + accents */
+    --on-dark: #f8f9fa;
+    --on-dark-muted: #dee2e6;
+    --on-dark-disabled: #6c757d;
+    --link-on-dark: #84c1ff;
+    --link-on-dark-hover: #b9d6f2;
+    --coral-on-dark: #f38375;
 
     /* Semantic Aliases */
     --bg-dark: var(--navy);
+    --bg-dark-deeper: var(--dark-bg);
     --fg-light: var(--white);
     --muted: #6c757d;
     --muted-on-dark: #f8f9fa;
     --border-subtle: rgba(185, 214, 242, 0.08);
+    --muted-on-dark-rgba: rgba(185, 214, 242, 0.7);
     --accent: var(--red);
+    --primary: var(--red);
+    --secondary: var(--navy);
+    --success: var(--gold);
+    --warning: var(--gold-bright);
+    --danger: var(--red);
+    --info: var(--navy-ocean);
+
+    /* Foreground aliases */
+    --fg1: var(--ink);
+    --fg2: var(--charcoal);
+    --fg3: var(--slate);
+
+    /* Overlays / gradients */
+    --hero-gradient: linear-gradient(135deg, rgba(9, 31, 64, 0.92) 0%, rgba(6, 26, 64, 0.88) 100%);
+    --dark-gradient: linear-gradient(-180deg, transparent 0, rgba(0, 0, 0, 0.3) 100%);
 
     /* Font Stacks */
     --font-headline: "GothamPro", system-ui, sans-serif;
     --font-body: "Gilroy", system-ui, sans-serif;
+    --font-serif: "Playfair Display", Georgia, serif;
     --font-mono: ui-monospace, "SFMono-Regular", "Cascadia Code", "Fira Code", monospace;
+
+    /* Type scale (fluid) */
+    --fs-h1: clamp(36px, 6vw, 64px);
+    --fs-h2: clamp(28px, 5vw, 48px);
+    --fs-h3: clamp(20px, 3vw, 28px);
+    --fs-h4: 21px;
+    --fs-h5: 17.5px;
+    --fs-h6: 15px;
+    --fs-body: 15px;
+    --fs-body-lg: 18px;
+    --fs-meta: 12px;
+    --fs-button: 12px;
+    --lh-body: 1.74;
+    --lh-heading: 1.05;
+    --ls-heading: -0.02em;
+    --ls-button: 0.08em;
+    --ls-meta: 0.1em;
+
+    /* Spacing (8px grid) */
+    --space-xs: 8px;
+    --space-sm: 12px;
+    --space-md: 16px;
+    --space-lg: 24px;
+    --space-xl: 32px;
+    --space-2xl: 48px;
+    --space-3xl: 64px;
+    --space-4xl: 96px;
+    --space-section: 140px;
+    --gutter-grid: 30px;
+    --gutter-grid-lg: 60px;
+    --gutter-mobile: 15px;
+
+    /* Radius — sharp edges signal precision */
+    --radius-0: 0;
+    --radius-sm: 4px;
+    --radius-focus: 4px;
+
+    /* Shadow */
+    --shadow-2xs: 0 0 10px rgba(0, 0, 0, 0.08);
+    --shadow-sm: 0 3px 9px rgba(0, 0, 0, 0.1);
+    --shadow-md: 0 0 30px rgba(0, 0, 0, 0.1);
+    --shadow-3md: 0 8px 20px rgba(0, 0, 0, 0.12);
+    --shadow-4md: 0 10px 30px rgba(0, 0, 0, 0.18);
+    --shadow-lg: 0 0 40px rgba(0, 0, 0, 0.15);
+    --shadow-xl: 0 20px 50px rgba(0, 0, 0, 0.2);
+    --shadow-cta-red: 0 8px 20px rgba(197, 32, 62, 0.2);
+
+    /* Motion */
+    --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+    --ease-in-expo: cubic-bezier(0.165, 0.84, 0.44, 1);
+    --ease-card: cubic-bezier(0.3, 0.2, 0.3, 0.3);
+    --dur-fast: 200ms;
+    --dur-base: 300ms;
+    --dur-mid: 500ms;
+    --dur-slide: 950ms;
+
+    /* Layout */
+    --container-sm: 576px;
+    --container-md: 768px;
+    --container-lg: 992px;
+    --container-xl: 1230px;
+    --container-2xl: 1400px;
+    --container-3xl: 1600px;
+
+    /* Focus */
+    --focus-ring: 3px solid var(--gold);
+    --focus-offset: 2px;
 }
 
 /* =============================================
@@ -261,6 +373,10 @@ nav[aria-label="Main Menu"] a {
     transform: translateY(-1px);
 }
 
+.btn-primary-upgraded:active {
+    transform: scale(0.95);
+}
+
 .btn-secondary-upgraded {
     font-family: var(--font-headline) !important;
     font-weight: 700 !important;
@@ -277,6 +393,10 @@ nav[aria-label="Main Menu"] a {
 
 .btn-secondary-upgraded:hover {
     border-color: var(--red) !important;
+}
+
+.btn-secondary-upgraded:active {
+    transform: scale(0.95);
 }
 
 .btn-ghost-upgraded {
@@ -408,6 +528,36 @@ body {
     }
 }
 
+/* =============================================
+   REDUCED MOTION — honor user preference globally
+   ============================================= */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    .fade-up {
+        opacity: 1;
+        animation: none !important;
+        transform: none !important;
+    }
+
+    .emoji-fall {
+        animation: none !important;
+    }
+
+    .btn-primary-upgraded:hover,
+    .btn-secondary-upgraded:hover,
+    .card-upgraded:hover {
+        transform: none !important;
+    }
+}
+
 /* Smooth scrolling */
 html {
     scroll-behavior: smooth;
@@ -474,7 +624,8 @@ h3 {
 }
 
 .section-title[data-align="left"] .title::before,
-.section-title .section-accent::before {
+.section-title .section-accent::before,
+.eyebrow::before {
     content: "";
     display: inline-block;
     width: 16px;
@@ -482,6 +633,18 @@ h3 {
     background: var(--red);
     margin-right: 12px;
     vertical-align: middle;
+}
+
+/* Standalone eyebrow label — monospace, uppercase, tracked */
+.eyebrow {
+    font-family: var(--font-mono);
+    font-size: var(--fs-meta);
+    text-transform: uppercase;
+    letter-spacing: var(--ls-meta);
+    color: var(--muted);
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
 }
 
 /* Print styles for portfolio checklist */

--- a/src/assets/css/globals.css
+++ b/src/assets/css/globals.css
@@ -647,6 +647,91 @@ h3 {
     align-items: center;
 }
 
+/* =============================================
+   SITE-WIDE SHARP-AESTHETIC ENFORCEMENT
+   Brings legacy containers into the Software-Factory /
+   Career-Guides visual language without per-page rewrites.
+   ============================================= */
+
+/* Zero-radius default on common surfaces. Genuine radius needs opt in
+   via a specific class (focus ring, .vwc-avatar, image corners). */
+.tw-rounded,
+.tw-rounded-md,
+.tw-rounded-lg,
+.tw-rounded-xl,
+.tw-rounded-2xl,
+.tw-rounded-3xl {
+    border-radius: 0 !important;
+}
+
+button.tw-rounded-full,
+a.tw-rounded-full:not(.vwc-avatar) {
+    border-radius: 0 !important;
+}
+
+/* Strip soft drop shadows on dark sections — they fight the 2% grain. */
+.dark-section .tw-shadow,
+.dark-section .tw-shadow-sm,
+.dark-section .tw-shadow-md,
+.dark-section .tw-shadow-lg,
+.dark-section .tw-shadow-xl,
+.dark-section .tw-shadow-2xl {
+    box-shadow: none !important;
+}
+
+/* Kill pastel/blueish-purple gradient leakage. Brand is navy + red + gold.
+   Containers that legitimately want a gradient opt in with .vwc-gradient. */
+.tw-bg-gradient-to-br:not(.vwc-gradient),
+.tw-bg-gradient-to-bl:not(.vwc-gradient),
+.tw-bg-gradient-to-tr:not(.vwc-gradient),
+.tw-bg-gradient-to-tl:not(.vwc-gradient),
+.tw-bg-gradient-to-r:not(.vwc-gradient),
+.tw-bg-gradient-to-l:not(.vwc-gradient),
+.tw-bg-gradient-to-t:not(.vwc-gradient),
+.tw-bg-gradient-to-b:not(.vwc-gradient) {
+    background-image: none !important;
+}
+
+/* Section eyebrow utility — short red bar + mono label, SF/CG signature. */
+.vwc-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--slate);
+}
+
+.vwc-eyebrow::before {
+    content: "";
+    display: inline-block;
+    width: 16px;
+    height: 2px;
+    background: var(--red);
+    flex-shrink: 0;
+}
+
+.dark-section .vwc-eyebrow {
+    color: var(--cream);
+}
+
+/* Sharp headline utility — apply to any heading that should match SF/CG
+   without rewriting the component. */
+.vwc-sharp {
+    font-family: var(--font-headline);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: -0.02em;
+    line-height: 1.02;
+}
+
+.vwc-sharp-xl {
+    font-size: clamp(40px, 7vw, 84px);
+    line-height: 0.98;
+}
+
 /* Print styles for portfolio checklist */
 @media print {
     header,

--- a/src/components/ui/design-system/index.ts
+++ b/src/components/ui/design-system/index.ts
@@ -1,0 +1,4 @@
+export { default as MonoMeta } from "./mono-meta";
+export { default as SectionEyebrow } from "./section-eyebrow";
+export { default as SharpHeadline } from "./sharp-headline";
+export { default as StatStrip, type StatCell } from "./stat-strip";

--- a/src/components/ui/design-system/mono-meta.tsx
+++ b/src/components/ui/design-system/mono-meta.tsx
@@ -1,0 +1,44 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+type Tone = "muted" | "bright" | "accent" | "gold";
+type Size = "xs" | "sm" | "md";
+
+interface Props {
+    children: ReactNode;
+    tone?: Tone;
+    size?: Size;
+    as?: "span" | "div" | "p";
+    className?: string;
+}
+
+const TONE_CLASS: Record<Tone, string> = {
+    muted: "tw-text-[#6C757D]",
+    bright: "tw-text-cream",
+    accent: "tw-text-red",
+    gold: "tw-text-gold",
+};
+
+const SIZE_CLASS: Record<Size, string> = {
+    xs: "tw-text-[10px]",
+    sm: "tw-text-[11px]",
+    md: "tw-text-[12px]",
+};
+
+const MonoMeta = ({ children, tone = "muted", size = "sm", as = "span", className }: Props) => {
+    const Tag = as;
+    return (
+        <Tag
+            className={clsx(
+                "tw-font-mono tw-uppercase tw-tracking-[0.12em]",
+                SIZE_CLASS[size],
+                TONE_CLASS[tone],
+                className
+            )}
+        >
+            {children}
+        </Tag>
+    );
+};
+
+export default MonoMeta;

--- a/src/components/ui/design-system/section-eyebrow.tsx
+++ b/src/components/ui/design-system/section-eyebrow.tsx
@@ -1,0 +1,52 @@
+import clsx from "clsx";
+
+interface Props {
+    label: string;
+    subLabel?: string;
+    tone?: "light" | "dark";
+    size?: "sm" | "md";
+    align?: "left" | "center";
+    className?: string;
+}
+
+const SectionEyebrow = ({
+    label,
+    subLabel,
+    tone = "light",
+    size = "sm",
+    align = "left",
+    className,
+}: Props) => {
+    const labelColor = tone === "dark" ? "tw-text-cream" : "tw-text-[#6C757D]";
+    const subColor = tone === "dark" ? "tw-text-[#B9D6F2]/70" : "tw-text-[#495057]";
+    const fontSize = size === "md" ? "tw-text-[12px]" : "tw-text-[11px]";
+
+    return (
+        <div
+            className={clsx(
+                "tw-flex tw-items-center tw-gap-3",
+                align === "center" && "tw-justify-center",
+                className
+            )}
+        >
+            <span aria-hidden="true" className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red" />
+            <span
+                className={clsx(
+                    "tw-font-mono tw-uppercase tw-tracking-[0.12em]",
+                    fontSize,
+                    labelColor
+                )}
+            >
+                {label}
+                {subLabel ? (
+                    <>
+                        <span className={clsx("tw-mx-2", subColor)}>/</span>
+                        <span className={subColor}>{subLabel}</span>
+                    </>
+                ) : null}
+            </span>
+        </div>
+    );
+};
+
+export default SectionEyebrow;

--- a/src/components/ui/design-system/sharp-headline.tsx
+++ b/src/components/ui/design-system/sharp-headline.tsx
@@ -1,0 +1,51 @@
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+type Tone = "navy" | "white" | "cream";
+type Size = "h1" | "h2" | "h3";
+
+interface Props {
+    as?: "h1" | "h2" | "h3" | "h4";
+    size?: Size;
+    tone?: Tone;
+    align?: "left" | "center";
+    children: ReactNode;
+    className?: string;
+}
+
+const TONE_CLASS: Record<Tone, string> = {
+    navy: "tw-text-navy",
+    white: "tw-text-white",
+    cream: "tw-text-cream",
+};
+
+const SIZE_CLASS: Record<Size, string> = {
+    h1: "[font-size:clamp(40px,7vw,84px)] [line-height:0.98]",
+    h2: "[font-size:clamp(32px,4.5vw,56px)] [line-height:1.02]",
+    h3: "[font-size:clamp(22px,2.6vw,32px)] [line-height:1.1]",
+};
+
+const SharpHeadline = ({
+    as: Tag = "h2",
+    size = "h2",
+    tone = "navy",
+    align = "left",
+    children,
+    className,
+}: Props) => {
+    return (
+        <Tag
+            className={clsx(
+                "tw-m-0 tw-font-heading tw-font-semibold tw-uppercase [letter-spacing:-0.02em]",
+                SIZE_CLASS[size],
+                TONE_CLASS[tone],
+                align === "center" && "tw-text-center",
+                className
+            )}
+        >
+            {children}
+        </Tag>
+    );
+};
+
+export default SharpHeadline;

--- a/src/components/ui/design-system/stat-strip.tsx
+++ b/src/components/ui/design-system/stat-strip.tsx
@@ -1,0 +1,70 @@
+import clsx from "clsx";
+
+export interface StatCell {
+    label: string;
+    value: string;
+    sub?: string;
+}
+
+interface Props {
+    cells: StatCell[];
+    tone?: "light" | "dark";
+    className?: string;
+}
+
+const StatStrip = ({ cells, tone = "dark", className }: Props) => {
+    const cellLabelColor = tone === "dark" ? "tw-text-[#6C757D]" : "tw-text-[#495057]";
+    const cellValueColor = tone === "dark" ? "tw-text-cream" : "tw-text-navy";
+    const borderColor = tone === "dark" ? "tw-border-cream/10" : "tw-border-silver";
+    const cols =
+        cells.length === 4
+            ? "md:tw-grid-cols-4"
+            : cells.length === 3
+              ? "md:tw-grid-cols-3"
+              : cells.length === 2
+                ? "md:tw-grid-cols-2"
+                : "md:tw-grid-cols-5";
+
+    return (
+        <div className={clsx("tw-grid tw-grid-cols-2 tw-border-t", cols, borderColor, className)}>
+            {cells.map((cell) => (
+                <div
+                    key={cell.label}
+                    className={clsx(
+                        "tw-flex tw-flex-col tw-gap-3 tw-px-6 tw-py-7 first:md:tw-border-l-0 md:tw-border-l",
+                        borderColor
+                    )}
+                >
+                    <span
+                        className={clsx(
+                            "tw-font-mono tw-text-[10.5px] tw-uppercase tw-tracking-[0.12em]",
+                            cellLabelColor
+                        )}
+                    >
+                        {cell.label}
+                    </span>
+                    <span
+                        className={clsx(
+                            "tw-font-heading tw-text-[30px] tw-font-semibold tw-leading-none",
+                            cellValueColor
+                        )}
+                    >
+                        {cell.value}
+                    </span>
+                    {cell.sub ? (
+                        <span
+                            className={clsx(
+                                "tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.08em]",
+                                cellLabelColor
+                            )}
+                        >
+                            {cell.sub}
+                        </span>
+                    ) : null}
+                </div>
+            ))}
+        </div>
+    );
+};
+
+export default StatStrip;

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -1,4 +1,5 @@
 import SEO from "@components/seo/page-seo";
+import { SectionEyebrow, SharpHeadline } from "@components/ui/design-system";
 import CtaArea from "@containers/cta/layout-01";
 import HeroArea from "@containers/hero/layout-07";
 import TimelineArea from "@containers/timeline";
@@ -70,40 +71,31 @@ const AboutUs: PageWithLayout = ({ data }) => {
                 </div>
             </div>
 
-            {/* Theory of Change Link - Enhanced */}
-            <div className="tw-container tw-my-16">
-                <div className="tw-mx-auto tw-max-w-4xl tw-rounded-2xl tw-border tw-border-gray-200 tw-bg-gradient-to-br tw-from-white tw-to-gray-50 tw-p-8 tw-shadow-xl tw-shadow-primary/5 md:tw-p-12">
-                    <div className="tw-text-center">
-                        <h2 className="tw-mb-4 tw-text-3xl tw-font-bold tw-text-secondary md:tw-text-4xl">
-                            Our Methodology
-                        </h2>
-                        <p className="tw-mb-8 tw-text-lg tw-text-body md:tw-text-xl">
-                            Want to understand how we transform veterans into software engineers?
-                            <br />
-                            Explore our comprehensive Theory of Change.
-                        </p>
+            {/* Theory of Change — Sharp link block */}
+            <section className="tw-py-20 md:tw-py-[120px]">
+                <div className="tw-container">
+                    <div className="tw-mx-auto tw-flex tw-max-w-4xl tw-flex-col tw-gap-6 tw-border-t tw-border-silver tw-pt-16 md:tw-flex-row md:tw-items-end md:tw-justify-between">
+                        <div className="tw-flex tw-flex-col tw-gap-4">
+                            <SectionEyebrow
+                                label="Methodology"
+                                subLabel="DOC 03 / THEORY OF CHANGE"
+                            />
+                            <SharpHeadline as="h2" size="h2" tone="navy">
+                                How we turn troops into
+                                <br />
+                                <span className="tw-text-red">software engineers</span>.
+                            </SharpHeadline>
+                        </div>
                         <Link
                             href="/theory-of-change"
-                            className="tw-group tw-inline-flex tw-items-center tw-gap-3 tw-rounded-lg tw-bg-primary tw-px-8 tw-py-4 tw-font-bold tw-text-white tw-shadow-lg tw-shadow-primary/25 tw-transition-all tw-duration-300 hover:tw-scale-105 hover:tw-bg-secondary hover:tw-shadow-xl hover:tw-shadow-primary/35 active:tw-scale-95"
+                            className="tw-inline-flex tw-items-center tw-gap-3 tw-border-2 tw-border-red tw-bg-red tw-px-7 tw-py-4 tw-font-heading tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.08em] tw-text-white tw-transition-colors hover:tw-border-red-crimson hover:tw-bg-red-crimson active:tw-scale-[0.97]"
                         >
-                            View Our Theory of Change
-                            <svg
-                                className="tw-h-5 tw-w-5 tw-transition-transform tw-duration-300 group-hover:tw-translate-x-1"
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M17 8l4 4m0 0l-4 4m4-4H3"
-                                />
-                            </svg>
+                            View Theory of Change
+                            <span aria-hidden="true">→</span>
                         </Link>
                     </div>
                 </div>
-            </div>
+            </section>
 
             <CtaArea data={content?.["cta-area"]} space="bottom" />
         </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import SEO from "@components/seo/page-seo";
+import { MonoMeta } from "@components/ui/design-system";
 import { EngagementModal } from "@components/ui/engagement-modal/EngagementModal";
 import BlogArea from "@containers/blog/layout-03";
 import BrandArea from "@containers/brand/layout-01";
@@ -54,6 +55,33 @@ const Home: PageProps = ({ data }) => {
     return (
         <>
             <SEO title="Home" />
+
+            {/* Operations brief — status bar across the top, SF/CG signature */}
+            <div className="tw-w-full tw-border-b tw-border-cream/10 tw-bg-navy tw-py-2.5">
+                <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-gap-x-6 tw-gap-y-2">
+                    <MonoMeta tone="bright" size="xs">
+                        <span className="tw-flex tw-items-center tw-gap-2">
+                            <span className="tw-relative tw-flex tw-h-[7px] tw-w-[7px]">
+                                <span className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-animate-ping tw-rounded-full tw-bg-red tw-opacity-75" />
+                                <span className="tw-relative tw-inline-flex tw-h-[7px] tw-w-[7px] tw-rounded-full tw-bg-red tw-shadow-[0_0_10px_#c5203e]" />
+                            </span>
+                            Live · 2026 Cohort
+                        </span>
+                    </MonoMeta>
+                    <MonoMeta tone="muted" size="xs">
+                        Placement · <span className="tw-text-cream">97%</span>
+                    </MonoMeta>
+                    <MonoMeta tone="muted" size="xs">
+                        Alumni earnings · <span className="tw-text-cream">$20M+</span>
+                    </MonoMeta>
+                    <MonoMeta tone="muted" size="xs">
+                        Status · <span className="tw-text-cream">501(c)(3)</span>
+                    </MonoMeta>
+                    <MonoMeta tone="muted" size="xs" className="tw-ml-auto">
+                        <span className="tw-text-cream">Applications Open</span>
+                    </MonoMeta>
+                </div>
+            </div>
 
             {/* Hero — full navy, dark-section for grain overlay */}
             <HeroArea data={content?.["hero-area"]} />

--- a/src/pages/mentor.tsx
+++ b/src/pages/mentor.tsx
@@ -2,6 +2,7 @@ import Breadcrumb from "@components/breadcrumb";
 import TextBlock from "@components/common/text-block";
 import MentorForm from "@components/forms/mentor-form";
 import SEO from "@components/seo/page-seo";
+import { SectionEyebrow, SharpHeadline } from "@components/ui/design-system";
 import CtaArea from "@containers/cta/layout-01";
 import FunfactArea from "@containers/funfact/layout-02";
 import GradationArea from "@containers/gradation";
@@ -66,24 +67,27 @@ const MentorPage: PageProps = ({ data }) => {
                 <FunfactArea data={content["funfact-area"]} />
             </Wrapper>
             <GradationArea data={content["gradation-area"]} />
-            <section className="tw-py-16 md:tw-py-20">
+            <section className="tw-py-20 md:tw-py-[120px]">
                 <div className="tw-container">
-                    <div className="tw-mx-auto tw-max-w-4xl">
-                        <h2 className="tw-mb-8 tw-text-3xl tw-font-bold tw-text-secondary md:tw-text-4xl">
-                            Who We&apos;re Looking For
-                        </h2>
-                        <ul className="tw-space-y-4 tw-text-lg tw-text-body">
+                    <div className="tw-mx-auto tw-flex tw-max-w-4xl tw-flex-col tw-gap-6">
+                        <SectionEyebrow label="Mentor Profile" subLabel="QUALIFICATIONS" />
+                        <SharpHeadline as="h2" size="h2" tone="navy">
+                            Who we&apos;re
+                            <br />
+                            <span className="tw-text-red">looking for.</span>
+                        </SharpHeadline>
+                        <ul className="tw-mt-6 tw-space-y-4 tw-font-body tw-text-charcoal tw-leading-[1.6] [font-size:clamp(16px,1.2vw,18px)]">
                             {lookingFor.map((item) => (
-                                <li key={item} className="tw-flex tw-gap-3">
+                                <li key={item} className="tw-flex tw-gap-4">
                                     <span
                                         aria-hidden="true"
-                                        className="tw-mt-2 tw-h-2 tw-w-2 tw-shrink-0 tw-rounded-full tw-bg-primary"
+                                        className="tw-mt-[10px] tw-h-[2px] tw-w-4 tw-shrink-0 tw-bg-red"
                                     />
                                     <span>{item}</span>
                                 </li>
                             ))}
                         </ul>
-                        <p className="tw-mt-8 tw-text-lg tw-text-body">
+                        <p className="tw-mt-6 tw-font-body tw-text-charcoal tw-leading-[1.6] [font-size:clamp(16px,1.2vw,18px)]">
                             You don&apos;t need to be a veteran to mentor. You need to be good at
                             your job and willing to invest time in someone who&apos;s working to get
                             where you are.
@@ -91,19 +95,26 @@ const MentorPage: PageProps = ({ data }) => {
                     </div>
                 </div>
             </section>
-            <section className="tw-bg-gray-50 tw-py-16 md:tw-py-20">
+            <section className="tw-bg-cream tw-py-20 md:tw-py-[120px]">
                 <div className="tw-container">
-                    <div className="tw-mx-auto tw-max-w-4xl">
-                        <h2 className="tw-mb-10 tw-text-3xl tw-font-bold tw-text-secondary md:tw-text-4xl">
-                            Why Engineers Mentor With Us
-                        </h2>
-                        <div className="tw-grid tw-gap-8 md:tw-grid-cols-2">
-                            <div className="tw-rounded-lg tw-border-l-4 tw-border-primary tw-bg-white tw-p-6 tw-shadow-sm">
-                                <h3 className="tw-mb-3 tw-text-xl tw-font-bold tw-text-secondary">
-                                    It&apos;s not charity work. It&apos;s engineering leadership
-                                    practice.
+                    <div className="tw-mx-auto tw-max-w-5xl">
+                        <div className="tw-flex tw-flex-col tw-gap-4">
+                            <SectionEyebrow
+                                label="Why Engineers Mentor"
+                                subLabel="LEADERSHIP / IMPACT"
+                            />
+                            <SharpHeadline as="h2" size="h2" tone="navy">
+                                It&apos;s practice.
+                                <br />
+                                <span className="tw-text-red">It&apos;s impact.</span>
+                            </SharpHeadline>
+                        </div>
+                        <div className="tw-mt-12 tw-grid tw-gap-6 md:tw-grid-cols-2">
+                            <article className="tw-border-t-2 tw-border-red tw-bg-white tw-p-8">
+                                <h3 className="tw-mb-4 tw-font-heading tw-text-[20px] tw-font-bold tw-uppercase tw-text-navy [letter-spacing:-0.01em] [line-height:1.2]">
+                                    Not charity. Engineering leadership practice.
                                 </h3>
-                                <p className="tw-text-body">
+                                <p className="tw-font-body tw-text-charcoal tw-leading-[1.6]">
                                     Mentoring a VWC troop is the closest thing to managing a junior
                                     engineer without the HR paperwork. You&apos;ll practice giving
                                     code reviews that teach, running 1-on-1s that develop people,
@@ -112,18 +123,18 @@ const MentorPage: PageProps = ({ data }) => {
                                     tell us that mentoring with VWC made them better at their day
                                     job.
                                 </p>
-                            </div>
-                            <div className="tw-rounded-lg tw-border-l-4 tw-border-primary tw-bg-white tw-p-6 tw-shadow-sm">
-                                <h3 className="tw-mb-3 tw-text-xl tw-font-bold tw-text-secondary">
+                            </article>
+                            <article className="tw-border-t-2 tw-border-red tw-bg-white tw-p-8">
+                                <h3 className="tw-mb-4 tw-font-heading tw-text-[20px] tw-font-bold tw-uppercase tw-text-navy [letter-spacing:-0.01em] [line-height:1.2]">
                                     Your time has measurable impact.
                                 </h3>
-                                <p className="tw-text-body">
+                                <p className="tw-font-body tw-text-charcoal tw-leading-[1.6]">
                                     This isn&apos;t a pen-pal program. Our troops ship code, pass
                                     technical interviews, and get hired. When your mentee lands a
                                     role at a company you respect, you&apos;ll know your Thursday
                                     evening code reviews had something to do with it.
                                 </p>
-                            </div>
+                            </article>
                         </div>
                     </div>
                 </div>

--- a/src/pages/programs.tsx
+++ b/src/pages/programs.tsx
@@ -1,5 +1,6 @@
 import ProgramCard from "@components/program-card";
 import SEO from "@components/seo/page-seo";
+import { MonoMeta, SectionEyebrow, SharpHeadline } from "@components/ui/design-system";
 import HeroArea from "@containers/hero/layout-07";
 import Layout from "@layout/layout-01";
 import { GetStaticProps, NextPage } from "next";
@@ -46,23 +47,41 @@ const ProgramsPage: PageWithLayout = ({ allPrograms, page }) => {
         <>
             <SEO title={`${page.title} | Vets Who Code`} />
             <HeroArea data={heroData} />
-            <main className="tw-container tw-mx-auto tw-max-w-6xl tw-px-4">
-                <div className="tw-mx-auto tw-mb-12 tw-mt-16 tw-max-w-4xl">
-                    <p className="tw-text-center tw-text-lg tw-text-gray-200">
-                        Our programs are designed to empower veterans with real-world skills,
-                        mentorship, and a supportive community—helping you transition, grow, and
-                        lead in tech.
-                    </p>
-                </div>
-                {/* Program Cards Grid - project card style */}
-                <section className="tw-mb-16">
-                    <div className="tw-grid tw-gap-8 sm:tw-grid-cols-2 lg:tw-grid-cols-3">
-                        {allPrograms.map((program) => (
-                            <ProgramCard key={program.slug} program={program} />
-                        ))}
+            <main>
+                {/* Programs index header — SF/CG aesthetic */}
+                <section className="tw-bg-cream tw-py-20 md:tw-py-[120px]">
+                    <div className="tw-container">
+                        <div className="tw-flex tw-flex-col tw-gap-6 md:tw-flex-row md:tw-items-end md:tw-justify-between">
+                            <div className="tw-flex tw-flex-col tw-gap-4">
+                                <SectionEyebrow
+                                    label="Programs Index"
+                                    subLabel={`${allPrograms.length} Active`}
+                                />
+                                <SharpHeadline as="h2" size="h2" tone="navy">
+                                    What we run.
+                                    <br />
+                                    <span className="tw-text-red">How troops engage.</span>
+                                </SharpHeadline>
+                            </div>
+                            <MonoMeta tone="muted" size="sm" className="md:tw-text-right">
+                                Sourced · VWC · Validated · Cohort Outcomes
+                            </MonoMeta>
+                        </div>
+
+                        <p className="tw-mt-10 tw-max-w-[720px] tw-font-body tw-text-charcoal tw-leading-[1.5] [font-size:clamp(18px,1.4vw,22px)]">
+                            Every program is mapped to verified labor-market demand. Pick the
+                            engagement that fits your stage: pre-troop assessment, full 17-week
+                            Hashflag Stack, or a Forward Deployed engagement through the Software
+                            Factory.
+                        </p>
+
+                        <div className="tw-mt-14 tw-grid tw-gap-8 sm:tw-grid-cols-2 lg:tw-grid-cols-3">
+                            {allPrograms.map((program) => (
+                                <ProgramCard key={program.slug} program={program} />
+                            ))}
+                        </div>
                     </div>
                 </section>
-                <hr className="tw-my-12 tw-border-t tw-border-gray-200" />
             </main>
         </>
     );

--- a/src/pages/sponsors.tsx
+++ b/src/pages/sponsors.tsx
@@ -1,45 +1,30 @@
 import SEO from "@components/seo/page-seo";
+import { MonoMeta, SectionEyebrow, SharpHeadline, StatStrip } from "@components/ui/design-system";
 import Layout from "@layout/layout-01";
 import type { NextPage } from "next";
-import React from "react";
-
-interface BenefitCardProps {
-    icon: string;
-    title: string;
-    description: string;
-}
 
 type PageWithLayout = NextPage & {
     Layout: typeof Layout;
 };
 
-const BenefitCard: React.FC<BenefitCardProps> = ({ icon, title, description }) => (
-    <div className="tw-text-center">
-        <div className="tw-mb-4 tw-flex tw-justify-center">
-            <i className={`${icon} tw-text-6xl tw-text-accent-dark`} />
-        </div>
-        <h3 className="tw-mb-2 tw-text-xl tw-font-bold tw-text-navy-deep">{title}</h3>
-        <p>{description}</p>
-    </div>
-);
-
-const benefits: BenefitCardProps[] = [
+const benefits = [
     {
-        icon: "fab fa-handshake",
-        title: "INTERNSHIPS",
+        label: "01",
+        title: "Internships",
         description:
-            "Test-drive the talent, increase productivity, enhance perspective with a diverse pool of candidates.",
+            "Test-drive the talent. Increase productivity. Diversify perspective with veteran candidates ready for production code on day one.",
     },
     {
-        icon: "fab fa-comments",
-        title: "GUARANTEED INTERVIEWS",
+        label: "02",
+        title: "Guaranteed interviews",
         description:
-            "Veterans are at risk of unemployment and underemployment. By guaranteeing an interview for veterans who successfully complete our curriculum you will increase their chances of securing gainful employment.",
+            "Veterans are at risk of unemployment and underemployment. Guarantee an interview for troops who complete the Hashflag Stack and you raise their odds of landing the role.",
     },
     {
-        icon: "fab fa-money-bill-alt",
-        title: "DONATIONS",
-        description: "Donate to the VWC organization to enable the training of more veterans.",
+        label: "03",
+        title: "Direct sponsorship",
+        description:
+            "Fund the program. Every dollar trains more veterans. EIN 86-2122804 — VWC is a 501(c)(3).",
     },
 ];
 
@@ -47,94 +32,174 @@ const SponsorPage: PageWithLayout = () => {
     return (
         <>
             <SEO title="Become a Sponsor" />
-            <div className="tw-min-h-screen tw-bg-white">
-                {/* Hero Section */}
-                <section className="tw-bg-navy-deep tw-py-16 tw-text-white">
-                    <div className="tw-container tw-mx-auto tw-px-4">
-                        <h1 className="tw-mb-4 tw-text-center tw-text-5xl tw-font-bold">
-                            WE WANT YOU
-                        </h1>
-                        <div className="tw-flex tw-justify-center">
-                            <div className="tw-relative tw--mb-20 tw-bg-accent tw-p-4 tw-text-secondary">
-                                <div className="tw-text-2xl tw-font-semibold">#VetsWhoCode</div>
-                            </div>
-                        </div>
-                    </div>
-                </section>
 
-                {/* Main Content */}
-                <main className="tw-container tw-mx-auto tw-px-4 tw-py-16">
-                    <div className="tw-mx-auto tw-mb-16 tw-max-w-4xl tw-text-center">
-                        <p className="tw-text-xl tw-text-navy-deep">
-                            After completing the VWC curriculum, our pool of veterans are able,
-                            willing, and highly qualified to enter the civilian workforce. Become a
-                            VWC Sponsor today and honor our veterans by making a real investment in
-                            helping their career by providing:
-                        </p>
-                    </div>
+            {/* Operations brief bar */}
+            <div className="tw-w-full tw-border-b tw-border-cream/10 tw-bg-navy tw-py-2.5">
+                <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-gap-x-6 tw-gap-y-2">
+                    <MonoMeta tone="bright" size="xs">
+                        <span className="tw-flex tw-items-center tw-gap-2">
+                            <span className="tw-relative tw-flex tw-h-[7px] tw-w-[7px]">
+                                <span className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-animate-ping tw-rounded-full tw-bg-red tw-opacity-75" />
+                                <span className="tw-relative tw-inline-flex tw-h-[7px] tw-w-[7px] tw-rounded-full tw-bg-red tw-shadow-[0_0_10px_#c5203e]" />
+                            </span>
+                            Live · Sponsor Brief v2.0
+                        </span>
+                    </MonoMeta>
+                    <MonoMeta tone="muted" size="xs">
+                        Classification · <span className="tw-text-cream">Public</span>
+                    </MonoMeta>
+                    <MonoMeta tone="muted" size="xs">
+                        EIN · <span className="tw-text-cream">86-2122804</span>
+                    </MonoMeta>
+                    <MonoMeta tone="muted" size="xs" className="tw-ml-auto">
+                        <span className="tw-text-cream">2026 Cohort Active</span>
+                    </MonoMeta>
+                </div>
+            </div>
 
-                    {/* Benefits Grid */}
-                    <div className="tw-mb-16 tw-grid tw-gap-8 md:tw-grid-cols-3">
-                        {benefits.map((benefit, index) => (
-                            <BenefitCard key={index} {...benefit} />
+            {/* Hero */}
+            <section className="dark-section tw-relative tw-overflow-hidden tw-bg-navy tw-py-20 md:tw-py-[120px]">
+                <div className="tw-container">
+                    <SectionEyebrow
+                        label="Sponsorship"
+                        subLabel="DOC 04 / BECOME A SPONSOR"
+                        tone="dark"
+                    />
+                    <SharpHeadline as="h1" size="h1" tone="white" className="tw-mt-6">
+                        We want you.
+                        <br />
+                        <span className="tw-text-red">#VetsWhoCode</span>
+                    </SharpHeadline>
+                    <p className="tw-mt-10 tw-max-w-[640px] tw-font-body tw-text-[#F8F9FA] tw-leading-[1.5] [font-size:clamp(18px,1.6vw,22px)]">
+                        After completing the Hashflag Stack, our troops are able, willing, and
+                        highly qualified to enter the civilian workforce. Sponsor VWC and make a
+                        real investment in their careers.
+                    </p>
+
+                    <div className="tw-mt-14">
+                        <StatStrip
+                            tone="dark"
+                            cells={[
+                                {
+                                    label: "Placement",
+                                    value: "97%",
+                                    sub: "of graduating troops",
+                                },
+                                {
+                                    label: "Alumni earnings",
+                                    value: "$20M+",
+                                    sub: "collective annual",
+                                },
+                                {
+                                    label: "Tax status",
+                                    value: "501(c)(3)",
+                                    sub: "EIN 86-2122804",
+                                },
+                                { label: "WOTC", value: "Eligible", sub: "no per-hire cap" },
+                            ]}
+                        />
+                    </div>
+                </div>
+            </section>
+
+            {/* Benefits */}
+            <section className="tw-bg-cream tw-py-20 md:tw-py-[120px]">
+                <div className="tw-container">
+                    <div className="tw-flex tw-flex-col tw-gap-4">
+                        <SectionEyebrow label="Engagement Options" subLabel="03 TRACKS" />
+                        <SharpHeadline as="h2" size="h2" tone="navy">
+                            Three ways
+                            <br />
+                            <span className="tw-text-red">to sponsor.</span>
+                        </SharpHeadline>
+                    </div>
+                    <div className="tw-mt-14 tw-grid tw-gap-8 md:tw-grid-cols-3">
+                        {benefits.map((benefit) => (
+                            <article
+                                key={benefit.label}
+                                className="tw-border-t-2 tw-border-red tw-bg-white tw-p-8"
+                            >
+                                <MonoMeta tone="muted" size="md">
+                                    Option {benefit.label}
+                                </MonoMeta>
+                                <h3 className="tw-mt-4 tw-font-heading tw-text-[22px] tw-font-bold tw-uppercase tw-text-navy [letter-spacing:-0.01em] [line-height:1.2]">
+                                    {benefit.title}
+                                </h3>
+                                <p className="tw-mt-4 tw-font-body tw-text-charcoal tw-leading-[1.6]">
+                                    {benefit.description}
+                                </p>
+                            </article>
                         ))}
                     </div>
+                </div>
+            </section>
 
-                    {/* Benefits Section */}
-                    <section className="tw-mb-16 tw-rounded-lg tw-bg-navy-midnight tw-p-8 tw-text-white">
-                        <h2 className="tw-mb-8 tw-text-center tw-text-3xl tw-font-bold">
-                            BENEFITS OF BECOMING A VWC SPONSOR
-                        </h2>
-                        <div className="tw-space-y-6">
-                            <p className="tw-text-lg">
-                                Add top-quality talent with a wealth of technical and soft skills to
-                                your organization today. Only 1/4 of the U.S. population meet the
-                                military's rigorous physical, behavioral and educational
-                                requirements.
+            {/* The case */}
+            <section className="dark-section tw-bg-navy tw-py-20 md:tw-py-[120px]">
+                <div className="tw-container">
+                    <div className="tw-mx-auto tw-max-w-3xl tw-flex tw-flex-col tw-gap-4">
+                        <SectionEyebrow label="Why Veterans Ship" subLabel="THE CASE" tone="dark" />
+                        <SharpHeadline as="h2" size="h2" tone="white">
+                            Veterans are not
+                            <br />
+                            <span className="tw-text-red">charity hires.</span>
+                        </SharpHeadline>
+                        <div className="tw-mt-8 tw-space-y-6 tw-font-body tw-text-[#F8F9FA] tw-leading-[1.65] [font-size:clamp(16px,1.2vw,18px)]">
+                            <p>
+                                Only 1 in 4 of the U.S. population meets the military&apos;s
+                                physical, behavioral, and educational standards. The people who do
+                                make it through are exceptionally well-trained, disciplined, team-
+                                oriented, goal-driven, and built for leadership.
                             </p>
-                            <p className="tw-text-lg">
-                                Individuals who have served in the military are exceptionally
-                                well-trained, highly-disciplined, accustomed to working in teams,
-                                goal-orientated and possess strong leadership qualities. This
-                                combination of skills and attributes aligns exceptionally well with
-                                the tech industry; veterans are already prepared to work harder and
-                                move faster on day one. Because employers prioritize attitude first
-                                and foremost, military members can fill critical positions and
-                                become valuable members of any team immediately.
+                            <p>
+                                That stack of attributes maps directly to the tech industry.
+                                Veterans are already prepared to work harder and move faster on day
+                                one. Because most engineering teams hire on attitude before skills,
+                                military members can step into critical roles and become valuable
+                                contributors immediately.
                             </p>
-                            <p className="tw-text-lg">
+                            <p>
                                 The Work Opportunity Tax Credit (WOTC) is a federal income tax
-                                credit available to employers who hire and retain veterans and
-                                individuals from targeted groups with significant barriers to
-                                employment. There is no limit on the number of individuals an
-                                employer can hire to qualify to claim the WOTC.
+                                credit available to employers who hire and retain veterans and other
+                                targeted groups facing significant barriers to employment. There is
+                                no per-hire cap.
                             </p>
                         </div>
-                    </section>
+                    </div>
+                </div>
+            </section>
 
-                    {/* Contact Section */}
-                    <section className="tw-rounded-lg tw-bg-secondary tw-p-8 tw-text-center tw-text-white">
-                        <h2 className="tw-mb-4 tw-text-2xl tw-font-bold">
-                            Contact Ayumi Bennett, Technical Program Manager
-                        </h2>
-                        <p className="tw-mb-6 tw-text-xl">
-                            ayumi@vetswhocode.io to learn how you can support a veteran today.
-                        </p>
-                        <p className="tw-text-sm">
-                            Vets Who Code Inc. is an exempt organization as described in Section
-                            501(c)(3) of the Internal Revenue Code. EIN 86-2122804
-                        </p>
-                    </section>
-                </main>
-
-                {/* Footer */}
-                <footer className="tw-bg-navy-deep tw-py-4 tw-text-center tw-text-white">
-                    <p>
-                        VISIT HTTPS://VETSWHOCODE.IO/SYLLABUS TO LEARN MORE ABOUT OUR FLAGSHIP
-                        CURRICULUM.
-                    </p>
-                </footer>
-            </div>
+            {/* Contact */}
+            <section className="cta-banner tw-bg-navy-deep tw-py-20 md:tw-py-[120px]">
+                <div className="tw-container">
+                    <div className="tw-mx-auto tw-max-w-3xl tw-text-center tw-flex tw-flex-col tw-gap-6">
+                        <SectionEyebrow
+                            label="Contact"
+                            subLabel="SPONSORSHIP DESK"
+                            tone="dark"
+                            align="center"
+                        />
+                        <SharpHeadline as="h2" size="h2" tone="white" align="center">
+                            Talk to
+                            <br />
+                            <span className="tw-text-red">Ayumi Bennett</span>.
+                        </SharpHeadline>
+                        <MonoMeta tone="bright" size="md">
+                            Technical Program Manager
+                        </MonoMeta>
+                        <a
+                            href="mailto:ayumi@vetswhocode.io"
+                            className="tw-inline-flex tw-self-center tw-items-center tw-gap-3 tw-border-2 tw-border-red tw-bg-red tw-px-7 tw-py-4 tw-font-heading tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.08em] tw-text-white tw-transition-colors hover:tw-border-red-crimson hover:tw-bg-red-crimson active:tw-scale-[0.97]"
+                        >
+                            ayumi@vetswhocode.io
+                            <span aria-hidden="true">→</span>
+                        </a>
+                        <MonoMeta tone="muted" size="xs" className="tw-mt-4">
+                            Vets Who Code Inc. · 501(c)(3) · EIN 86-2122804
+                        </MonoMeta>
+                    </div>
+                </div>
+            </section>
         </>
     );
 };


### PR DESCRIPTION
## Summary

The Software Factory and Career Guides pages set a distinctive aesthetic — Captain America / Obama campaign / Palantir vibe: sharp zero-radius, navy + red + gold palette, GothamPro uppercase headlines, mono section eyebrows with the 16×2 red bar, monospaced metadata, status bars with pulsing dots. Most of the rest of the site doesn't carry that language. This PR closes the gap.

Two layers of change: foundation (token additions + global CSS guards) and surface (new shared components + page-level refits on the highest-traffic pages).

## What changed

### Foundation

- `src/assets/css/globals.css` — full design-system token scales now in `:root` (extended navy/red/gold scales, neutrals, dark-surface, dark-mode aliases, hero gradient, type/space/radius/shadow/motion/layout/focus tokens). Button press-squish `:active { scale(0.95) }`. Generic `.eyebrow` selector with the 16×2 red bar. `@media (prefers-reduced-motion: reduce)` block (production gap from DESIGN_DOC).
- Site-wide guards in the same file:
  - Zero-radius default on Tailwind radius utilities (`tw-rounded`, `tw-rounded-md/lg/xl/2xl/3xl`, plus button/anchor `tw-rounded-full` unless `.vwc-avatar`).
  - No soft drop shadows on dark sections.
  - No pastel / bluish-purple gradient backgrounds (`tw-bg-gradient-to-*`) unless explicitly opted in via `.vwc-gradient`.
  - `.vwc-eyebrow` and `.vwc-sharp` opt-in utilities.

### Shared design-system components

`src/components/ui/design-system/`:

- `SectionEyebrow` — 16×2 red bar + mono label with optional sub-label, light/dark tone, left/center align.
- `SharpHeadline` — GothamPro uppercase clamp() sizing, h1/h2/h3 sizes, navy/white/cream tones, h1/h2/h3/h4 tag.
- `MonoMeta` — mono uppercase tracked labels, size (xs/sm/md), tone (muted/bright/accent/gold).
- `StatStrip` — bordered horizontal grid of stat cells (label/value/sub), light/dark tone, auto column count.

### Page refits

- **Home** (`src/pages/index.tsx`) — operations-brief status bar across the top with pulsing dot, key stats (placement, alumni earnings, 501(c)(3), applications open). Carries the SF/CG signature on the front door without rewriting all the home containers.
- **About-us** (`src/pages/about-us.tsx`) — replaced rounded gradient Theory-of-Change card with a sharp link block: section eyebrow, sharp headline with red emphasis, square red CTA button. Zero-radius, no shadow.
- **Sponsors** (`src/pages/sponsors.tsx`) — full rewrite. Operations brief bar, dark-section hero with eyebrow / sharp headline / stat strip (placement, alumni earnings, 501(c)(3), WOTC), three numbered "engagement options" cards on cream with red top-border, dark-section case for "veterans are not charity hires," sharp contact band.
- **Mentor** (`src/pages/mentor.tsx`) — replaced the two generic h2 sections with sharp eyebrow + headline clusters. Replaced rounded-lg cards with red-top-bordered sharp cards. Replaced bullet dots with the 2px red dash marker.
- **Programs** (`src/pages/programs.tsx`) — replaced generic intro paragraph with a Hashflag-style index header: eyebrow ("Programs Index"), sharp headline with red accent, mono meta caption.

## What is intentionally NOT in this PR

- Per-container rewrites (`@containers/hero/layout-*`, `funfact/*`, `event/*`, `service/*`, `testimonial/*`, etc.). The global CSS guards already sharpen them — full rewrites can land per-container in follow-ups.
- Pages I'd refit in follow-up PRs: `theory-of-change`, `team`, `media`, `faq`, `contact-us`, `apply` page-level chrome, `donate` page-level chrome, `join-our-community`, `programs/core-curriculum`. Each is a thin page composing legacy containers — refits go either at the container level or in dedicated PRs.
- Admin, auth-gated, course-detail, blog post template, profile, certificate, challenges, jobs, jodie, orders, store, events detail, zoom detail — different concerns, out of scope.

## Test plan

- [ ] `npm run typecheck` (pre-existing errors in test files + swagger types only — none introduced)
- [ ] `npm run lint` — Biome clean
- [ ] `npm test`
- [ ] `npm run dev` and visit:
  - [ ] `/` — operations-brief status bar visible above hero
  - [ ] `/about-us` — Theory-of-Change link block is sharp (no rounded card, no gradient)
  - [ ] `/sponsors` — full SF-style layout (operations bar, dark hero with stat strip, numbered tracks, dark case section, contact band)
  - [ ] `/mentor` — eyebrow + sharp headline sections, red-top-bordered cards
  - [ ] `/programs` — Hashflag-style index header above the grid
- [ ] macOS Reduce Motion → fade-ups + hover-transforms suppressed
- [ ] Tab through interactive elements → gold 3px focus ring with 2px offset visible
- [ ] Tab a primary button → press-squish `scale(0.95)` on active
- [ ] Verify no off-brand gradient backgrounds anywhere
- [ ] Verify zero-radius on cards / inputs / modals across the affected pages