### PR TITLE
chore(software-factory): Remove factory email from CTA bullets

### DIFF
--- a/src/containers/software-factory/cta/index.tsx
+++ b/src/containers/software-factory/cta/index.tsx
@@ -127,10 +127,6 @@ const CtaSection = () => {
                             <li>· Currently booking Q3 2026</li>
                             <li>· 2 squads available</li>
                             <li>· Average response time: 1 business day</li>
-                            <li>
-                                · Or email:{" "}
-                                <a href="mailto:factory@vetswhocode.io">factory@vetswhocode.io</a>
-                            </li>
                         </ul>
                     </div>
 


### PR DESCRIPTION
## Summary

Drops the "Or email: factory@vetswhocode.io" bullet from the Software Factory discovery CTA so the form is the single intake path.

## What changed

- `src/containers/software-factory/cta/index.tsx` — removed the `<li>` containing the mailto link. Surrounding copy and form unchanged.

## Test plan

- [ ] Visit `/programs/software-factory` (or wherever the CTA renders)
- [ ] Confirm the bullet list shows three items: "Currently booking Q3 2026," "2 squads available," "Average response time: 1 business day"
- [ ] Confirm the email line is gone and the form is the only submission path
- [ ] No layout shift or stray separators