### PR TITLE
feat(theory-of-change): Recast as git-log pipeline narrative

### DIFF
--- a/src/containers/theory-of-change/commit-section.tsx
+++ b/src/containers/theory-of-change/commit-section.tsx
@@ -1,0 +1,292 @@
+import { scrollUpVariants } from "@utils/variants";
+import clsx from "clsx";
+import { motion } from "motion/react";
+import { branchColor, type Phase } from "./phases-data";
+import styles from "./theory.module.css";
+
+interface Props {
+    phase: Phase;
+}
+
+const CommitSection = ({ phase }: Props) => {
+    const dark = phase.theme === "dark";
+    const color = branchColor(phase.branchId, phase.theme);
+    const bodyText = dark ? "rgba(248,249,250,0.78)" : "var(--charcoal)";
+    const headlineColor = dark ? "#fff" : "var(--navy)";
+    const eyebrowColor = dark ? "rgba(185,214,242,0.65)" : "var(--slate)";
+    const borderColor = dark ? "1px solid rgba(185,214,242,0.12)" : "1px solid rgba(9,31,64,0.12)";
+    const diffBg = dark ? "#212529" : "#fff";
+    const diffBorder = dark ? "1px solid rgba(185,214,242,0.10)" : "1px solid var(--silver)";
+    const markerBg = dark ? "rgba(248,249,250,0.04)" : "rgba(9,31,64,0.02)";
+
+    return (
+        <section
+            className={clsx(
+                dark ? "dark-section tw-bg-navy tw-text-white" : "tw-bg-cream",
+                "tw-py-[120px]"
+            )}
+            aria-labelledby={`toc-phase-${phase.n}-headline`}
+        >
+            <div className="tw-mx-auto tw-max-w-[1230px] tw-px-5 md:tw-px-10">
+                {/* Section header */}
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-12 tw-grid tw-grid-cols-1 tw-items-end tw-gap-6 tw-pb-8 md:tw-grid-cols-[1.4fr_1fr]"
+                    style={{ borderBottom: borderColor }}
+                >
+                    <h2
+                        id={`toc-phase-${phase.n}-headline`}
+                        className="tw-m-0 tw-font-heading tw-uppercase"
+                        style={{
+                            color: headlineColor,
+                            fontWeight: 900,
+                            fontSize: "clamp(36px, 6vw, 72px)",
+                            letterSpacing: "-0.025em",
+                            lineHeight: 1.02,
+                        }}
+                    >
+                        {phase.title}
+                        <span className="tw-text-red">{phase.accent}</span>
+                    </h2>
+                    <div className="tw-flex tw-flex-col tw-gap-1.5 md:tw-text-right">
+                        <span
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 13,
+                                fontWeight: 700,
+                                color: "var(--red)",
+                                letterSpacing: "0.1em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            {phase.branchName}
+                        </span>
+                        <span
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                color: eyebrowColor,
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            {phase.metaDescription}
+                        </span>
+                    </div>
+                </motion.div>
+
+                {/* Commit container */}
+                <div
+                    className={clsx(
+                        styles.timelineRail,
+                        dark && "dark",
+                        "tw-mx-auto tw-max-w-[1100px]"
+                    )}
+                >
+                    <motion.article
+                        initial="offscreen"
+                        whileInView="onscreen"
+                        viewport={{ once: true, amount: 0.2 }}
+                        variants={scrollUpVariants}
+                        className="tw-relative tw-pl-[60px] md:tw-pl-[88px]"
+                    >
+                        {/* Commit node — outlined square */}
+                        <div
+                            aria-hidden="true"
+                            className="tw-absolute tw-flex tw-items-center tw-justify-center"
+                            style={{
+                                top: 8,
+                                left: 13,
+                                width: 32,
+                                height: 32,
+                                color,
+                            }}
+                        >
+                            <div
+                                style={{
+                                    width: 30,
+                                    height: 30,
+                                    border: `2.5px solid ${color}`,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    justifyContent: "center",
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        width: 10,
+                                        height: 10,
+                                        background: color,
+                                    }}
+                                />
+                            </div>
+                        </div>
+
+                        {/* Commit head: hash + tag + branch + step */}
+                        <div
+                            className="tw-mb-6 tw-flex tw-flex-wrap tw-items-center tw-gap-4"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                            }}
+                        >
+                            <span style={{ color }}>{phase.hash}</span>
+                            <span
+                                style={{
+                                    border: `1px solid ${color}`,
+                                    padding: "3px 8px",
+                                    color,
+                                }}
+                            >
+                                {phase.tag}
+                            </span>
+                            <span style={{ color: eyebrowColor, fontStyle: "italic" }}>
+                                {phase.branchName}
+                            </span>
+                            <span
+                                className="tw-ml-auto tw-font-heading"
+                                style={{
+                                    fontWeight: 700,
+                                    color: dark ? "#fff" : "var(--navy)",
+                                    letterSpacing: "0.1em",
+                                }}
+                            >
+                                {phase.step}
+                            </span>
+                        </div>
+
+                        {/* Commit title */}
+                        <h3
+                            className="tw-m-0 tw-mb-5 tw-font-heading tw-uppercase"
+                            style={{
+                                color: headlineColor,
+                                fontWeight: 900,
+                                fontSize: "clamp(28px, 3.6vw, 44px)",
+                                letterSpacing: "-0.025em",
+                                lineHeight: 1.05,
+                            }}
+                        >
+                            {phase.headline}
+                        </h3>
+
+                        {/* Commit lede */}
+                        <p
+                            className="tw-m-0 tw-mb-10 tw-font-body"
+                            style={{
+                                color: bodyText,
+                                fontSize: 18,
+                                lineHeight: 1.65,
+                                maxWidth: 720,
+                            }}
+                        >
+                            {phase.lede}
+                        </p>
+
+                        {/* Diff block */}
+                        <div
+                            role="list"
+                            style={{
+                                background: diffBg,
+                                border: diffBorder,
+                            }}
+                        >
+                            {phase.diffs.map((row, i) => (
+                                <div
+                                    key={row.label}
+                                    role="listitem"
+                                    className={clsx(styles.diffRow, dark && styles.diffRowDark)}
+                                    style={{
+                                        borderTop:
+                                            i === 0
+                                                ? "none"
+                                                : dark
+                                                  ? "1px solid rgba(185,214,242,0.08)"
+                                                  : "1px solid var(--silver)",
+                                    }}
+                                >
+                                    <div
+                                        className="tw-flex tw-items-start tw-justify-center"
+                                        style={{
+                                            color,
+                                            background: markerBg,
+                                            borderRight: diffBorder,
+                                            fontFamily: "var(--font-mono)",
+                                            fontSize: 14,
+                                            fontWeight: 700,
+                                            padding: "22px 0",
+                                        }}
+                                    >
+                                        +
+                                    </div>
+                                    <div
+                                        className="tw-flex tw-flex-col tw-gap-2"
+                                        style={{ padding: "22px 28px" }}
+                                    >
+                                        <div
+                                            style={{
+                                                fontFamily: "var(--font-mono)",
+                                                fontSize: 10,
+                                                fontWeight: 700,
+                                                color,
+                                                letterSpacing: "0.14em",
+                                                textTransform: "uppercase",
+                                            }}
+                                        >
+                                            {row.label}
+                                        </div>
+                                        <p
+                                            className="tw-m-0 tw-font-body"
+                                            style={{
+                                                color: bodyText,
+                                                fontSize: 15.5,
+                                                lineHeight: 1.6,
+                                            }}
+                                        >
+                                            {row.text}
+                                        </p>
+                                    </div>
+                                    <div
+                                        className={styles.diffIndex}
+                                        style={{
+                                            padding: "22px 24px 22px 0",
+                                            fontFamily: "var(--font-mono)",
+                                            fontSize: 10,
+                                            color: eyebrowColor,
+                                            letterSpacing: "0.12em",
+                                            alignSelf: "center",
+                                        }}
+                                    >
+                                        {String(i + 1).padStart(2, "0")}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* Commit foot */}
+                        <div
+                            className="tw-mt-6 tw-flex tw-flex-wrap tw-gap-6"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 11,
+                                letterSpacing: "0.14em",
+                                textTransform: "uppercase",
+                                color: eyebrowColor,
+                            }}
+                        >
+                            <span style={{ color, fontWeight: 700 }}>{phase.footAdd}</span>
+                            <span>{phase.footMiddle}</span>
+                            <span>build: passing</span>
+                        </div>
+                    </motion.article>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default CommitSection;

