### PR TITLE
feat(about): Rebuild About Us as long-form story document

### DIFF
--- a/src/containers/about/about.module.css
+++ b/src/containers/about/about.module.css
@@ -1,0 +1,246 @@
+/* Shared primitives for the About Us redesign. */
+
+@keyframes vwcBlink {
+    0%,
+    50% {
+        opacity: 1;
+    }
+    50.01%,
+    100% {
+        opacity: 0;
+    }
+}
+
+.blink {
+    display: inline-block;
+    animation: vwcBlink 1.2s steps(2) infinite;
+}
+
+.blinkSlow {
+    animation: vwcBlink 1.1s steps(2) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .blink,
+    .blinkSlow {
+        animation: none;
+        opacity: 1;
+    }
+}
+
+/* Pillar card — hover lifts, drops shadow, slides in a 2px red top border. */
+.pillarCard {
+    position: relative;
+    background: #fff;
+    border: 1px solid var(--silver, #dee2e6);
+    padding: 40px 36px 44px;
+    display: flex;
+    flex-direction: column;
+    transition:
+        transform 280ms cubic-bezier(0.3, 0.2, 0.3, 0.3),
+        box-shadow 280ms cubic-bezier(0.3, 0.2, 0.3, 0.3);
+    box-shadow: 0 1px 0 rgba(9, 31, 64, 0.02);
+}
+
+.pillarCard:hover,
+.pillarCard:focus-within {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 40px rgba(9, 31, 64, 0.1);
+}
+
+.pillarCard::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--red, #c5203e);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 320ms cubic-bezier(0.3, 0.2, 0.3, 0.3);
+}
+
+.pillarCard:hover::before,
+.pillarCard:focus-within::before {
+    transform: scaleX(1);
+}
+
+/* Spine chapter button — adjacent left-border accent when active. */
+.spineItem {
+    position: relative;
+    margin-left: -1px;
+    padding: 12px 0 12px 24px;
+    border-left: 2px solid transparent;
+    background: none;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 220ms ease;
+}
+
+.spineItemActive {
+    border-left-color: var(--red, #c5203e);
+}
+
+.spineItem:focus-visible {
+    outline: 2px solid var(--gold, #fdb330);
+    outline-offset: 4px;
+}
+
+/* JoinCTA pathway card — full surface flips to navy on hover/focus. */
+.pathwayCard {
+    position: relative;
+    background: #fff;
+    color: var(--ink, #1a1823);
+    border: 1px solid var(--silver, #dee2e6);
+    padding: 48px 40px 40px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    min-height: 360px;
+    text-decoration: none;
+    transition:
+        transform 320ms cubic-bezier(0.3, 0.2, 0.3, 0.3),
+        background-color 320ms cubic-bezier(0.3, 0.2, 0.3, 0.3),
+        color 320ms cubic-bezier(0.3, 0.2, 0.3, 0.3),
+        box-shadow 320ms cubic-bezier(0.3, 0.2, 0.3, 0.3);
+    box-shadow: 0 1px 0 rgba(9, 31, 64, 0.02);
+}
+
+.pathwayCard::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--red, #c5203e);
+}
+
+.pathwayCard:hover,
+.pathwayCard:focus-visible {
+    background: var(--navy, #091f40);
+    color: #fff;
+    transform: translateY(-4px);
+    box-shadow: 0 22px 50px rgba(9, 31, 64, 0.18);
+}
+
+.pathwayCard:hover .pathwayKind,
+.pathwayCard:focus-visible .pathwayKind,
+.pathwayCard:hover .pathwayCta,
+.pathwayCard:focus-visible .pathwayCta {
+    color: var(--gold, #fdb330);
+}
+
+.pathwayCard:hover .pathwayTitle,
+.pathwayCard:focus-visible .pathwayTitle {
+    color: #fff;
+}
+
+.pathwayCard:hover .pathwayBody,
+.pathwayCard:focus-visible .pathwayBody {
+    color: rgba(248, 249, 250, 0.85);
+}
+
+.pathwayCard:hover .pathwayCta,
+.pathwayCard:focus-visible .pathwayCta {
+    border-top-color: rgba(185, 214, 242, 0.2);
+}
+
+.pathwayCard:hover .pathwayArrow,
+.pathwayCard:focus-visible .pathwayArrow {
+    transform: translateX(6px);
+}
+
+.pathwayKind,
+.pathwayCta {
+    color: var(--red, #c5203e);
+    transition: color 240ms;
+}
+
+.pathwayCta {
+    border-top: 1px solid var(--silver, #dee2e6);
+    transition:
+        color 240ms,
+        border-top-color 240ms;
+}
+
+.pathwayTitle {
+    color: var(--navy, #091f40);
+    transition: color 240ms;
+}
+
+.pathwayBody {
+    color: var(--charcoal, #495057);
+    transition: color 240ms;
+}
+
+.pathwayArrow {
+    display: inline-block;
+    transition: transform 240ms;
+}
+
+/* Alumni cell hover tint. */
+.alumniCell {
+    background: #fff;
+    transition: background-color 200ms;
+}
+
+.alumniCell:hover {
+    background: rgba(197, 32, 62, 0.04);
+}
+
+/* Theory primary CTA — uses VWC button press semantics. */
+.theoryCtaPrimary {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+    background: var(--red, #c5203e);
+    color: #fff;
+    font-family: var(--font-headline);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 18px 28px;
+    border: 0;
+    border-radius: 0;
+    box-shadow: 0 8px 20px rgba(197, 32, 62, 0.3);
+    transition:
+        transform 200ms ease,
+        background-color 200ms ease;
+    text-decoration: none;
+}
+
+.theoryCtaPrimary:hover {
+    transform: translateY(-1px);
+    background: var(--red-crimson, #a51c30);
+}
+
+.theoryCtaPrimary:active {
+    transform: scale(0.97);
+}
+
+.theoryCtaSecondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+    background: transparent;
+    color: #fff;
+    font-family: var(--font-headline);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 18px 28px;
+    border: 1px solid rgba(185, 214, 242, 0.4);
+    border-radius: 0;
+    transition: border-color 200ms ease;
+    text-decoration: none;
+}
+
+.theoryCtaSecondary:hover {
+    border-color: #fff;
+}

--- a/src/containers/about/alumni.tsx
+++ b/src/containers/about/alumni.tsx
@@ -1,0 +1,145 @@
+import { scrollUpVariants } from "@utils/variants";
+import clsx from "clsx";
+import { motion } from "motion/react";
+import styles from "./about.module.css";
+
+const ALUMNI = [
+    "Microsoft",
+    "GitHub",
+    "Google",
+    "Salesforce",
+    "JP Morgan Chase",
+    "Amazon",
+    "Accenture",
+    "Deloitte",
+    "Booz Allen",
+    "Chewy",
+    "CBS Interactive",
+    "+ many more",
+];
+
+const Alumni = () => {
+    const lastRowStart = ALUMNI.length - 4;
+
+    return (
+        <section className="tw-bg-cream tw-py-[120px]" aria-labelledby="about-alumni-headline">
+            <div className="tw-mx-auto tw-max-w-[1320px] tw-px-6 md:tw-px-12">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-16 tw-grid tw-grid-cols-1 tw-gap-12 lg:tw-grid-cols-[1fr_1.4fr] lg:tw-items-end lg:tw-gap-20"
+                >
+                    <div>
+                        <span
+                            className="tw-inline-flex tw-items-center tw-gap-3 tw-text-[#6C757D]"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.16em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                            />
+                            Where Our Alumni Engineer
+                        </span>
+                        <h2
+                            id="about-alumni-headline"
+                            className="tw-m-0 tw-mt-6 tw-font-heading tw-uppercase tw-text-navy"
+                            style={{
+                                fontWeight: 800,
+                                fontSize: "clamp(36px, 4.4vw, 56px)",
+                                letterSpacing: "-0.025em",
+                                lineHeight: 1.05,
+                            }}
+                        >
+                            Service stripes,
+                            <br />
+                            now shipping code.
+                        </h2>
+                    </div>
+                    <p
+                        className="tw-m-0 tw-font-body tw-text-[#495057]"
+                        style={{ fontSize: 17, lineHeight: 1.7, maxWidth: 520 }}
+                    >
+                        A representative sample of the companies hiring VWC graduates. Roles span
+                        platform, mobile, data, and consulting. Names are listed for transparency,
+                        not endorsement.
+                    </p>
+                </motion.div>
+
+                <div
+                    className="tw-grid tw-grid-cols-2 sm:tw-grid-cols-3 lg:tw-grid-cols-4"
+                    style={{ border: "1px solid var(--silver)", background: "#fff" }}
+                >
+                    {ALUMNI.map((name, i) => {
+                        const inLastRow = i >= lastRowStart;
+                        const inLastCol = (i + 1) % 4 === 0;
+                        return (
+                            <div
+                                key={name}
+                                className={clsx(
+                                    styles.alumniCell,
+                                    "tw-relative tw-flex tw-flex-col tw-justify-between"
+                                )}
+                                style={{
+                                    padding: "44px 32px",
+                                    minHeight: 160,
+                                    borderRight: inLastCol ? "none" : "1px solid var(--silver)",
+                                    borderBottom: inLastRow ? "none" : "1px solid var(--silver)",
+                                }}
+                            >
+                                <span
+                                    className="tw-text-[#6C757D]"
+                                    style={{
+                                        position: "absolute",
+                                        top: 14,
+                                        right: 16,
+                                        fontFamily: "var(--font-mono)",
+                                        fontSize: 10,
+                                        letterSpacing: "0.14em",
+                                        opacity: 0.6,
+                                    }}
+                                >
+                                    {String(i + 1).padStart(2, "0")}
+                                </span>
+                                <h3
+                                    className="tw-m-0 tw-font-heading tw-text-navy"
+                                    style={{
+                                        fontWeight: 800,
+                                        fontSize: 24,
+                                        letterSpacing: "-0.01em",
+                                        lineHeight: 1.15,
+                                    }}
+                                >
+                                    {name}
+                                </h3>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div
+                    className="tw-mt-10 tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4 tw-text-[#6C757D]"
+                    style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 11,
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                    }}
+                >
+                    <span>
+                        ↪ Partial list · Hundreds more across SMBs, startups, and federal contracts
+                    </span>
+                    <span>Last updated · Q2 2026</span>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Alumni;

--- a/src/containers/about/hero.tsx
+++ b/src/containers/about/hero.tsx
@@ -1,0 +1,279 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+import styles from "./about.module.css";
+
+const monoEyebrow = {
+    fontFamily: "var(--font-mono)",
+    fontSize: 11,
+    letterSpacing: "0.18em",
+    textTransform: "uppercase" as const,
+    color: "rgba(185,214,242,0.65)",
+};
+
+const Hero = () => {
+    return (
+        <section
+            className="dark-section tw-relative tw-overflow-hidden tw-bg-navy tw-pb-[100px] tw-pt-[160px]"
+            aria-labelledby="about-hero-headline"
+        >
+            <span
+                aria-hidden="true"
+                className="tw-pointer-events-none tw-absolute tw-inset-0"
+                style={{
+                    background:
+                        "linear-gradient(135deg, rgba(9,31,64,0.92) 0%, rgba(6,26,64,0.88) 100%)",
+                }}
+            />
+
+            <div className="tw-relative tw-mx-auto tw-max-w-[1320px] tw-px-6 md:tw-px-12">
+                <div className="tw-grid tw-grid-cols-1 tw-gap-12 lg:tw-grid-cols-[1.25fr_1fr] lg:tw-items-center lg:tw-gap-20">
+                    <motion.div
+                        initial="offscreen"
+                        whileInView="onscreen"
+                        viewport={{ once: true, amount: 0.3 }}
+                        variants={scrollUpVariants}
+                    >
+                        <div
+                            className="tw-mb-9 tw-flex tw-flex-wrap tw-items-center tw-gap-3.5"
+                            style={monoEyebrow}
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                            />
+                            <span>Doc 01 · About Us</span>
+                            <span
+                                aria-hidden="true"
+                                className="tw-inline-block tw-h-1.5 tw-w-1.5 tw-rounded-full tw-bg-gold"
+                            />
+                            <span>Est. 2014 · 501(c)(3) · EIN 86-2122804</span>
+                        </div>
+
+                        <h1
+                            id="about-hero-headline"
+                            className="tw-m-0 tw-font-heading tw-uppercase tw-text-white"
+                            style={{
+                                fontWeight: 900,
+                                fontSize: "clamp(48px, 6.4vw, 92px)",
+                                lineHeight: 0.96,
+                                letterSpacing: "-0.025em",
+                            }}
+                        >
+                            We don&apos;t fill
+                            <br />
+                            seats. We build
+                            <br />
+                            <span className="tw-text-red">engineers</span>
+                            <span
+                                aria-hidden="true"
+                                className={styles.blink}
+                                style={{
+                                    verticalAlign: "baseline",
+                                    width: "0.55em",
+                                    height: "0.08em",
+                                    background: "var(--gold)",
+                                    marginLeft: "0.12em",
+                                }}
+                            />
+                        </h1>
+
+                        <p
+                            className="tw-mt-9 tw-font-body"
+                            style={{
+                                fontSize: 19,
+                                lineHeight: 1.7,
+                                color: "rgba(248,249,250,0.85)",
+                                maxWidth: 560,
+                            }}
+                        >
+                            Vets Who Code is a remote-first software engineering accelerator for
+                            U.S. military veterans and military spouses. Free. Selective.
+                            Outcome-focused. A nonprofit built by veterans who walked the same
+                            transition and refused to settle for thank-you-for-your-service.
+                        </p>
+
+                        <div
+                            className="tw-mt-12 tw-flex tw-flex-wrap tw-gap-9 tw-border-t tw-pt-8"
+                            style={{ borderColor: "rgba(185,214,242,0.12)" }}
+                        >
+                            {[
+                                { label: "Founded", value: "2014 · Decade strong" },
+                                { label: "Format", value: "17 weeks · Fully remote" },
+                                { label: "Cost to troops", value: "$0 · Always" },
+                            ].map((item) => (
+                                <div key={item.label} className="tw-flex tw-flex-col tw-gap-1.5">
+                                    <span
+                                        style={{
+                                            fontFamily: "var(--font-mono)",
+                                            fontSize: 10,
+                                            letterSpacing: "0.16em",
+                                            textTransform: "uppercase",
+                                            color: "rgba(185,214,242,0.55)",
+                                        }}
+                                    >
+                                        {item.label}
+                                    </span>
+                                    <span
+                                        className="tw-font-heading tw-text-white"
+                                        style={{
+                                            fontWeight: 700,
+                                            fontSize: 18,
+                                            letterSpacing: "-0.01em",
+                                        }}
+                                    >
+                                        {item.value}
+                                    </span>
+                                </div>
+                            ))}
+                        </div>
+                    </motion.div>
+
+                    <motion.aside
+                        aria-label="VWC Charter"
+                        initial="offscreen"
+                        whileInView="onscreen"
+                        viewport={{ once: true, amount: 0.3 }}
+                        variants={scrollUpVariants}
+                        className="tw-flex tw-flex-col tw-justify-between"
+                        style={{
+                            aspectRatio: "4 / 5",
+                            background:
+                                "linear-gradient(180deg, rgba(185,214,242,0.04) 0%, rgba(185,214,242,0.01) 100%)",
+                            border: "1px solid rgba(185,214,242,0.18)",
+                            padding: "40px 36px 32px",
+                        }}
+                    >
+                        <div
+                            className="tw-flex tw-items-center tw-justify-between tw-pb-[18px]"
+                            style={{
+                                ...monoEyebrow,
+                                fontSize: 10,
+                                borderBottom: "1px solid rgba(185,214,242,0.12)",
+                            }}
+                        >
+                            <span>Doc 01 · Charter</span>
+                            <span
+                                className="tw-text-gold"
+                                style={{
+                                    fontFamily: "var(--font-mono)",
+                                    fontSize: 9,
+                                    letterSpacing: "0.22em",
+                                    padding: "4px 8px",
+                                    border: "1px solid rgba(253,179,48,0.4)",
+                                }}
+                            >
+                                Ratified 2014
+                            </span>
+                        </div>
+
+                        <div className="tw-flex tw-flex-1 tw-flex-col tw-justify-center tw-py-8">
+                            <div
+                                className="tw-mb-[18px]"
+                                style={{
+                                    fontFamily: "var(--font-mono)",
+                                    fontSize: 10,
+                                    letterSpacing: "0.18em",
+                                    textTransform: "uppercase",
+                                    color: "rgba(185,214,242,0.6)",
+                                }}
+                            >
+                                The Tagline · Three Words
+                            </div>
+                            <p
+                                className="tw-m-0 tw-font-heading tw-uppercase tw-text-white"
+                                style={{
+                                    fontWeight: 900,
+                                    fontSize: "clamp(40px, 4vw, 56px)",
+                                    lineHeight: 0.98,
+                                    letterSpacing: "-0.025em",
+                                }}
+                            >
+                                Retool<span className="tw-text-gold">.</span>
+                                <br />
+                                Retrain<span className="tw-text-gold">.</span>
+                                <br />
+                                <span className="tw-text-red">Relaunch</span>
+                                <span className="tw-text-gold">.</span>
+                            </p>
+                            <p
+                                className="tw-mt-7 tw-font-body"
+                                style={{
+                                    fontSize: 14,
+                                    lineHeight: 1.7,
+                                    color: "rgba(248,249,250,0.75)",
+                                    paddingLeft: 14,
+                                    borderLeft: "2px solid var(--red)",
+                                    margin: "28px 0 0",
+                                }}
+                            >
+                                Our vision is to close the digital talent gap and ease career
+                                transition for military veterans through software development
+                                training.
+                            </p>
+                        </div>
+
+                        <div
+                            className="tw-flex tw-items-end tw-justify-between tw-gap-3 tw-pt-[22px]"
+                            style={{ borderTop: "1px solid rgba(185,214,242,0.12)" }}
+                        >
+                            <div className="tw-flex tw-flex-col tw-gap-1">
+                                <span
+                                    style={{
+                                        fontFamily: "var(--font-mono)",
+                                        fontSize: 9,
+                                        letterSpacing: "0.22em",
+                                        textTransform: "uppercase",
+                                        color: "rgba(185,214,242,0.5)",
+                                    }}
+                                >
+                                    Issued by
+                                </span>
+                                <span
+                                    className="tw-font-heading tw-text-white"
+                                    style={{
+                                        fontWeight: 700,
+                                        fontSize: 13,
+                                        letterSpacing: "-0.005em",
+                                    }}
+                                >
+                                    Vets Who Code · Founders
+                                </span>
+                            </div>
+                            <div
+                                aria-hidden="true"
+                                className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-text-center"
+                                style={{
+                                    width: 60,
+                                    height: 60,
+                                    border: "1px solid rgba(253,179,48,0.45)",
+                                    fontFamily: "var(--font-mono)",
+                                    fontSize: 8,
+                                    letterSpacing: "0.18em",
+                                    color: "var(--gold)",
+                                    lineHeight: 1.3,
+                                    padding: 6,
+                                }}
+                            >
+                                <span
+                                    className="tw-font-heading"
+                                    style={{
+                                        fontWeight: 900,
+                                        fontSize: 18,
+                                        color: "var(--gold)",
+                                        letterSpacing: "-0.02em",
+                                        marginBottom: 2,
+                                    }}
+                                >
+                                    501
+                                </span>
+                                <span>c · 3</span>
+                            </div>
+                        </div>
+                    </motion.aside>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Hero;

--- a/src/containers/about/join-cta.tsx
+++ b/src/containers/about/join-cta.tsx
@@ -1,0 +1,150 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+import Link from "next/link";
+import styles from "./about.module.css";
+
+interface Pathway {
+    kind: string;
+    title: string;
+    body: string;
+    cta: string;
+    href: string;
+}
+
+const PATHWAYS: Pathway[] = [
+    {
+        kind: "For Veterans · Military Spouses",
+        title: "Apply to the next cohort",
+        body: "If you're a veteran or military spouse staring at the civilian tech world and wondering where you fit — this is it. Cohorts begin three times a year. Selective. Free. Forever.",
+        cta: "Start your application",
+        href: "/apply",
+    },
+    {
+        kind: "For Senior Engineers",
+        title: "Mentor a troop",
+        body: "We need senior engineers who've made the leap themselves. Show up on Slack, run a code review, sit on a final project panel. Two hours a month moves someone's career.",
+        cta: "Become a mentor",
+        href: "/mentor",
+    },
+    {
+        kind: "For Allies · Donors · Companies",
+        title: "Fund the mission",
+        body: "Every troop graduates free. That's only possible because donors, alumni, and corporate partners fund the seats. Tax-deductible. EIN 86-2122804. Transparency seal current.",
+        cta: "Donate or sponsor",
+        href: "/donate",
+    },
+];
+
+const JoinCta = () => {
+    return (
+        <section
+            className="tw-bg-cream tw-pb-[140px] tw-pt-[120px]"
+            aria-labelledby="about-join-headline"
+        >
+            <div className="tw-mx-auto tw-max-w-[1320px] tw-px-6 md:tw-px-12">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-14 tw-grid tw-grid-cols-1 tw-gap-12 lg:tw-grid-cols-[1fr_1.4fr] lg:tw-items-end lg:tw-gap-20"
+                >
+                    <div>
+                        <span
+                            className="tw-inline-flex tw-items-center tw-gap-3 tw-text-[#6C757D]"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.16em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                            />
+                            Join the Mission · Three Pathways
+                        </span>
+                        <h2
+                            id="about-join-headline"
+                            className="tw-m-0 tw-mt-6 tw-font-heading tw-uppercase tw-text-navy"
+                            style={{
+                                fontWeight: 900,
+                                fontSize: "clamp(40px, 5vw, 64px)",
+                                letterSpacing: "-0.025em",
+                                lineHeight: 1.02,
+                            }}
+                        >
+                            Write the next <span className="tw-text-red">chapter</span>
+                            <br />
+                            of your mission.
+                        </h2>
+                    </div>
+                    <p
+                        className="tw-m-0 tw-font-body tw-text-[#495057]"
+                        style={{ fontSize: 17, lineHeight: 1.7, maxWidth: 520 }}
+                    >
+                        We can only place 97% of troops because of the people who show up around
+                        them. Pick your pathway — apply, mentor, or fund a seat. Every role moves a
+                        veteran forward.
+                    </p>
+                </motion.div>
+
+                <div className="tw-grid tw-grid-cols-1 tw-gap-8 lg:tw-grid-cols-3">
+                    {PATHWAYS.map((p, i) => (
+                        <Link key={p.title} href={p.href} className={styles.pathwayCard}>
+                            <span
+                                className={styles.pathwayKind}
+                                style={{
+                                    fontFamily: "var(--font-mono)",
+                                    fontSize: 11,
+                                    letterSpacing: "0.18em",
+                                    textTransform: "uppercase",
+                                }}
+                            >
+                                {String(i + 1).padStart(2, "0")} · {p.kind}
+                            </span>
+                            <h3
+                                className={`${styles.pathwayTitle} tw-m-0 tw-font-heading tw-uppercase`}
+                                style={{
+                                    fontWeight: 800,
+                                    fontSize: 32,
+                                    letterSpacing: "-0.02em",
+                                    lineHeight: 1.05,
+                                }}
+                            >
+                                {p.title}
+                            </h3>
+                            <p
+                                className={`${styles.pathwayBody} tw-m-0 tw-font-body`}
+                                style={{
+                                    fontSize: 15.5,
+                                    lineHeight: 1.7,
+                                    flex: 1,
+                                }}
+                            >
+                                {p.body}
+                            </p>
+                            <span
+                                className={`${styles.pathwayCta} tw-flex tw-items-center tw-gap-2.5 tw-pt-5`}
+                                style={{
+                                    fontFamily: "var(--font-mono)",
+                                    fontSize: 11,
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                }}
+                            >
+                                {p.cta}
+                                <span aria-hidden="true" className={styles.pathwayArrow}>
+                                    →
+                                </span>
+                            </span>
+                        </Link>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default JoinCta;

--- a/src/containers/about/pillars.tsx
+++ b/src/containers/about/pillars.tsx
@@ -1,0 +1,448 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+import styles from "./about.module.css";
+
+type Treatment = "syllabus" | "timezones" | "terminal";
+
+interface Pillar {
+    n: string;
+    kind: string;
+    title: string;
+    body: string;
+    footnote: string;
+    treatment: Treatment;
+}
+
+const PILLARS: Pillar[] = [
+    {
+        n: "01",
+        kind: "Pedagogy",
+        title: "Focus on Impactful Learning",
+        body: "128 Lightcast-validated skills. Every module maps to what employers are hiring for — nothing we teach is decorative. If our students can't make money with it, we don't bother teaching it.",
+        footnote: "128 skills · Lightcast-validated",
+        treatment: "syllabus",
+    },
+    {
+        n: "02",
+        kind: "Format",
+        title: "Learning Without Limits",
+        body: "Remote-first since 2014. Train from your kitchen table, a barracks, or a PCS move — the program travels with you. Virtual lectures, live mentorship, your timezone.",
+        footnote: "100% remote · since day one",
+        treatment: "timezones",
+    },
+    {
+        n: "03",
+        kind: "Outcome",
+        title: "Practical Coding Proficiency",
+        body: "Be a software engineer. You'll debug, design systems, and ship code under pressure — not memorize syntax for a certificate. Pair programming, code reviews, real production work.",
+        footnote: "Ship code · not certificates",
+        treatment: "terminal",
+    },
+];
+
+const SYLLABUS = [
+    { code: "M01", name: "Foundations · JavaScript", n: 14 },
+    { code: "M02", name: "React · TypeScript", n: 22 },
+    { code: "M03", name: "APIs · Data · Auth", n: 18 },
+    { code: "M04", name: "Testing · CI/CD", n: 16 },
+    { code: "M05", name: "Systems Design", n: 20 },
+    { code: "M06", name: "AI Integration", n: 14 },
+    { code: "M07", name: "Production Engineering", n: 12 },
+    { code: "M08", name: "Capstone · Crucible Project", n: 12 },
+];
+
+const TIMEZONES = [
+    { city: "Fort Bragg, NC", z: "EST  —  0900" },
+    { city: "Camp Pendleton", z: "PST  —  0600" },
+    { city: "JBLM, WA", z: "PST  —  0600" },
+    { city: "Ramstein AB, DE", z: "CET  —  1500" },
+    { city: "Okinawa, JP", z: "JST  —  2200" },
+    { city: "Honolulu, HI", z: "HST  —  0400" },
+];
+
+const TERMINAL_LINES: { kind: "prompt" | "out" | "ship"; text: string }[] = [
+    { kind: "prompt", text: "$ vwc deploy --troop=t-217" },
+    { kind: "out", text: "✓ PR opened    · 3 reviewers" },
+    { kind: "out", text: "✓ CI passing   · 482 tests · 14.2s" },
+    { kind: "out", text: "✓ Code review  · LGTM · sr.eng" },
+    { kind: "prompt", text: "$ git push origin main" },
+    { kind: "ship", text: "● SHIPPED to production" },
+];
+
+const visualHeader = {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    fontFamily: "var(--font-mono)",
+    fontSize: 9,
+    letterSpacing: "0.18em",
+    textTransform: "uppercase" as const,
+    color: "rgba(185,214,242,0.65)",
+    paddingBottom: 8,
+    borderBottom: "1px solid rgba(185,214,242,0.10)",
+};
+
+const visualFooter = {
+    paddingTop: 8,
+    borderTop: "1px solid rgba(185,214,242,0.10)",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    fontFamily: "var(--font-mono)",
+    fontSize: 9,
+    letterSpacing: "0.16em",
+    textTransform: "uppercase" as const,
+    color: "rgba(185,214,242,0.55)",
+};
+
+const SyllabusVisual = () => (
+    <div
+        className="tw-mb-7 tw-flex tw-flex-col tw-overflow-hidden tw-bg-navy tw-text-white"
+        style={{ aspectRatio: "5 / 3", padding: "18px 22px" }}
+    >
+        <div style={visualHeader}>
+            <span>Syllabus · 128 skills</span>
+            <span
+                className="tw-text-gold"
+                style={{
+                    border: "1px solid rgba(253,179,48,0.35)",
+                    padding: "2px 6px",
+                    fontSize: 8,
+                    letterSpacing: "0.16em",
+                }}
+            >
+                Lightcast ✓
+            </span>
+        </div>
+        <ul className="tw-m-0 tw-flex tw-flex-1 tw-list-none tw-flex-col tw-justify-center tw-p-0">
+            {SYLLABUS.map((m) => (
+                <li
+                    key={m.code}
+                    className="tw-grid tw-items-baseline tw-gap-2.5"
+                    style={{
+                        gridTemplateColumns: "32px 1fr auto",
+                        padding: "1.5px 0",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        color: "rgba(248,249,250,0.85)",
+                        letterSpacing: "0.03em",
+                    }}
+                >
+                    <span style={{ color: "rgba(185,214,242,0.5)", fontSize: 9 }}>{m.code}</span>
+                    <span className="tw-text-white">{m.name}</span>
+                    <span className="tw-text-gold" style={{ fontSize: 10, fontWeight: 600 }}>
+                        {m.n}
+                    </span>
+                </li>
+            ))}
+        </ul>
+        <div style={visualFooter}>
+            <span>Total · validated</span>
+            <span className="tw-text-red" style={{ fontSize: 11, letterSpacing: "0.10em" }}>
+                128 / 128
+            </span>
+        </div>
+    </div>
+);
+
+const TimezonesVisual = () => (
+    <div
+        className="tw-mb-7 tw-flex tw-flex-col tw-overflow-hidden tw-bg-navy tw-text-white"
+        style={{ aspectRatio: "5 / 3", padding: "18px 22px" }}
+    >
+        <div style={visualHeader}>
+            <span>Cohort · Active locations</span>
+            <span
+                aria-hidden="true"
+                style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: "50%",
+                    background: "#27c93f",
+                    boxShadow: "0 0 8px rgba(39,201,63,0.5)",
+                }}
+            />
+        </div>
+        <ul className="tw-m-0 tw-flex tw-flex-1 tw-list-none tw-flex-col tw-justify-center tw-p-0">
+            {TIMEZONES.map((t, i) => (
+                <li
+                    key={t.city}
+                    className="tw-grid tw-items-baseline tw-gap-2.5"
+                    style={{
+                        gridTemplateColumns: "22px 1fr auto",
+                        padding: "2.5px 0",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10.5,
+                        color: "rgba(248,249,250,0.85)",
+                        letterSpacing: "0.04em",
+                    }}
+                >
+                    <span style={{ color: "rgba(185,214,242,0.45)", fontSize: 9 }}>
+                        {String(i + 1).padStart(2, "0")}
+                    </span>
+                    <span className="tw-text-white">{t.city}</span>
+                    <span
+                        className="tw-text-gold"
+                        style={{ letterSpacing: "0.06em", fontSize: 10 }}
+                    >
+                        {t.z}
+                    </span>
+                </li>
+            ))}
+        </ul>
+        <div style={{ ...visualFooter, gap: 10 }}>
+            <span
+                aria-hidden="true"
+                style={{
+                    display: "inline-block",
+                    width: 8,
+                    height: 8,
+                    borderRadius: "50%",
+                    border: "1px solid var(--red)",
+                }}
+            />
+            <span className="tw-flex-1">Standup convenes · 1300Z daily</span>
+        </div>
+    </div>
+);
+
+const TerminalVisual = () => (
+    <div
+        className="tw-mb-7 tw-flex tw-flex-col tw-overflow-hidden"
+        style={{
+            aspectRatio: "5 / 3",
+            background: "#0c0a14",
+            border: "1px solid rgba(185,214,242,0.12)",
+        }}
+    >
+        <div
+            className="tw-flex tw-items-center tw-gap-1.5"
+            style={{
+                padding: "8px 12px",
+                background: "#161422",
+                borderBottom: "1px solid rgba(185,214,242,0.08)",
+            }}
+        >
+            {(["#ff5f56", "#ffbd2e", "#27c93f"] as const).map((c) => (
+                <span
+                    key={c}
+                    style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: "50%",
+                        background: c,
+                    }}
+                />
+            ))}
+            <span
+                className="tw-flex-1 tw-text-center"
+                style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 9,
+                    letterSpacing: "0.12em",
+                    color: "rgba(248,249,250,0.45)",
+                    marginRight: 30,
+                }}
+            >
+                final-project.t-217 — zsh
+            </span>
+        </div>
+        <div
+            className="tw-flex tw-flex-1 tw-flex-col tw-gap-0.5"
+            style={{
+                padding: "12px 16px 14px",
+                fontFamily: "var(--font-mono)",
+                fontSize: 11,
+                lineHeight: 1.55,
+            }}
+        >
+            {TERMINAL_LINES.map((l) => (
+                <div
+                    key={l.text}
+                    style={{
+                        color:
+                            l.kind === "prompt"
+                                ? "#fff"
+                                : l.kind === "ship"
+                                  ? "var(--red)"
+                                  : "rgba(185,214,242,0.7)",
+                        fontWeight: l.kind === "ship" ? 700 : 400,
+                        letterSpacing: l.kind === "ship" ? "0.08em" : 0,
+                        textTransform: l.kind === "ship" ? "uppercase" : "none",
+                        fontSize: 10.5,
+                        marginTop: l.kind === "ship" ? 4 : 0,
+                    }}
+                >
+                    {l.text}
+                </div>
+            ))}
+            <div className="tw-mt-0.5 tw-flex tw-items-center tw-gap-1.5" aria-hidden="true">
+                <span style={{ color: "#fff", fontSize: 10.5 }}>$</span>
+                <span
+                    className={styles.blinkSlow}
+                    style={{
+                        display: "inline-block",
+                        width: 7,
+                        height: 12,
+                        background: "var(--gold)",
+                    }}
+                />
+            </div>
+        </div>
+    </div>
+);
+
+const PillarVisual = ({ treatment }: { treatment: Treatment }) => {
+    if (treatment === "syllabus") return <SyllabusVisual />;
+    if (treatment === "timezones") return <TimezonesVisual />;
+    return <TerminalVisual />;
+};
+
+const Pillars = () => {
+    return (
+        <section className="tw-bg-cream tw-py-[120px]" aria-labelledby="about-pillars-headline">
+            <div className="tw-mx-auto tw-max-w-[1320px] tw-px-6 md:tw-px-12">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-grid tw-grid-cols-1 tw-gap-12 tw-border-b tw-pb-[72px] lg:tw-grid-cols-[1fr_1.4fr] lg:tw-items-end lg:tw-gap-20"
+                    style={{ borderColor: "rgba(9,31,64,0.12)" }}
+                >
+                    <div>
+                        <span
+                            className="tw-inline-flex tw-items-center tw-gap-3 tw-text-[#6C757D]"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.16em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                            />
+                            The Program · Three Promises
+                        </span>
+                        <h2
+                            id="about-pillars-headline"
+                            className="tw-m-0 tw-mt-6 tw-font-heading tw-uppercase tw-text-navy"
+                            style={{
+                                fontWeight: 900,
+                                fontSize: "clamp(40px, 4.8vw, 64px)",
+                                lineHeight: 1.02,
+                                letterSpacing: "-0.025em",
+                            }}
+                        >
+                            What we teach. How we teach it. Why it works.
+                        </h2>
+                    </div>
+                    <div>
+                        <p
+                            className="tw-m-0 tw-font-body tw-text-[#495057]"
+                            style={{ fontSize: 18, lineHeight: 1.7, maxWidth: 560 }}
+                        >
+                            We are not a bootcamp. We are a selective, outcome-focused training
+                            program that maps every hour of instruction to verified labor market
+                            demand. The shape of the program is the shape of these three
+                            commitments.
+                        </p>
+                        <span
+                            className="tw-mt-5 tw-inline-flex tw-items-center tw-gap-2.5 tw-text-[#6C757D]"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                style={{ width: 14, height: 1, background: "var(--red)" }}
+                            />
+                            Operating since 2014
+                        </span>
+                    </div>
+                </motion.div>
+
+                <div className="tw-mt-20 tw-grid tw-grid-cols-1 tw-gap-10 lg:tw-grid-cols-3">
+                    {PILLARS.map((p) => (
+                        <motion.article
+                            key={p.n}
+                            initial="offscreen"
+                            whileInView="onscreen"
+                            viewport={{ once: true, amount: 0.2 }}
+                            variants={scrollUpVariants}
+                            className={styles.pillarCard}
+                        >
+                            <div className="tw-mb-8 tw-flex tw-items-center tw-justify-between">
+                                <span
+                                    className="tw-font-heading tw-text-navy"
+                                    style={{
+                                        fontWeight: 900,
+                                        fontSize: 56,
+                                        letterSpacing: "-0.04em",
+                                        lineHeight: 1,
+                                    }}
+                                >
+                                    {p.n}
+                                </span>
+                                <span
+                                    className="tw-text-[#6C757D]"
+                                    style={{
+                                        fontFamily: "var(--font-mono)",
+                                        fontSize: 10,
+                                        letterSpacing: "0.18em",
+                                        textTransform: "uppercase",
+                                        padding: "6px 10px",
+                                        border: "1px solid var(--silver)",
+                                    }}
+                                >
+                                    {p.kind}
+                                </span>
+                            </div>
+                            <PillarVisual treatment={p.treatment} />
+                            <h3
+                                className="tw-mb-3.5 tw-mt-0 tw-font-heading tw-uppercase tw-text-navy"
+                                style={{
+                                    fontWeight: 800,
+                                    fontSize: 22,
+                                    letterSpacing: "-0.01em",
+                                    lineHeight: 1.15,
+                                }}
+                            >
+                                {p.title}
+                            </h3>
+                            <p
+                                className="tw-m-0 tw-font-body tw-text-[#495057]"
+                                style={{ fontSize: 15.5, lineHeight: 1.72 }}
+                            >
+                                {p.body}
+                            </p>
+                            <div
+                                className="tw-mt-auto tw-flex tw-items-center tw-justify-between tw-pt-6 tw-text-[#6C757D]"
+                                style={{
+                                    borderTop: "1px solid var(--silver)",
+                                    fontFamily: "var(--font-mono)",
+                                    fontSize: 10,
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                }}
+                            >
+                                <span>
+                                    <span className="tw-text-red">●</span>
+                                    &nbsp;&nbsp;{p.footnote}
+                                </span>
+                                <span>{p.n} / 03</span>
+                            </div>
+                        </motion.article>
+                    ))}
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Pillars;

--- a/src/containers/about/quote.tsx
+++ b/src/containers/about/quote.tsx
@@ -1,0 +1,90 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+
+const Quote = () => {
+    return (
+        <section
+            className="dark-section tw-relative tw-overflow-hidden tw-bg-navy tw-py-[140px] tw-text-white"
+            aria-labelledby="about-quote-headline"
+        >
+            <span
+                aria-hidden="true"
+                className="tw-pointer-events-none tw-absolute tw-select-none tw-font-heading"
+                style={{
+                    fontWeight: 900,
+                    fontSize: 480,
+                    lineHeight: 1,
+                    color: "rgba(197,32,62,0.10)",
+                    top: -80,
+                    left: 40,
+                }}
+            >
+                &ldquo;
+            </span>
+
+            <motion.div
+                initial="offscreen"
+                whileInView="onscreen"
+                viewport={{ once: true, amount: 0.3 }}
+                variants={scrollUpVariants}
+                className="tw-relative tw-mx-auto tw-max-w-[1100px] tw-px-6 tw-text-left md:tw-px-12"
+            >
+                <span
+                    className="tw-mb-9 tw-inline-flex tw-items-center tw-gap-3"
+                    style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 11,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                        color: "rgba(185,214,242,0.65)",
+                    }}
+                >
+                    <span
+                        aria-hidden="true"
+                        className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                    />
+                    Mission Statement
+                </span>
+                <blockquote
+                    id="about-quote-headline"
+                    className="tw-mb-12 tw-mt-0 tw-font-heading tw-text-white"
+                    style={{
+                        fontWeight: 700,
+                        fontSize: "clamp(36px, 4.6vw, 68px)",
+                        lineHeight: 1.12,
+                        letterSpacing: "-0.02em",
+                        maxWidth: 980,
+                        marginInlineStart: 0,
+                    }}
+                >
+                    We don&apos;t train veterans to fill seats. We train them to be{" "}
+                    <span className="tw-text-red">impactful</span> on their engineering teams at
+                    companies that shape the world.
+                </blockquote>
+                <div
+                    className="tw-flex tw-items-center tw-gap-[18px] tw-pt-8"
+                    style={{ borderTop: "1px solid rgba(185,214,242,0.12)" }}
+                >
+                    <span aria-hidden="true" className="tw-h-[2px] tw-w-8 tw-bg-red" />
+                    <span
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 11,
+                            letterSpacing: "0.16em",
+                            textTransform: "uppercase",
+                            color: "rgba(185,214,242,0.8)",
+                        }}
+                    >
+                        Vets Who Code &middot; Founding Charter
+                        <span style={{ color: "rgba(185,214,242,0.5)" }}>
+                            {" "}
+                            &mdash; ratified 2014
+                        </span>
+                    </span>
+                </div>
+            </motion.div>
+        </section>
+    );
+};
+
+export default Quote;

--- a/src/containers/about/stats.tsx
+++ b/src/containers/about/stats.tsx
@@ -1,0 +1,159 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+
+const STATS = [
+    {
+        n: "97",
+        suffix: "%",
+        label: "Placement rate",
+        sub: "Of graduates land tech roles within months of completion.",
+    },
+    {
+        n: "$20M",
+        suffix: "+",
+        label: "Alumni earnings",
+        sub: "Collective compensation earned by VWC alumni to date.",
+    },
+    {
+        n: "500",
+        suffix: "+",
+        label: "Veterans by 2030",
+        sub: "Our scale-by-depth target. Small cohorts. Real outcomes.",
+    },
+    {
+        n: "$0",
+        suffix: "",
+        label: "Cost to troops",
+        sub: "Always free. Funded by donors, alumni, and corporate partners.",
+    },
+];
+
+const Stats = () => {
+    return (
+        <section
+            className="dark-section tw-relative tw-overflow-hidden tw-bg-navy tw-py-[100px] tw-text-white"
+            style={{
+                borderTop: "1px solid rgba(185,214,242,0.08)",
+                borderBottom: "1px solid rgba(185,214,242,0.08)",
+            }}
+            aria-labelledby="about-stats-headline"
+        >
+            <div className="tw-relative tw-mx-auto tw-max-w-[1320px] tw-px-6 md:tw-px-12">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-14 tw-flex tw-flex-wrap tw-items-baseline tw-justify-between tw-gap-10 tw-pb-14"
+                    style={{ borderBottom: "1px solid rgba(185,214,242,0.12)" }}
+                >
+                    <span
+                        className="tw-inline-flex tw-items-center tw-gap-3"
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 11,
+                            letterSpacing: "0.18em",
+                            textTransform: "uppercase",
+                            color: "rgba(185,214,242,0.65)",
+                        }}
+                    >
+                        <span
+                            aria-hidden="true"
+                            className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                        />
+                        The Receipts · A Decade On
+                    </span>
+                    <h2
+                        id="about-stats-headline"
+                        className="tw-m-0 tw-font-heading tw-uppercase tw-text-white"
+                        style={{
+                            fontWeight: 800,
+                            fontSize: "clamp(28px, 3vw, 40px)",
+                            letterSpacing: "-0.02em",
+                        }}
+                    >
+                        We surface our numbers, openly.
+                    </h2>
+                </motion.div>
+
+                <div className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-4">
+                    {STATS.map((s, i) => (
+                        <motion.div
+                            key={s.label}
+                            initial="offscreen"
+                            whileInView="onscreen"
+                            viewport={{ once: true, amount: 0.3 }}
+                            variants={scrollUpVariants}
+                            className="tw-relative"
+                            style={{
+                                padding:
+                                    i === STATS.length - 1 ? "12px 0 12px 0" : "12px 36px 12px 0",
+                                borderRight:
+                                    i === STATS.length - 1
+                                        ? "none"
+                                        : "1px solid rgba(185,214,242,0.10)",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="tw-absolute tw-left-0 tw-top-0 tw-h-[2px] tw-w-8 tw-bg-red"
+                            />
+                            <span
+                                className="tw-mb-2.5 tw-block"
+                                style={{
+                                    fontFamily: "var(--font-mono)",
+                                    fontSize: 11,
+                                    letterSpacing: "0.14em",
+                                    textTransform: "uppercase",
+                                    color: "rgba(185,214,242,0.7)",
+                                }}
+                            >
+                                {s.label}
+                            </span>
+                            <span
+                                className="tw-mb-[18px] tw-block tw-font-heading tw-text-white"
+                                style={{
+                                    fontWeight: 900,
+                                    fontSize: "clamp(56px, 6vw, 88px)",
+                                    lineHeight: 0.95,
+                                    letterSpacing: "-0.04em",
+                                }}
+                            >
+                                {s.n}
+                                <span className="tw-text-red">{s.suffix}</span>
+                            </span>
+                            <p
+                                className="tw-m-0 tw-font-body"
+                                style={{
+                                    fontSize: 14,
+                                    lineHeight: 1.55,
+                                    color: "rgba(248,249,250,0.6)",
+                                    maxWidth: 220,
+                                }}
+                            >
+                                {s.sub}
+                            </p>
+                        </motion.div>
+                    ))}
+                </div>
+
+                <div
+                    className="tw-mt-14 tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4 tw-pt-8"
+                    style={{
+                        borderTop: "1px solid rgba(185,214,242,0.08)",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 11,
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: "rgba(185,214,242,0.55)",
+                    }}
+                >
+                    <span>EIN 86-2122804 · 501(c)(3) Nonprofit · Tax-deductible</span>
+                    <span>Source · Internal cohort data · Updated quarterly</span>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Stats;

--- a/src/containers/about/story.tsx
+++ b/src/containers/about/story.tsx
@@ -1,0 +1,378 @@
+import clsx from "clsx";
+import { useCallback, useEffect, useRef, useState } from "react";
+import styles from "./about.module.css";
+
+interface Chapter {
+    n: string;
+    arc: string;
+    title: string;
+    img: string;
+    body: string[];
+    callout: { value: string; label: string };
+}
+
+const CHAPTERS: Chapter[] = [
+    {
+        n: "01",
+        arc: "The Ordinary World",
+        title: "Where We Started",
+        img: "https://res.cloudinary.com/vetswhocode/image/upload/v1746583122/8_azjgpx.png",
+        body: [
+            "For years, veterans like us stepped out of uniform and into a civilian job market that spoke a language we didn't yet understand. Recruiters skimmed past our leadership stories. Résumés disappeared into applicant-tracking systems. The gap between our disciplined experience and the tech roles we wanted felt wider than the ocean we once crossed.",
+            "Nobody was solving it — not the transition programs, not the nonprofits collecting thank-you-for-your-service donations, not the bootcamps charging $20K for a certificate. So in 2014, we decided to build the solution ourselves.",
+        ],
+        callout: {
+            value: "$20K",
+            label: "What a typical bootcamp charged. We do it free.",
+        },
+    },
+    {
+        n: "02",
+        arc: "The Call to Adventure",
+        title: "Building Our Bridge",
+        img: "https://res.cloudinary.com/vetswhocode/image/upload/v1746583127/10_khmgby.png",
+        body: [
+            "Instead of settling for 'thanks for your service,' a handful of us gathered on late-night video calls and asked: what if we built our own bridge? That question became Vets Who Code — a mission to transform military grit into world-class software engineering skill.",
+            "Could a free, fully remote program really move veterans into top tech jobs? We were told it was impossible without massive tuition or fancy campuses. We pushed forward anyway. Missions rarely start with perfect resources.",
+        ],
+        callout: {
+            value: "2014",
+            label: "Year zero. A handful of vets. A laptop each. A Slack channel.",
+        },
+    },
+    {
+        n: "03",
+        arc: "Tests and Allies",
+        title: "The Journey",
+        img: "https://res.cloudinary.com/vetswhocode/image/upload/v1746583121/6_qi229q.png",
+        body: [
+            "Our mentors emerged from the veteran community itself: senior engineers, tech leads, and hiring managers who had already made the leap. They guided us in translating NATO phonetics into JavaScript functions, after-action reviews into code reviews, and squad tactics into agile collaboration.",
+            "Daily pair-programming sessions, weekend hack-a-thons, live code audits. Time-zone differences, career doubts, and imposter syndrome tried to slow us down — but the ally network grew, and mentors showed up on Slack at zero-dark-thirty to keep us moving.",
+        ],
+        callout: {
+            value: "0-DARK-30",
+            label: "When our mentors show up. The Slack never sleeps.",
+        },
+    },
+    {
+        n: "04",
+        arc: "The Reward and Return",
+        title: "Full Circle Impact",
+        img: "https://res.cloudinary.com/vetswhocode/image/upload/v1746590042/4_a79tb5.png",
+        body: [
+            "Every veteran faces a crucible project — a full-stack application built under real-world constraints. Graduates emerge with production portfolios, lifelong allies, and offer letters that turn service stripes into six-figure salaries.",
+            "Collectively, alumni have earned $20M+ and now ship code at Microsoft, GitHub, Salesforce, JP Morgan Chase, Chewy, Apple, Google, and CBS Interactive. But the journey doesn't end at first employment. Alumni return as mentors and donors, passing on their knowledge and funding the next cohort. The pipeline feeds itself. That's by design.",
+        ],
+        callout: {
+            value: "$20M+",
+            label: "Collective alumni earnings. Mentors. Donors. Next cohort fuel.",
+        },
+    },
+    {
+        n: "05",
+        arc: "Return with the Elixir",
+        title: "Our Vision Forward",
+        img: "https://res.cloudinary.com/vetswhocode/image/upload/v1746590043/9_ahefah.png",
+        body: [
+            "Veterans are stakeholders, not charity cases. That principle drives everything we build.",
+            "A decade in, Vets Who Code has evolved into a remote-first, AI-enabled nonprofit that blends human mentorship with machine intelligence to personalize learning and keep our curriculum evergreen. By 2030 we will have trained 500+ veterans as software engineers, generated $50M+ in collective alumni earnings, and maintained a 97% placement rate — built on small cohorts, not mass enrollment. We scale depth, not volume.",
+            "If you're a veteran staring at the civilian tech world and wondering where you fit — this is it. Apply. Show up. Write the next chapter of your mission in code.",
+        ],
+        callout: {
+            value: "500+",
+            label: "Veterans engineered by 2030. Scale by depth, not volume.",
+        },
+    },
+];
+
+const Story = () => {
+    const [active, setActive] = useState(0);
+    const refs = useRef<(HTMLElement | null)[]>([]);
+
+    useEffect(() => {
+        if (typeof IntersectionObserver === "undefined") return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((e) => {
+                    if (e.isIntersecting) {
+                        const idx = Number(
+                            (e.target as HTMLElement).getAttribute("data-chapter-idx")
+                        );
+                        setActive(idx);
+                    }
+                });
+            },
+            { rootMargin: "-30% 0px -55% 0px", threshold: 0 }
+        );
+        for (const el of refs.current) {
+            if (el) observer.observe(el);
+        }
+        return () => observer.disconnect();
+    }, []);
+
+    const goTo = useCallback((i: number) => {
+        const el = refs.current[i];
+        if (!el) return;
+        const top = el.getBoundingClientRect().top + window.scrollY - 100;
+        window.scrollTo({ top, behavior: "smooth" });
+    }, []);
+
+    return (
+        <section className="tw-bg-cream tw-py-[120px]" aria-labelledby="about-story-headline">
+            <div className="tw-mx-auto tw-max-w-[1320px] tw-px-6 md:tw-px-12">
+                <div className="tw-mb-24 tw-grid tw-grid-cols-1 tw-gap-12 lg:tw-grid-cols-[1fr_1.4fr] lg:tw-items-end lg:tw-gap-20">
+                    <div>
+                        <span
+                            className="tw-inline-flex tw-items-center tw-gap-3 tw-text-[#6C757D]"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.16em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                            />
+                            Doc 02 · Our Story
+                        </span>
+                        <h2
+                            id="about-story-headline"
+                            className="tw-m-0 tw-mt-6 tw-font-heading tw-uppercase tw-text-navy"
+                            style={{
+                                fontWeight: 900,
+                                fontSize: "clamp(44px, 5.2vw, 72px)",
+                                letterSpacing: "-0.025em",
+                                lineHeight: 1.02,
+                            }}
+                        >
+                            A decade of <span className="tw-text-red">mission</span>,
+                            <br />
+                            told in five chapters.
+                        </h2>
+                    </div>
+                    <p
+                        className="tw-m-0 tw-font-body tw-text-[#495057]"
+                        style={{ fontSize: 18, lineHeight: 1.7, maxWidth: 560 }}
+                    >
+                        We built Vets Who Code because nobody else was going to. What follows is the
+                        unedited version of how a Slack channel turned into a software engineering
+                        accelerator that placed nearly every troop who finished it.
+                    </p>
+                </div>
+
+                <div className="tw-grid tw-grid-cols-1 tw-items-start tw-gap-12 lg:tw-grid-cols-[260px_1fr] lg:tw-gap-24">
+                    <aside
+                        aria-label="Chapter navigation"
+                        className="lg:tw-sticky"
+                        style={{ top: 120, alignSelf: "start" }}
+                    >
+                        <div
+                            className="tw-mb-6 tw-flex tw-items-center tw-gap-2.5 tw-text-[#6C757D]"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 10,
+                                letterSpacing: "0.18em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                style={{ width: 14, height: 1, background: "var(--red)" }}
+                            />
+                            Chapters
+                        </div>
+                        <ol
+                            className="tw-m-0 tw-list-none tw-p-0"
+                            style={{ borderLeft: "1px solid rgba(9,31,64,0.12)" }}
+                        >
+                            {CHAPTERS.map((c, i) => (
+                                <li key={c.n}>
+                                    <button
+                                        type="button"
+                                        onClick={() => goTo(i)}
+                                        className={clsx(
+                                            styles.spineItem,
+                                            active === i && styles.spineItemActive
+                                        )}
+                                        aria-current={active === i ? "true" : undefined}
+                                    >
+                                        <span
+                                            className="tw-mb-1 tw-block"
+                                            style={{
+                                                fontFamily: "var(--font-mono)",
+                                                fontSize: 10,
+                                                letterSpacing: "0.16em",
+                                                textTransform: "uppercase",
+                                                color: active === i ? "var(--red)" : "var(--slate)",
+                                                fontWeight: 500,
+                                                transition: "color 220ms",
+                                            }}
+                                        >
+                                            Ch. {c.n} · {c.arc}
+                                        </span>
+                                        <span
+                                            className="tw-block tw-font-heading"
+                                            style={{
+                                                fontWeight: active === i ? 700 : 500,
+                                                fontSize: 14,
+                                                letterSpacing: "-0.005em",
+                                                color:
+                                                    active === i
+                                                        ? "var(--navy)"
+                                                        : "var(--charcoal)",
+                                                lineHeight: 1.3,
+                                                transition: "all 220ms",
+                                            }}
+                                        >
+                                            {c.title}
+                                        </span>
+                                    </button>
+                                </li>
+                            ))}
+                        </ol>
+                    </aside>
+
+                    <div className="tw-flex tw-flex-col" style={{ gap: 96 }}>
+                        {CHAPTERS.map((c, i) => (
+                            <article
+                                key={c.n}
+                                ref={(el) => {
+                                    refs.current[i] = el;
+                                }}
+                                data-chapter-idx={i}
+                                style={{ scrollMarginTop: 100 }}
+                            >
+                                <div
+                                    className="tw-mb-8 tw-flex tw-flex-wrap tw-items-baseline tw-gap-6 tw-pb-6"
+                                    style={{
+                                        borderBottom: "1px solid rgba(9,31,64,0.12)",
+                                    }}
+                                >
+                                    <span
+                                        className="tw-font-heading tw-text-red"
+                                        style={{
+                                            fontWeight: 900,
+                                            fontSize: 56,
+                                            letterSpacing: "-0.04em",
+                                            lineHeight: 1,
+                                        }}
+                                    >
+                                        {c.n}
+                                    </span>
+                                    <span
+                                        className="tw-text-[#6C757D]"
+                                        style={{
+                                            fontFamily: "var(--font-mono)",
+                                            fontSize: 11,
+                                            letterSpacing: "0.18em",
+                                            textTransform: "uppercase",
+                                        }}
+                                    >
+                                        <span
+                                            aria-hidden="true"
+                                            className="tw-mr-3 tw-inline-block tw-h-1.5 tw-w-1.5 tw-rounded-full tw-bg-gold tw-align-middle"
+                                        />
+                                        {c.arc}
+                                    </span>
+                                </div>
+                                <h3
+                                    className="tw-mb-9 tw-mt-0 tw-font-heading tw-uppercase tw-text-navy"
+                                    style={{
+                                        fontWeight: 800,
+                                        fontSize: "clamp(32px, 3.6vw, 48px)",
+                                        letterSpacing: "-0.02em",
+                                        lineHeight: 1.05,
+                                    }}
+                                >
+                                    {c.title}
+                                </h3>
+
+                                <div className="tw-grid tw-grid-cols-1 tw-items-start tw-gap-10 lg:tw-grid-cols-2 lg:tw-gap-14">
+                                    <div className="lg:tw-sticky" style={{ top: 140 }}>
+                                        <div
+                                            className="tw-relative tw-overflow-hidden tw-bg-navy"
+                                            style={{ aspectRatio: "4 / 5" }}
+                                        >
+                                            <span
+                                                aria-hidden="true"
+                                                className="tw-absolute tw-left-0 tw-top-0 tw-z-10 tw-h-[2px] tw-w-14 tw-bg-red"
+                                            />
+                                            <img
+                                                src={c.img}
+                                                alt=""
+                                                className="tw-absolute tw-inset-0 tw-h-full tw-w-full tw-object-cover"
+                                            />
+                                        </div>
+                                        <div
+                                            className="tw-mt-4 tw-flex tw-items-center tw-gap-2.5 tw-text-[#6C757D]"
+                                            style={{
+                                                fontFamily: "var(--font-mono)",
+                                                fontSize: 10,
+                                                letterSpacing: "0.16em",
+                                                textTransform: "uppercase",
+                                            }}
+                                        >
+                                            <span
+                                                aria-hidden="true"
+                                                style={{
+                                                    width: 14,
+                                                    height: 1,
+                                                    background: "var(--red)",
+                                                }}
+                                            />
+                                            Fig. {c.n} — {c.title}
+                                        </div>
+                                    </div>
+                                    <div>
+                                        <div
+                                            className="tw-font-body tw-text-ink"
+                                            style={{ fontSize: 17, lineHeight: 1.74 }}
+                                        >
+                                            {c.body.map((para) => (
+                                                <p
+                                                    key={para.slice(0, 32)}
+                                                    style={{ margin: "0 0 22px" }}
+                                                >
+                                                    {para}
+                                                </p>
+                                            ))}
+                                        </div>
+                                        <div
+                                            className="tw-mt-9 tw-bg-white tw-text-navy"
+                                            style={{
+                                                padding: "24px 28px",
+                                                borderLeft: "2px solid var(--red)",
+                                                fontFamily: "var(--font-mono)",
+                                                fontSize: 12,
+                                                letterSpacing: "0.10em",
+                                                textTransform: "uppercase",
+                                                lineHeight: 1.6,
+                                                fontWeight: 500,
+                                            }}
+                                        >
+                                            <span
+                                                className="tw-mb-1.5 tw-block tw-font-heading tw-text-red"
+                                                style={{
+                                                    fontSize: 28,
+                                                    fontWeight: 900,
+                                                    letterSpacing: "-0.02em",
+                                                }}
+                                            >
+                                                {c.callout.value}
+                                            </span>
+                                            {c.callout.label}
+                                        </div>
+                                    </div>
+                                </div>
+                            </article>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Story;

--- a/src/containers/about/theory.tsx
+++ b/src/containers/about/theory.tsx
@@ -1,0 +1,94 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+import Link from "next/link";
+import styles from "./about.module.css";
+
+const Theory = () => {
+    return (
+        <section
+            className="dark-section tw-relative tw-overflow-hidden tw-bg-navy tw-py-[100px] tw-text-white"
+            style={{ borderTop: "1px solid rgba(185,214,242,0.08)" }}
+            aria-labelledby="about-theory-headline"
+        >
+            <span
+                aria-hidden="true"
+                className="tw-absolute tw-left-0 tw-top-0 tw-h-px tw-w-12 tw-bg-red"
+            />
+            <div className="tw-relative tw-mx-auto tw-grid tw-max-w-[1320px] tw-grid-cols-1 tw-gap-12 tw-px-6 md:tw-px-12 lg:tw-grid-cols-[1fr_1.4fr] lg:tw-items-center lg:tw-gap-20">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                >
+                    <span
+                        className="tw-mb-6 tw-inline-flex tw-items-center tw-gap-3"
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 11,
+                            letterSpacing: "0.18em",
+                            textTransform: "uppercase",
+                            color: "rgba(185,214,242,0.65)",
+                        }}
+                    >
+                        <span
+                            aria-hidden="true"
+                            className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                        />
+                        Methodology · Doc 03
+                    </span>
+                    <h2
+                        id="about-theory-headline"
+                        className="tw-m-0 tw-font-heading tw-uppercase tw-text-white"
+                        style={{
+                            fontWeight: 900,
+                            fontSize: "clamp(36px, 4.4vw, 56px)",
+                            lineHeight: 1.02,
+                            letterSpacing: "-0.025em",
+                        }}
+                    >
+                        How we turn troops into{" "}
+                        <span className="tw-text-red">software engineers.</span>
+                    </h2>
+                </motion.div>
+
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-flex tw-flex-col tw-gap-8"
+                >
+                    <p
+                        className="tw-m-0 tw-font-body"
+                        style={{
+                            fontSize: 17,
+                            lineHeight: 1.7,
+                            color: "rgba(248,249,250,0.85)",
+                            maxWidth: 620,
+                        }}
+                    >
+                        Our Theory of Change is the working document that maps every hour of our
+                        curriculum to a labor-market outcome. It&apos;s how we justify a 97%
+                        placement rate to donors, board members, and the troops themselves. Read the
+                        full methodology — including the evaluation framework, mentor protocols, and
+                        2030 roadmap.
+                    </p>
+
+                    <div className="tw-flex tw-flex-wrap tw-gap-4">
+                        <Link href="/theory-of-change" className={styles.theoryCtaPrimary}>
+                            View Theory of Change
+                            <span aria-hidden="true">→</span>
+                        </Link>
+                        <Link href="/programs" className={styles.theoryCtaSecondary}>
+                            Browse Curriculum
+                            <span aria-hidden="true">→</span>
+                        </Link>
+                    </div>
+                </motion.div>
+            </div>
+        </section>
+    );
+};
+
+export default Theory;

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -1,117 +1,40 @@
 import SEO from "@components/seo/page-seo";
-import { SectionEyebrow, SharpHeadline } from "@components/ui/design-system";
-import CtaArea from "@containers/cta/layout-01";
-import HeroArea from "@containers/hero/layout-07";
-import TimelineArea from "@containers/timeline";
+import Alumni from "@containers/about/alumni";
+import Hero from "@containers/about/hero";
+import JoinCta from "@containers/about/join-cta";
+import Pillars from "@containers/about/pillars";
+import Quote from "@containers/about/quote";
+import Stats from "@containers/about/stats";
+import Story from "@containers/about/story";
+import Theory from "@containers/about/theory";
 import Layout from "@layout/layout-01";
-import AlumniStrip from "@ui/alumni-strip";
-import PullQuote from "@ui/pull-quote";
-import { normalizedData } from "@utils/methods";
-import type { GetStaticProps } from "next";
-import Link from "next/link";
-import { getPageData } from "../lib/page";
-
-// Base content interface
-interface PageContent extends Record<string, unknown> {
-    section: string;
-    title?: string;
-    content?: string;
-    metadata?: Record<string, unknown>;
-    customFields?: Record<string, unknown>;
-    section_title?: {
-        title?: string;
-        subtitle?: string;
-    };
-    items?: Array<{
-        id: number | string;
-        headings?: Array<{ id: number | string; content: string }>;
-        texts?: Array<{ id: number | string; content: string }>;
-        images?: Array<{ src: string }>;
-    }>;
-    buttons?: Array<{
-        id: number | string;
-        content: string;
-        path: string;
-    }>;
-}
-
-type TProps = {
-    data: {
-        page: {
-            content: PageContent[];
-        };
-    };
-};
 
 type PageWithLayout = {
-    (props: TProps): JSX.Element;
+    (): JSX.Element;
     Layout: typeof Layout;
 };
 
-const AboutUs: PageWithLayout = ({ data }) => {
-    const content = normalizedData<PageContent>(data.page?.content, "section");
-
+const AboutUs: PageWithLayout = () => {
     return (
         <>
             <SEO title="About Us | Vets Who Code" />
-            <h1 className="tw-sr-only">About Us</h1>
-            <HeroArea data={content?.["hero-area"]} />
-            <TimelineArea data={content?.["timeline-area"]} />
-
-            {/* Mission pull-quote + alumni proof */}
-            <div className="dark-section tw-bg-navy tw-mt-20 md:tw-mt-[120px] tw-py-20 md:tw-py-[120px]">
-                <div className="tw-container">
-                    <PullQuote
-                        emphasis="We don't train veterans to fill seats."
-                        continuation="We train them to be impactful on their engineering teams at companies that shape the world."
-                    />
-                    <div className="tw-mt-14 md:tw-mt-20">
-                        <AlumniStrip align="center" />
-                    </div>
-                </div>
-            </div>
-
-            {/* Theory of Change — Sharp link block */}
-            <section className="tw-py-20 md:tw-py-[120px]">
-                <div className="tw-container">
-                    <div className="tw-mx-auto tw-flex tw-max-w-4xl tw-flex-col tw-gap-6 tw-border-t tw-border-silver tw-pt-16 md:tw-flex-row md:tw-items-end md:tw-justify-between">
-                        <div className="tw-flex tw-flex-col tw-gap-4">
-                            <SectionEyebrow
-                                label="Methodology"
-                                subLabel="DOC 03 / THEORY OF CHANGE"
-                            />
-                            <SharpHeadline as="h2" size="h2" tone="navy">
-                                How we turn troops into
-                                <br />
-                                <span className="tw-text-red">software engineers</span>.
-                            </SharpHeadline>
-                        </div>
-                        <Link
-                            href="/theory-of-change"
-                            className="tw-inline-flex tw-items-center tw-gap-3 tw-border-2 tw-border-red tw-bg-red tw-px-7 tw-py-4 tw-font-heading tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.08em] tw-text-white tw-transition-colors hover:tw-border-red-crimson hover:tw-bg-red-crimson active:tw-scale-[0.97]"
-                        >
-                            View Theory of Change
-                            <span aria-hidden="true">→</span>
-                        </Link>
-                    </div>
-                </div>
-            </section>
-
-            <CtaArea data={content?.["cta-area"]} space="bottom" />
+            <Hero />
+            <Pillars />
+            <Stats />
+            <Story />
+            <Quote />
+            <Alumni />
+            <Theory />
+            <JoinCta />
         </>
     );
 };
 
 AboutUs.Layout = Layout;
 
-export const getStaticProps: GetStaticProps = () => {
-    const page = getPageData("inner", "about-us");
-
+export const getStaticProps = () => {
     return {
         props: {
-            data: {
-                page,
-            },
             layout: {
                 headerShadow: true,
                 headerFluid: false,


### PR DESCRIPTION
## Summary

- Replaces the CMS-driven About Us page with eight purpose-built sections under `src/containers/about/`, recasting the page as a long-form nonprofit story document.
- Centerpiece is a sticky chapter spine driven by `IntersectionObserver` that walks readers through five Hero's-Journey chapters; supporting sections include an editorial hero with a typographic charter card, a three-pillar manifesto with custom visuals (Syllabus / Cohort Timezones / Terminal), a receipts stats band, a mission pull-quote, an alumni tabular grid, a Theory of Change teaser, and a three-pathway CTA (Apply / Mentor / Donate).
- All animations honor `prefers-reduced-motion` via a shared `about.module.css`. Copy is the user-approved version from the design handoff (e.g. pillar 02 uses "Virtual" lectures; alumni grid omits role labels).

## Test plan

- [ ] Vercel preview builds without errors
- [ ] `/about-us` renders all eight sections in order on desktop
- [ ] Hero blink cursor pulses next to "engineers"
- [ ] Pillar cards lift on hover and reveal the 2px red top border
- [ ] Chapter spine highlights the active chapter as you scroll; click-to-scroll lands at the right offset
- [ ] Sticky chapter image stays pinned within each chapter while the prose scrolls
- [ ] Quote section shows the giant ghost quotation mark behind the blockquote
- [ ] Alumni cells tint red on hover
- [ ] Theory CTAs route to `/theory-of-change` and `/programs`
- [ ] JoinCTA cards flip to navy with the arrow translating +6px on hover and on keyboard focus
- [ ] Reduced-motion OS setting kills the blink and entrance animations
- [ ] Layout collapses cleanly at `<992px` (single-column) and `<576px` (full stack)