--- a/src/containers/theory-of-change/core-belief.tsx
+++ b/src/containers/theory-of-change/core-belief.tsx
@@ -1,0 +1,103 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+
+const CoreBelief = () => {
+    return (
+        <section
+            className="tw-relative tw-overflow-hidden tw-bg-cream tw-py-[120px]"
+            aria-labelledby="toc-belief-headline"
+        >
+            <div className="tw-relative tw-mx-auto tw-max-w-[1230px] tw-px-5 md:tw-px-10">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-14 tw-flex tw-flex-wrap tw-items-center tw-gap-4 tw-text-[#6C757D]"
+                    style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 11,
+                        letterSpacing: "0.16em",
+                        textTransform: "uppercase",
+                    }}
+                >
+                    <span
+                        aria-hidden="true"
+                        className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
+                    />
+                    <span>README.md · core belief</span>
+                    <span aria-hidden="true" className="tw-h-px tw-flex-1 tw-bg-[#DEE2E6]" />
+                    <span>commit 0000000</span>
+                </motion.div>
+
+                <div className="tw-grid tw-grid-cols-1 tw-gap-12 lg:tw-grid-cols-[minmax(280px,1fr)_minmax(420px,1.6fr)] lg:tw-gap-20">
+                    <motion.h2
+                        id="toc-belief-headline"
+                        initial="offscreen"
+                        whileInView="onscreen"
+                        viewport={{ once: true, amount: 0.3 }}
+                        variants={scrollUpVariants}
+                        className="tw-m-0 tw-font-heading tw-uppercase tw-text-navy"
+                        style={{
+                            fontWeight: 900,
+                            fontSize: "clamp(36px, 5vw, 60px)",
+                            lineHeight: 1.02,
+                            letterSpacing: "-0.025em",
+                        }}
+                    >
+                        Veterans are
+                        <br />
+                        <span className="tw-text-red">stakeholders,</span>
+                        <br />
+                        not charity cases.
+                    </motion.h2>
+
+                    <motion.div
+                        initial="offscreen"
+                        whileInView="onscreen"
+                        viewport={{ once: true, amount: 0.3 }}
+                        variants={scrollUpVariants}
+                        className="tw-relative tw-pl-8"
+                        style={{ borderLeft: "1px solid var(--silver)" }}
+                    >
+                        <span
+                            aria-hidden="true"
+                            className="tw-absolute tw-left-[-1px] tw-top-0 tw-h-16 tw-w-0.5 tw-bg-red"
+                        />
+                        <p
+                            className="tw-m-0 tw-font-heading tw-text-navy"
+                            style={{
+                                fontWeight: 600,
+                                fontSize: 22,
+                                lineHeight: 1.45,
+                                letterSpacing: "-0.01em",
+                            }}
+                        >
+                            Military experience instills a unique blend of grit, discipline, and
+                            adaptive thinking. Pair it with technical training and real product
+                            work, and you get exceptional engineers.
+                        </p>
+                        <p
+                            className="tw-mt-6 tw-font-body tw-text-ink"
+                            style={{ fontSize: 18, lineHeight: 1.7 }}
+                        >
+                            Vets Who Code is not a bootcamp. It is a selective, outcome-focused
+                            training program that maps every hour of instruction to verified
+                            labor-market demand. We channel potential through a proven,
+                            product-focused learning ecosystem — not a curriculum in isolation.
+                        </p>
+                        <p
+                            className="tw-mt-6 tw-font-body tw-text-ink"
+                            style={{ fontSize: 18, lineHeight: 1.7 }}
+                        >
+                            If our students can&apos;t make money with it, we don&apos;t bother
+                            teaching it.
+                        </p>
+                    </motion.div>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default CoreBelief;

--- a/src/containers/theory-of-change/hero-git-graph.tsx
+++ b/src/containers/theory-of-change/hero-git-graph.tsx
@@ -1,0 +1,310 @@
+import { motion, useInView, useReducedMotion } from "motion/react";
+import { useRef } from "react";
+
+interface Branch {
+    id: "b1" | "b2" | "b3" | "b4" | "b5";
+    name: string;
+    label: string;
+    commits: string[];
+    y: number;
+    hash: string;
+    color: string;
+}
+
+const BRANCHES: Branch[] = [
+    {
+        id: "b1",
+        name: "feat/inputs",
+        label: "Inputs",
+        commits: ["cohort", "platform", "mentors", "tooling"],
+        y: 80,
+        hash: "9a1c3f2",
+        color: "#C5203E",
+    },
+    {
+        id: "b2",
+        name: "feat/activities",
+        label: "Activities",
+        commits: ["modules", "pairing", "open-src", "products", "career"],
+        y: 180,
+        hash: "3c47b08",
+        color: "#FDB330",
+    },
+    {
+        id: "b3",
+        name: "build/outputs",
+        label: "Outputs",
+        commits: ["github", "projects", "skills", "network"],
+        y: 280,
+        hash: "f5d92ae",
+        color: "#B9D6F2",
+    },
+    {
+        id: "b4",
+        name: "release/outcomes",
+        label: "Outcomes",
+        commits: ["hires", "alumni", "mobility", "impact"],
+        y: 380,
+        hash: "b27e914",
+        color: "#F38375",
+    },
+    {
+        id: "b5",
+        name: "impact/long",
+        label: "Impact",
+        commits: ["ecosystem", "wealth", "narrative", "model", "diversity"],
+        y: 480,
+        hash: "0d8f1c6",
+        color: "#FFE169",
+    },
+];
+
+const HERO_W = 700;
+const HERO_H = 560;
+const FORK_X = 110;
+const TRACK_START = 180;
+const TRACK_END = 480;
+const MERGE_X = 580;
+const MAIN_Y = 280;
+const INIT_X = 50;
+const FINAL_X = 640;
+
+const PHASE_COLS = [
+    { x: 200, label: "T+0" },
+    { x: 280, label: "T+04" },
+    { x: 360, label: "T+09" },
+    { x: 440, label: "T+12" },
+    { x: 520, label: "T+24" },
+];
+
+const branchPath = (y: number) =>
+    `M ${FORK_X} ${MAIN_Y} C ${FORK_X + 30} ${MAIN_Y}, ${FORK_X + 30} ${y}, ${FORK_X + 70} ${y} L ${MERGE_X - 70} ${y} C ${MERGE_X - 30} ${y}, ${MERGE_X - 30} ${MAIN_Y}, ${MERGE_X} ${MAIN_Y}`;
+
+const commitX = (i: number, n: number) =>
+    n === 1
+        ? (TRACK_START + TRACK_END) / 2
+        : TRACK_START + (i / (n - 1)) * (TRACK_END - TRACK_START);
+
+const HeroGitGraph = () => {
+    const ref = useRef<HTMLDivElement>(null);
+    const inView = useInView(ref, { once: true, amount: 0.2 });
+    const reduced = useReducedMotion();
+    const play = inView || reduced;
+
+    return (
+        <div ref={ref} className="tw-w-full">
+            <svg
+                viewBox={`0 0 ${HERO_W} ${HERO_H}`}
+                preserveAspectRatio="xMidYMid meet"
+                role="img"
+                aria-label="Animated git graph: five branches forking from a service line and merging into a v1.0 engineer release."
+                className="tw-block tw-h-auto tw-w-full"
+            >
+                {/* Faint main line — service to production */}
+                <line
+                    x1={INIT_X}
+                    y1={MAIN_Y}
+                    x2={FINAL_X}
+                    y2={MAIN_Y}
+                    stroke="#B9D6F2"
+                    strokeOpacity={0.4}
+                    strokeWidth={1.5}
+                />
+
+                {/* Phase column dashed guides */}
+                {PHASE_COLS.map((c) => (
+                    <g key={c.label}>
+                        <line
+                            x1={c.x}
+                            y1={40}
+                            x2={c.x}
+                            y2={HERO_H - 20}
+                            stroke="rgba(185,214,242,0.06)"
+                            strokeDasharray="2 4"
+                            strokeWidth={1}
+                        />
+                        <text
+                            x={c.x}
+                            y={HERO_H - 6}
+                            textAnchor="middle"
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 9.5,
+                                fill: "rgba(185,214,242,0.5)",
+                                letterSpacing: "0.08em",
+                            }}
+                        >
+                            {c.label}
+                        </text>
+                    </g>
+                ))}
+
+                {/* Top label */}
+                <text
+                    x={INIT_X}
+                    y={30}
+                    style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        fill: "rgba(185,214,242,0.55)",
+                        letterSpacing: "0.12em",
+                    }}
+                >
+                    $ git log --graph --oneline --all
+                </text>
+
+                {/* INIT node */}
+                <circle
+                    cx={INIT_X}
+                    cy={MAIN_Y}
+                    r={8}
+                    fill="none"
+                    stroke="#B9D6F2"
+                    strokeWidth={2}
+                />
+                <circle cx={INIT_X} cy={MAIN_Y} r={3} fill="#B9D6F2" />
+                <text
+                    x={INIT_X - 4}
+                    y={MAIN_Y - 16}
+                    style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10,
+                        fill: "rgba(185,214,242,0.7)",
+                        letterSpacing: "0.12em",
+                    }}
+                >
+                    init: service
+                </text>
+
+                {/* Branches */}
+                {BRANCHES.map((b, branchIdx) => (
+                    <g key={b.id}>
+                        <motion.path
+                            d={branchPath(b.y)}
+                            fill="none"
+                            stroke={b.color}
+                            strokeWidth={1.5}
+                            initial={{ pathLength: 0 }}
+                            animate={play ? { pathLength: 1 } : { pathLength: 0 }}
+                            transition={{
+                                duration: reduced ? 0 : 1.1,
+                                delay: reduced ? 0 : 0.25 + branchIdx * 0.18,
+                                ease: [0.19, 1, 0.22, 1],
+                            }}
+                        />
+                        <text
+                            x={FORK_X + 80}
+                            y={b.y - 12}
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 10,
+                                fill: b.color,
+                                letterSpacing: "0.12em",
+                            }}
+                        >
+                            {b.label}
+                        </text>
+
+                        {/* Commits along the track */}
+                        {b.commits.map((_, i) => {
+                            const x = commitX(i, b.commits.length);
+                            const delay = reduced ? 0 : 1.1 + branchIdx * 0.18 + i * 0.12;
+                            return (
+                                <motion.g
+                                    key={`${b.id}-${i}`}
+                                    initial={{ opacity: 0, scale: 0.5 }}
+                                    animate={
+                                        play ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 0.5 }
+                                    }
+                                    transition={{
+                                        duration: reduced ? 0 : 0.28,
+                                        delay,
+                                        ease: "easeOut",
+                                    }}
+                                    style={{ transformOrigin: `${x}px ${b.y}px` }}
+                                >
+                                    <circle
+                                        cx={x}
+                                        cy={b.y}
+                                        r={5}
+                                        fill="none"
+                                        stroke={b.color}
+                                        strokeWidth={2}
+                                    />
+                                    <circle cx={x} cy={b.y} r={2} fill={b.color} />
+                                </motion.g>
+                            );
+                        })}
+
+                        {/* Hash label below the first commit */}
+                        <motion.text
+                            x={commitX(0, b.commits.length)}
+                            y={b.y + 22}
+                            textAnchor="middle"
+                            initial={{ opacity: 0 }}
+                            animate={play ? { opacity: 0.85 } : { opacity: 0 }}
+                            transition={{
+                                duration: reduced ? 0 : 0.4,
+                                delay: reduced ? 0 : 1.1 + branchIdx * 0.18,
+                            }}
+                            style={{
+                                fontFamily: "var(--font-mono)",
+                                fontSize: 10,
+                                fill: "rgba(185,214,242,0.55)",
+                                letterSpacing: "0.1em",
+                            }}
+                        >
+                            {b.hash}
+                        </motion.text>
+                    </g>
+                ))}
+
+                {/* FINAL release node + v1.0 tag */}
+                <motion.g
+                    initial={{ opacity: 0 }}
+                    animate={play ? { opacity: 1 } : { opacity: 0 }}
+                    transition={{
+                        duration: reduced ? 0 : 0.5,
+                        delay: reduced ? 0 : 2.7,
+                    }}
+                >
+                    <circle
+                        cx={FINAL_X}
+                        cy={MAIN_Y}
+                        r={11}
+                        fill="none"
+                        stroke="#C5203E"
+                        strokeWidth={2.5}
+                    />
+                    <circle cx={FINAL_X} cy={MAIN_Y} r={5} fill="#C5203E" />
+                    <line
+                        x1={FINAL_X}
+                        y1={MAIN_Y - 32}
+                        x2={FINAL_X}
+                        y2={MAIN_Y - 10}
+                        stroke="#C5203E"
+                        strokeWidth={1.5}
+                    />
+                    <rect x={FINAL_X - 80} y={MAIN_Y - 60} width={168} height={28} fill="#C5203E" />
+                    <text
+                        x={FINAL_X + 4}
+                        y={MAIN_Y - 41}
+                        textAnchor="middle"
+                        style={{
+                            fontFamily: "var(--font-headline)",
+                            fontSize: 11,
+                            fontWeight: 700,
+                            fill: "#fff",
+                            letterSpacing: "0.12em",
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        v1.0 — engineer
+                    </text>
+                </motion.g>
+            </svg>
+        </div>
+    );
+};
+
+export default HeroGitGraph;

--- a/src/containers/theory-of-change/hero.tsx
+++ b/src/containers/theory-of-change/hero.tsx
@@ -1,0 +1,166 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+import HeroGitGraph from "./hero-git-graph";
+import styles from "./theory.module.css";
+
+const META = [
+    { label: "Repository", value: "vetswhocode/troops" },
+    { label: "Branch", value: "main → production" },
+    { label: "Cohort", value: "2026 · open" },
+    { label: "License", value: "501(c)(3) · free" },
+];
+
+const Hero = () => {
+    return (
+        <section
+            className="dark-section tw-relative tw-overflow-hidden tw-bg-navy tw-pb-20 tw-pt-[140px] tw-text-white lg:tw-min-h-screen"
+            aria-labelledby="toc-hero-headline"
+        >
+            <span aria-hidden="true" className={styles.heroGrid} />
+            <span aria-hidden="true" className={styles.heroGlow} />
+
+            <div className="tw-relative tw-mx-auto tw-grid tw-max-w-[1230px] tw-grid-cols-1 tw-items-center tw-gap-12 tw-px-5 md:tw-px-10 lg:tw-grid-cols-[minmax(320px,1fr)_minmax(420px,1.2fr)] lg:tw-gap-20">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                >
+                    <div
+                        className="tw-mb-9 tw-flex tw-items-center tw-gap-3"
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 12,
+                            letterSpacing: "0.16em",
+                            textTransform: "uppercase",
+                            color: "var(--gold)",
+                        }}
+                    >
+                        <span
+                            aria-hidden="true"
+                            className="tw-inline-block tw-h-[2px] tw-w-7 tw-bg-red"
+                        />
+                        Theory of Change · v2026
+                    </div>
+
+                    <h1
+                        id="toc-hero-headline"
+                        className="tw-m-0 tw-font-heading tw-uppercase tw-text-white"
+                        style={{
+                            fontWeight: 900,
+                            fontSize: "clamp(48px, 8vw, 104px)",
+                            lineHeight: 0.92,
+                            letterSpacing: "-0.03em",
+                        }}
+                    >
+                        Service.
+                        <br />
+                        <span className="tw-text-red">Software.</span>
+                        <br />
+                        <span
+                            style={{
+                                color: "transparent",
+                                WebkitTextStroke: "2px #fff",
+                            }}
+                        >
+                            Shipped.
+                        </span>
+                    </h1>
+
+                    <p
+                        className="tw-mt-9 tw-font-body"
+                        style={{
+                            fontSize: 18,
+                            lineHeight: 1.65,
+                            color: "rgba(185,214,242,0.7)",
+                            maxWidth: 480,
+                        }}
+                    >
+                        A 17-week, remote-first pipeline that turns disciplined operators into
+                        production software engineers. This is the commit log.
+                    </p>
+
+                    <div
+                        className="tw-mt-12 tw-grid tw-grid-cols-2 tw-gap-x-8 tw-gap-y-5 tw-pt-7"
+                        style={{ borderTop: "1px solid rgba(185,214,242,0.12)" }}
+                    >
+                        {META.map((m) => (
+                            <div key={m.label}>
+                                <div
+                                    style={{
+                                        fontFamily: "var(--font-mono)",
+                                        fontSize: 10,
+                                        letterSpacing: "0.16em",
+                                        textTransform: "uppercase",
+                                        color: "rgba(185,214,242,0.55)",
+                                        marginBottom: 6,
+                                    }}
+                                >
+                                    {m.label}
+                                </div>
+                                <div
+                                    className="tw-font-heading tw-uppercase tw-text-white"
+                                    style={{
+                                        fontWeight: 700,
+                                        fontSize: 14,
+                                        letterSpacing: "0.02em",
+                                    }}
+                                >
+                                    {m.value}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div
+                        className="tw-mt-10 tw-flex tw-items-center tw-gap-3"
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 11,
+                            letterSpacing: "0.14em",
+                            textTransform: "uppercase",
+                            color: "rgba(185,214,242,0.55)",
+                        }}
+                    >
+                        <span className="tw-text-red">$</span>
+                        <span>git checkout theory-of-change</span>
+                        <span
+                            aria-hidden="true"
+                            className="tw-ml-auto tw-flex tw-items-center tw-gap-2"
+                        >
+                            <span className={styles.statusDot} />
+                            2026 cohort active
+                        </span>
+                    </div>
+                </motion.div>
+
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-w-full"
+                >
+                    <HeroGitGraph />
+                </motion.div>
+            </div>
+
+            <div
+                aria-hidden="true"
+                className="tw-mt-16 tw-flex tw-flex-col tw-items-center tw-gap-3"
+                style={{
+                    fontFamily: "var(--font-mono)",
+                    fontSize: 10,
+                    letterSpacing: "0.18em",
+                    textTransform: "uppercase",
+                    color: "rgba(185,214,242,0.45)",
+                }}
+            >
+                <span>scroll · git log</span>
+                <span className={styles.scrollCue} />
+            </div>
+        </section>
+    );
+};
+
+export default Hero;

--- a/src/containers/theory-of-change/merge-banner.tsx
+++ b/src/containers/theory-of-change/merge-banner.tsx
@@ -1,0 +1,62 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+
+const MergeBanner = () => {
+    return (
+        <section
+            className="dark-section tw-bg-navy tw-py-20 tw-text-white"
+            aria-label="Merge banner: activities into main"
+        >
+            <div className="tw-mx-auto tw-max-w-[1230px] tw-px-5 md:tw-px-10">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-grid tw-grid-cols-1 tw-items-center tw-gap-8 md:tw-grid-cols-[auto_1fr]"
+                    style={{ borderLeft: "4px solid var(--red)", padding: "32px 40px" }}
+                >
+                    <pre
+                        className="tw-m-0 tw-text-gold"
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 12,
+                            lineHeight: 1.4,
+                            letterSpacing: "0.04em",
+                        }}
+                    >{`|
+|\\
+| |
+|/
+*`}</pre>
+                    <div className="tw-flex tw-flex-col tw-gap-2">
+                        <h3
+                            className="tw-m-0 tw-font-heading tw-uppercase tw-text-white"
+                            style={{
+                                fontWeight: 900,
+                                fontSize: "clamp(20px, 2.4vw, 26px)",
+                                letterSpacing: "-0.02em",
+                                lineHeight: 1.15,
+                            }}
+                        >
+                            Merge branch &apos;activities&apos; into &apos;main&apos;
+                        </h3>
+                        <p
+                            className="tw-m-0 tw-font-body"
+                            style={{
+                                fontSize: 15,
+                                lineHeight: 1.65,
+                                color: "rgba(185,214,242,0.7)",
+                            }}
+                        >
+                            17 weeks of input + activity collapse into a single, deployable
+                            engineer. The remaining commits are downstream of that merge.
+                        </p>
+                    </div>
+                </motion.div>
+            </div>
+        </section>
+    );
+};
+
+export default MergeBanner;

--- a/src/containers/theory-of-change/phases-data.ts
+++ b/src/containers/theory-of-change/phases-data.ts
@@ -1,0 +1,233 @@
+export type BranchId = "b1" | "b2" | "b3" | "b4" | "b5";
+
+export interface DiffRow {
+    label: string;
+    text: string;
+}
+
+export interface Phase {
+    step: string;
+    n: string;
+    title: string;
+    accent: string;
+    branchName: string;
+    metaDescription: string;
+    hash: string;
+    tag: string;
+    headline: string;
+    lede: string;
+    diffs: DiffRow[];
+    footAdd: string;
+    footMiddle: string;
+    theme: "light" | "dark";
+    branchId: BranchId;
+}
+
+export const PHASES: Phase[] = [
+    {
+        step: "Step 01 / 05",
+        n: "01",
+        title: "Phase 01 — ",
+        accent: "Inputs.",
+        branchName: "feat/inputs",
+        metaDescription: "who we recruit · what we equip",
+        hash: "9a1c3f2",
+        tag: "phase-01",
+        headline: "We start with motivated operators.",
+        lede: "U.S. military veterans and military spouses who are ready to transition into tech, and who can carry a 17-week sprint to completion. Our inputs are deliberately small in number and high in signal.",
+        diffs: [
+            {
+                label: "cohort/learners.md",
+                text: "A curated selection of veteran learners with high aptitude and drive.",
+            },
+            {
+                label: "platform/curriculum.md",
+                text: "The VWC learning platform — open-source curriculum, projects, blog, all under one roof.",
+            },
+            {
+                label: "network/mentors.md",
+                text: "A network of experienced mentors, industry veterans, and alumni coaches.",
+            },
+            {
+                label: "infra/community.md",
+                text: "Community infrastructure for remote collaboration and code reviews.",
+            },
+            {
+                label: "tools/devkit.md",
+                text: "Access to development tools, GitHub repositories, and cloud environments.",
+            },
+        ],
+        footAdd: "+5 inputs added",
+        footMiddle: "5 files changed",
+        theme: "dark",
+        branchId: "b1",
+    },
+    {
+        step: "Step 02 / 05",
+        n: "02",
+        title: "Phase 02 — ",
+        accent: "Activities.",
+        branchName: "feat/activities",
+        metaDescription: "17 weeks · 100% remote · product-driven",
+        hash: "3c47b08",
+        tag: "phase-02",
+        headline: "We run a real engineering workflow.",
+        lede: "Troops don't watch lectures — they ship. Every week mirrors the cadence of a working software team: tickets, pull requests, code review, deploy.",
+        diffs: [
+            {
+                label: "curriculum/12-modules.md",
+                text: "Platform-based learning — a rigorous 12-module open-source curriculum, from core web fundamentals to backend APIs and DevOps.",
+            },
+            {
+                label: "mentorship/pair.md",
+                text: "Every troop pairs with mentors from our alumni and industry network: weekly check-ins, code reviews, career strategy.",
+            },
+            {
+                label: "contrib/open-source.md",
+                text: "Learners contribute to internal and external open-source projects — scalable, readable code that integrates into production.",
+            },
+            {
+                label: "products/aegis.md",
+                text: "Veterans work on real nonprofit apps used by real users — the PTSD Toolkit, AEGIS — portfolio-ready with real-world scope.",
+            },
+            {
+                label: "career/weekly.md",
+                text: "Resume reviews, GitHub audits, behavioral interview prep, async job-search drills — every week.",
+            },
+        ],
+        footAdd: "+5 workflows added",
+        footMiddle: "17 weeks scheduled",
+        theme: "light",
+        branchId: "b2",
+    },
+    {
+        step: "Step 03 / 05",
+        n: "03",
+        title: "Phase 03 — ",
+        accent: "Outputs.",
+        branchName: "build/outputs",
+        metaDescription: "what graduates leave with",
+        hash: "f5d92ae",
+        tag: "phase-03",
+        headline: "A graduate is a deployable artifact.",
+        lede: "By end-of-program, every troop has a build that compiles in front of a hiring manager — portfolio, references, fluency, and the social proof to back it.",
+        diffs: [
+            {
+                label: "profile/github.md",
+                text: "A strong GitHub profile reflecting open-source and production-level contributions.",
+            },
+            {
+                label: "portfolio/shipped.md",
+                text: "Completed software products deployed or used by actual users.",
+            },
+            {
+                label: "skills/stack.md",
+                text: "Job-ready skills: TypeScript, React, Next.js, Python, FastAPI, Git, CI/CD.",
+            },
+            {
+                label: "network/references.md",
+                text: "Direct mentorship and professional guidance from engineers already in the field.",
+            },
+        ],
+        footAdd: "+4 outputs added",
+        footMiddle: "portfolio: ready",
+        theme: "light",
+        branchId: "b3",
+    },
+    {
+        step: "Step 04 / 05",
+        n: "04",
+        title: "Phase 04 — ",
+        accent: "Outcomes.",
+        branchName: "release/outcomes",
+        metaDescription: "6–12 months post-graduation",
+        hash: "b27e914",
+        tag: "phase-04",
+        headline: "The build runs in production.",
+        lede: "Within a year of graduating, the program's measurable results show up on resumes, payroll, and in the open-source contributions our alumni go back to author.",
+        diffs: [
+            {
+                label: "jobs/placed.log",
+                text: "Veterans hired into six-figure tech roles in software engineering, DevOps, or data.",
+            },
+            {
+                label: "alumni/return.log",
+                text: "Alumni re-engage as mentors, speakers, and open-source contributors.",
+            },
+            {
+                label: "mobility/economic.log",
+                text: "Economic mobility — especially among underrepresented and minority veterans.",
+            },
+            {
+                label: "product/in-use.log",
+                text: "Tools and apps they built are running in front of real users.",
+            },
+            {
+                label: "pipeline/visibility.log",
+                text: "Portfolio visibility — troops stand out in competitive hiring funnels.",
+            },
+        ],
+        footAdd: "+5 outcomes recorded",
+        footMiddle: "cycle: 6–12 mo",
+        theme: "dark",
+        branchId: "b4",
+    },
+    {
+        step: "Step 05 / 05",
+        n: "05",
+        title: "Phase 05 — ",
+        accent: "Impact.",
+        branchName: "impact/long",
+        metaDescription: "generational · structural",
+        hash: "0d8f1c6",
+        tag: "phase-05",
+        headline: "The narrative changes with the build.",
+        lede: "Repeated, replicable wins reshape the system that produced them — for the individual veteran, for their family, and for the tech industry's idea of who belongs at the keyboard.",
+        diffs: [
+            {
+                label: "ecosystem/veteran.md",
+                text: "A visible, high-performing ecosystem of veteran technologists rooted in service and real engineering.",
+            },
+            {
+                label: "family/wealth.md",
+                text: "Generational wealth creation and stability for veteran families.",
+            },
+            {
+                label: "industry/narrative.md",
+                text: "A transformed narrative: veterans aren't just hires — they're builders, maintainers, innovators.",
+            },
+            {
+                label: "model/replicable.md",
+                text: "A proven, replicable nonprofit model: product-based learning + mentorship + community.",
+            },
+            {
+                label: "workforce/diversity.md",
+                text: "A more diverse, mission-driven U.S. tech workforce reflecting service, resilience, contribution.",
+            },
+        ],
+        footAdd: "+5 long-term effects",
+        footMiddle: "horizon: generational",
+        theme: "light",
+        branchId: "b5",
+    },
+];
+
+/* Branch palette — `currentColor` for each commit's marker and diff `+` glyph. */
+export const BRANCH_COLOR_LIGHT: Record<BranchId, string> = {
+    b1: "#C5203E", // red
+    b2: "#FDB330", // gold
+    b3: "#0353A4", // navy-royal
+    b4: "#A51C30", // red-crimson
+    b5: "#C9A227", // gold-deep
+};
+
+export const BRANCH_COLOR_DARK: Record<BranchId, string> = {
+    b1: "#C5203E",
+    b2: "#FDB330",
+    b3: "#B9D6F2", // navy-sky
+    b4: "#F38375", // coral-on-dark
+    b5: "#FFE169", // gold-light
+};
+
+export const branchColor = (b: BranchId, theme: "light" | "dark") =>
+    theme === "dark" ? BRANCH_COLOR_DARK[b] : BRANCH_COLOR_LIGHT[b];

--- a/src/containers/theory-of-change/pipeline.tsx
+++ b/src/containers/theory-of-change/pipeline.tsx
@@ -1,0 +1,224 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion, useInView, useReducedMotion } from "motion/react";
+import { useRef } from "react";
+
+const PHASES = [
+    { x: 100, label: "INPUTS", sub: "who + what", ring: "#C5203E", fill: "#C5203E" },
+    {
+        x: 330,
+        label: "ACTIVITIES",
+        sub: "17-week program",
+        ring: "#DBB42C",
+        fill: "#DBB42C",
+    },
+    {
+        x: 560,
+        label: "OUTPUTS",
+        sub: "skills + portfolio",
+        ring: "#0353A4",
+        fill: "#0353A4",
+    },
+    {
+        x: 790,
+        label: "OUTCOMES",
+        sub: "6–12 months",
+        ring: "#A51C30",
+        fill: "#A51C30",
+    },
+    {
+        x: 1020,
+        label: "IMPACT",
+        sub: "long-term",
+        ring: "#C9A227",
+        fill: "#C9A227",
+    },
+];
+
+const Y = 180;
+
+const PipelineDiagram = () => {
+    const ref = useRef<SVGSVGElement>(null);
+    const inView = useInView(ref, { once: true, amount: 0.3 });
+    const reduced = useReducedMotion();
+    const play = inView || reduced;
+    const lastX = PHASES[PHASES.length - 1].x;
+    const arrowX = lastX + 60;
+
+    return (
+        <svg
+            ref={ref}
+            viewBox="0 0 1140 360"
+            preserveAspectRatio="xMidYMid meet"
+            className="tw-block tw-h-auto tw-w-full"
+        >
+            {/* Spine */}
+            <line
+                x1={PHASES[0].x}
+                y1={Y}
+                x2={lastX}
+                y2={Y}
+                stroke="rgba(9,31,64,0.18)"
+                strokeWidth={1}
+            />
+            {/* Red accent line that grows on reveal */}
+            <motion.line
+                x1={PHASES[0].x}
+                y1={Y}
+                x2={lastX}
+                y2={Y}
+                stroke="#C5203E"
+                strokeWidth={2}
+                initial={{ pathLength: 0 }}
+                animate={play ? { pathLength: 1 } : { pathLength: 0 }}
+                transition={{
+                    duration: reduced ? 0 : 1.6,
+                    ease: [0.19, 1, 0.22, 1],
+                }}
+            />
+
+            {PHASES.map((p, i) => (
+                <g key={p.label}>
+                    <line
+                        x1={p.x}
+                        y1={Y - 16}
+                        x2={p.x}
+                        y2={Y - 30}
+                        stroke="rgba(9,31,64,0.25)"
+                        strokeWidth={1}
+                    />
+                    <text
+                        x={p.x}
+                        y={Y - 50}
+                        textAnchor="middle"
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 10,
+                            fill: "#6C757D",
+                            letterSpacing: "0.18em",
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        phase-{String(i + 1).padStart(2, "0")}
+                    </text>
+                    <circle cx={p.x} cy={Y} r={16} fill="#fff" stroke={p.ring} strokeWidth={2.5} />
+                    <circle cx={p.x} cy={Y} r={6} fill={p.fill} />
+                    <text
+                        x={p.x}
+                        y={Y + 50}
+                        textAnchor="middle"
+                        style={{
+                            fontFamily: "var(--font-headline)",
+                            fontSize: 13,
+                            fontWeight: 700,
+                            fill: "#091F40",
+                            letterSpacing: "0.06em",
+                        }}
+                    >
+                        {p.label}
+                    </text>
+                    <text
+                        x={p.x}
+                        y={Y + 72}
+                        textAnchor="middle"
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 10,
+                            fill: "#6C757D",
+                            letterSpacing: "0.12em",
+                        }}
+                    >
+                        {p.sub}
+                    </text>
+                </g>
+            ))}
+
+            {/* Arrow + trailing label */}
+            <motion.g
+                initial={{ opacity: 0 }}
+                animate={play ? { opacity: 1 } : { opacity: 0 }}
+                transition={{
+                    duration: reduced ? 0 : 0.4,
+                    delay: reduced ? 0 : 1.4,
+                }}
+            >
+                <path
+                    d={`M ${arrowX - 20} ${Y} L ${arrowX} ${Y} M ${arrowX - 8} ${Y - 6} L ${arrowX} ${Y} L ${arrowX - 8} ${Y + 6}`}
+                    stroke="#C5203E"
+                    strokeWidth={2}
+                    fill="none"
+                    strokeLinecap="square"
+                    strokeLinejoin="miter"
+                />
+                <text
+                    x={arrowX + 12}
+                    y={Y + 5}
+                    style={{
+                        fontFamily: "var(--font-headline)",
+                        fontSize: 13,
+                        fontWeight: 700,
+                        fill: "#C5203E",
+                        letterSpacing: "0.06em",
+                    }}
+                >
+                    → shipped
+                </text>
+            </motion.g>
+        </svg>
+    );
+};
+
+const Pipeline = () => {
+    return (
+        <section className="tw-bg-[#F8F9FA] tw-py-[120px]" aria-labelledby="toc-pipeline-headline">
+            <div className="tw-mx-auto tw-max-w-[1230px] tw-px-5 md:tw-px-10">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-12 tw-flex tw-flex-wrap tw-items-end tw-justify-between tw-gap-6"
+                >
+                    <h2
+                        id="toc-pipeline-headline"
+                        className="tw-m-0 tw-font-heading tw-uppercase tw-text-navy"
+                        style={{
+                            fontWeight: 900,
+                            fontSize: "clamp(28px, 4vw, 44px)",
+                            letterSpacing: "-0.02em",
+                            lineHeight: 1.05,
+                        }}
+                    >
+                        The five-phase pipeline.
+                    </h2>
+                    <div
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: 12,
+                            letterSpacing: "0.12em",
+                            color: "#495057",
+                        }}
+                    >
+                        <span className="tw-text-red">$</span> git log{" "}
+                        <span style={{ color: "#0353A4" }}>--graph --all --decorate</span>
+                    </div>
+                </motion.div>
+
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.2 }}
+                    variants={scrollUpVariants}
+                    className="tw-bg-white"
+                    style={{
+                        border: "1px solid var(--silver)",
+                        padding: "56px 40px 40px",
+                    }}
+                >
+                    <PipelineDiagram />
+                </motion.div>
+            </div>
+        </section>
+    );
+};
+
+export default Pipeline;

--- a/src/containers/theory-of-change/theory.module.css
+++ b/src/containers/theory-of-change/theory.module.css
@@ -1,0 +1,208 @@
+/* Shared primitives for the Theory of Change redesign. */
+
+/* Faint 60px grid wash on the hero background, masked to the left half. */
+.heroGrid {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image:
+        linear-gradient(rgba(185, 214, 242, 0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(185, 214, 242, 0.04) 1px, transparent 1px);
+    background-size: 60px 60px;
+    mask-image: radial-gradient(
+        circle at 0% 50%,
+        #000 0%,
+        rgba(0, 0, 0, 0.4) 60%,
+        transparent 100%
+    );
+    -webkit-mask-image: radial-gradient(
+        circle at 0% 50%,
+        #000 0%,
+        rgba(0, 0, 0, 0.4) 60%,
+        transparent 100%
+    );
+}
+
+/* Red radial glow on the hero right side. */
+.heroGlow {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(ellipse at 100% 50%, rgba(197, 32, 62, 0.12) 0%, transparent 60%);
+}
+
+/* Gold status dot with a glow + soft pulse. */
+.statusDot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--gold, #fdb330);
+    box-shadow: 0 0 12px rgba(253, 179, 48, 0.6);
+    animation: tocPulse 2s ease-in-out infinite;
+    flex-shrink: 0;
+    display: inline-block;
+}
+
+@keyframes tocPulse {
+    0%,
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    50% {
+        transform: scale(1.3);
+        opacity: 0.55;
+    }
+}
+
+/* Vertical scroll cue line that wipes top→bottom→top. */
+.scrollCue {
+    position: relative;
+    width: 1px;
+    height: 40px;
+    overflow: hidden;
+    background: rgba(185, 214, 242, 0.18);
+}
+
+.scrollCue::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, var(--red, #c5203e) 0%, transparent 100%);
+    animation: tocScrollCue 2s ease-in-out infinite;
+}
+
+@keyframes tocScrollCue {
+    0%,
+    100% {
+        transform: translateY(-100%);
+    }
+    50% {
+        transform: translateY(100%);
+    }
+}
+
+/* Diff row hover tint (light + dark variants). */
+.diffRow {
+    display: grid;
+    grid-template-columns: 56px 1fr auto;
+    align-items: stretch;
+    transition: background-color 200ms ease;
+}
+
+.diffRow:hover {
+    background-color: rgba(197, 32, 62, 0.04);
+}
+
+.diffRowDark:hover {
+    background-color: rgba(197, 32, 62, 0.08);
+}
+
+@media (max-width: 767px) {
+    .diffRow {
+        grid-template-columns: 44px 1fr;
+    }
+
+    .diffIndex {
+        display: none !important;
+    }
+}
+
+/* Commit timeline rail — vertical fading gradient line at the left edge. */
+.timelineRail {
+    position: relative;
+}
+
+.timelineRail::before {
+    content: "";
+    position: absolute;
+    left: 28px;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: linear-gradient(
+        180deg,
+        transparent 0%,
+        rgba(9, 31, 64, 0.18) 8%,
+        rgba(9, 31, 64, 0.18) 92%,
+        transparent 100%
+    );
+}
+
+.timelineRail.dark::before {
+    background: linear-gradient(
+        180deg,
+        transparent 0%,
+        rgba(185, 214, 242, 0.18) 8%,
+        rgba(185, 214, 242, 0.18) 92%,
+        transparent 100%
+    );
+}
+
+@media (max-width: 767px) {
+    .timelineRail::before {
+        left: 14px;
+    }
+}
+
+/* CTA buttons — primary (red) + ghost (outlined). */
+.ctaPrimary {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    background: var(--red, #c5203e);
+    color: #fff;
+    font-family: var(--font-headline);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 16px 28px;
+    border: 0;
+    border-radius: 0;
+    box-shadow: 0 8px 20px rgba(197, 32, 62, 0.2);
+    transition:
+        transform 200ms ease,
+        background-color 200ms ease,
+        box-shadow 200ms ease;
+    text-decoration: none;
+}
+
+.ctaPrimary:hover {
+    transform: translateY(-1px);
+    background: var(--red-crimson, #a51c30);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+}
+
+.ctaPrimary:active {
+    transform: scale(0.95);
+}
+
+.ctaGhost {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    background: transparent;
+    color: #fff;
+    font-family: var(--font-headline);
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 16px 28px;
+    border: 1px solid rgba(185, 214, 242, 0.4);
+    border-radius: 0;
+    text-decoration: none;
+    transition: border-color 200ms ease;
+}
+
+.ctaGhost:hover {
+    border-color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .statusDot,
+    .scrollCue::after {
+        animation: none;
+    }
+}

--- a/src/containers/theory-of-change/vision.tsx
+++ b/src/containers/theory-of-change/vision.tsx
@@ -1,0 +1,137 @@
+import { scrollUpVariants } from "@utils/variants";
+import { motion } from "motion/react";
+import Link from "next/link";
+import styles from "./theory.module.css";
+
+const Vision = () => {
+    return (
+        <section
+            className="dark-section tw-relative tw-overflow-hidden tw-bg-navy tw-pb-0 tw-pt-[120px] tw-text-white"
+            aria-labelledby="toc-vision-headline"
+        >
+            <div className="tw-mx-auto tw-max-w-[1230px] tw-px-5 md:tw-px-10">
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-7 tw-text-gold"
+                    style={{
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 11,
+                        letterSpacing: "0.18em",
+                        textTransform: "uppercase",
+                    }}
+                >
+                    <span aria-hidden="true">/</span>
+                    <span aria-hidden="true">/</span> HEAD → vision/2030
+                </motion.div>
+
+                <motion.h2
+                    id="toc-vision-headline"
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-m-0 tw-mb-12 tw-font-heading tw-uppercase tw-text-white"
+                    style={{
+                        fontWeight: 900,
+                        fontSize: "clamp(36px, 6vw, 80px)",
+                        letterSpacing: "-0.025em",
+                        lineHeight: 1.02,
+                    }}
+                >
+                    A platform is not a curriculum.
+                    <br />
+                    It is a <span className="tw-text-red">launchpad.</span>
+                </motion.h2>
+
+                <motion.p
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-m-0 tw-mb-6 tw-font-body"
+                    style={{
+                        fontSize: 18,
+                        lineHeight: 1.7,
+                        color: "rgba(185,214,242,0.7)",
+                        maxWidth: 760,
+                    }}
+                >
+                    We envision a future where every veteran who wants a career in tech has access
+                    to the platform, mentorship, and tools they need to succeed.
+                </motion.p>
+                <motion.p
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-m-0 tw-font-body"
+                    style={{
+                        fontSize: 18,
+                        lineHeight: 1.7,
+                        color: "rgba(185,214,242,0.7)",
+                        maxWidth: 760,
+                    }}
+                >
+                    By continuing to build open-source tools that matter, develop products people
+                    use, and uplift our own through mentoring and advocacy, Vets Who Code will
+                    remain a blueprint for what&apos;s possible when service meets software.
+                </motion.p>
+
+                <motion.p
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-mb-12 tw-mt-9 tw-font-heading tw-uppercase tw-text-white"
+                    style={{
+                        fontWeight: 900,
+                        fontSize: "clamp(20px, 2.4vw, 28px)",
+                        letterSpacing: "-0.01em",
+                        lineHeight: 1.15,
+                    }}
+                >
+                    Retool. Retrain. Relaunch.
+                </motion.p>
+
+                <motion.div
+                    initial="offscreen"
+                    whileInView="onscreen"
+                    viewport={{ once: true, amount: 0.3 }}
+                    variants={scrollUpVariants}
+                    className="tw-flex tw-flex-wrap tw-gap-4"
+                >
+                    <Link href="/apply" className={styles.ctaPrimary}>
+                        Apply Now
+                        <span aria-hidden="true">→</span>
+                    </Link>
+                    <Link href="/about-us" className={styles.ctaGhost}>
+                        Read About Us
+                    </Link>
+                </motion.div>
+
+                <div
+                    className="tw-mt-12 tw-flex tw-flex-wrap tw-items-center tw-gap-3 tw-pt-10"
+                    style={{
+                        borderTop: "1px solid rgba(185,214,242,0.08)",
+                        paddingBottom: 40,
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 10.5,
+                        letterSpacing: "0.14em",
+                        textTransform: "uppercase",
+                        color: "rgba(185,214,242,0.45)",
+                    }}
+                >
+                    <span className="tw-text-red">$</span>
+                    <span>
+                        git log · 5 phases · 23 commits · #VetsWhoCode · 501(c)(3) · EIN 86-2122804
+                    </span>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+export default Vision;

--- a/src/pages/theory-of-change.tsx
+++ b/src/pages/theory-of-change.tsx
@@ -1,182 +1,41 @@
 import SEO from "@components/seo/page-seo";
-import CtaArea from "@containers/cta/layout-01";
-import HeroArea from "@containers/hero/layout-07";
+import CommitSection from "@containers/theory-of-change/commit-section";
+import CoreBelief from "@containers/theory-of-change/core-belief";
+import Hero from "@containers/theory-of-change/hero";
+import MergeBanner from "@containers/theory-of-change/merge-banner";
+import { PHASES } from "@containers/theory-of-change/phases-data";
+import Pipeline from "@containers/theory-of-change/pipeline";
+import Vision from "@containers/theory-of-change/vision";
 import Layout from "@layout/layout-01";
-import PullQuote from "@ui/pull-quote";
-import { normalizedData } from "@utils/methods";
-import type { GetStaticProps } from "next";
-import { getPageData } from "../lib/page";
-
-// Base content interface
-interface PageContent extends Record<string, unknown> {
-    section: string;
-    title?: string;
-    content?: string;
-    metadata?: Record<string, unknown>;
-    customFields?: Record<string, unknown>;
-    section_title?: {
-        title?: string;
-        subtitle?: string;
-    };
-    items?: Array<{
-        id: number | string;
-        headings?: Array<{ id: number | string; content: string }>;
-        texts?: Array<{
-            id: number | string;
-            content: string;
-            type?: "paragraph" | "bullet" | "subheading";
-        }>;
-        images?: Array<{ src: string }>;
-    }>;
-    buttons?: Array<{
-        id: number | string;
-        content: string;
-        path: string;
-    }>;
-}
-
-type TProps = {
-    data: {
-        page: {
-            content: PageContent[];
-        };
-    };
-};
 
 type PageWithLayout = {
-    (props: TProps): JSX.Element;
+    (): JSX.Element;
     Layout: typeof Layout;
 };
 
-const TheoryOfChange: PageWithLayout = ({ data }) => {
-    const content = normalizedData<PageContent>(data.page?.content, "section");
-    const theoryOfChangeData = content?.["theory-of-change-area"] as PageContent | undefined;
-
+const TheoryOfChange: PageWithLayout = () => {
     return (
         <>
             <SEO title="Theory of Change | Vets Who Code" />
-            <h1 className="tw-sr-only">Theory of Change</h1>
-            <HeroArea data={content?.["hero-area"]} />
-
-            {/* Mission anchor */}
-            <div className="dark-section tw-bg-navy tw-mt-20 md:tw-mt-[120px] tw-py-20 md:tw-py-[120px]">
-                <div className="tw-container">
-                    <PullQuote
-                        emphasis="We don't train veterans to fill seats."
-                        continuation="We train them to be impactful on their engineering teams at companies that shape the world."
-                    />
-                </div>
-            </div>
-
-            {theoryOfChangeData && (
-                <div className="tw-py-15 md:tw-py-20 lg:tw-py-28">
-                    <div className="tw-container">
-                        {theoryOfChangeData.section_title?.title && (
-                            <h2 className="tw-mb-4 tw-text-center tw-text-3xl tw-font-bold md:tw-text-4xl lg:tw-text-5xl">
-                                {theoryOfChangeData.section_title.title}
-                            </h2>
-                        )}
-                        {theoryOfChangeData.section_title?.subtitle && (
-                            <p className="tw-mb-10 tw-text-center tw-text-lg md:tw-mb-16">
-                                {theoryOfChangeData.section_title.subtitle}
-                            </p>
-                        )}
-                        {theoryOfChangeData.items?.map((item, itemIndex) => (
-                            <div key={item.id} className="tw-mb-16 last:tw-mb-0">
-                                {item.headings?.map((heading) => (
-                                    <h3
-                                        key={heading.id}
-                                        className="tw-mb-5 tw-text-2xl tw-font-semibold"
-                                    >
-                                        {heading.content}
-                                    </h3>
-                                ))}
-                                <div className="tw-text-base tw-text-gray-200">
-                                    {item.texts?.map((text, index) => {
-                                        if (text.type === "subheading") {
-                                            return (
-                                                <h4
-                                                    key={text.id}
-                                                    className="tw-mb-3 tw-mt-6 tw-text-lg tw-font-semibold first:tw-mt-0"
-                                                >
-                                                    {text.content}
-                                                </h4>
-                                            );
-                                        }
-
-                                        if (text.type === "paragraph") {
-                                            return (
-                                                <p key={text.id} className="tw-mb-4">
-                                                    {text.content}
-                                                </p>
-                                            );
-                                        }
-
-                                        if (text.type === "bullet") {
-                                            return (
-                                                <div
-                                                    key={text.id}
-                                                    className="tw-mb-3 tw-flex last:tw-mb-0"
-                                                >
-                                                    <div className="tw-mr-2">•</div>
-                                                    <div>{text.content}</div>
-                                                </div>
-                                            );
-                                        }
-
-                                        if (item.texts && item.texts.length > 1 && index === 0) {
-                                            return (
-                                                <p key={text.id} className="tw-mb-4">
-                                                    {text.content}
-                                                </p>
-                                            );
-                                        }
-
-                                        if (item.texts && item.texts.length > 1 && index > 0) {
-                                            return (
-                                                <div
-                                                    key={text.id}
-                                                    className="tw-mb-3 tw-flex last:tw-mb-0"
-                                                >
-                                                    <div className="tw-mr-2">•</div>
-                                                    <div>{text.content}</div>
-                                                </div>
-                                            );
-                                        }
-
-                                        return (
-                                            <p key={text.id} className="tw-mb-4">
-                                                {text.content}
-                                            </p>
-                                        );
-                                    })}
-                                </div>
-
-                                {theoryOfChangeData.items &&
-                                    itemIndex < theoryOfChangeData.items.length - 1 && (
-                                        <hr className="tw-my-10 tw-border-gray-200" />
-                                    )}
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            )}
-
-            <CtaArea data={content?.["cta-area"]} space="bottom" />
+            <Hero />
+            <CoreBelief />
+            <Pipeline />
+            <CommitSection phase={PHASES[0]} />
+            <CommitSection phase={PHASES[1]} />
+            <MergeBanner />
+            <CommitSection phase={PHASES[2]} />
+            <CommitSection phase={PHASES[3]} />
+            <CommitSection phase={PHASES[4]} />
+            <Vision />
         </>
     );
 };
 
 TheoryOfChange.Layout = Layout;
 
-export const getStaticProps: GetStaticProps = () => {
-    const page = getPageData("inner", "theory-of-change");
-
+export const getStaticProps = () => {
     return {
         props: {
-            data: {
-                page,
-            },
             layout: {
                 headerShadow: true,
                 headerFluid: false,


### PR DESCRIPTION
## Summary

- Replaces the CMS-driven `/theory-of-change` page with a long-form narrative built on a `git log --graph` metaphor.
- Hero ships an animated SVG (`HeroGitGraph`) — five branches fork from a service line and merge into a `v1.0 — engineer` release, driven by Framer Motion `pathLength` + staggered commit dots.
- Below the hero: README-style core belief, a five-phase `PipelineDiagram` SVG with growing red accent, five reusable `CommitSection` cards (Inputs / Activities / Outputs / Outcomes / Impact) with branch-colored markers + diff rows, a merge banner between Activities and Outputs, and a Vision closer with Apply + About Us CTAs plus the `5 phases · 23 commits` footer signature.
- Phase data is centralized in `phases-data.ts`. All animations honor `prefers-reduced-motion` via `useReducedMotion()`.

## Test plan

- [ ] Vercel preview builds without errors
- [ ] `/theory-of-change` renders all ten sections in order on desktop
- [ ] Hero git graph plays once when the hero comes into view (paths draw, commit dots pop in, `v1.0 — engineer` tag lands last)
- [ ] Gold status dot pulses next to "2026 cohort active"; vertical scroll cue wipes top↔bottom
- [ ] Pipeline diagram: red accent line grows along the spine on reveal; arrow + `→ shipped` label fade in after
- [ ] Each of the five phase sections shows the correct branch color on the commit marker, diff `+` glyph, hash, tag pill, and `+N added` footer label
- [ ] Diff rows tint red on hover (lighter tint on dark sections)
- [ ] Merge banner displays the ASCII glyph (`|` `|\` `| |` `|/` `*`) in gold next to the merge copy
- [ ] Vision CTAs route to `/apply` and `/about-us`; primary button presses with `scale(0.95)`
- [ ] Reduced-motion OS setting freezes the status dot, scroll cue, graph paths, and pipeline reveal (state jumps straight to end)
- [ ] Layout collapses cleanly at `<1024px` (hero single-column) and `<768px` (diff-index hides, timeline rail shifts left)