### PR TITLE
fix(theory-of-change): Replace fictional apps with real shipped products

### DIFF
--- a/src/containers/theory-of-change/phases-data.ts
+++ b/src/containers/theory-of-change/phases-data.ts
@@ -87,8 +87,8 @@ export const PHASES: Phase[] = [
                 text: "Learners contribute to internal and external open-source projects — scalable, readable code that integrates into production.",
             },
             {
-                label: "products/aegis.md",
-                text: "Veterans work on real nonprofit apps used by real users — the PTSD Toolkit, AEGIS — portfolio-ready with real-world scope.",
+                label: "products/shipped.md",
+                text: "Troops ship into real VWC products — this Next.js platform, VetsAI's MOS translator, the Hashflag VS Code theme, the API List. Production code with real users.",
             },
             {
                 label: "career/weekly.md",


### PR DESCRIPTION
## Summary

The Phase 02 (Activities) diff row in the Theory of Change page referenced **PTSD Toolkit** and **AEGIS** — neither of which VWC has actually built. Replaces that copy with the real shipped surface:

- this Next.js platform (LMS, RBAC, J0dI3 integration)
- VetsAI's MOS translator
- the Hashflag VS Code theme
- the API List

Diff label renamed from \`products/aegis.md\` → \`products/shipped.md\` to match.

## Test plan

- [ ] Vercel preview \`/theory-of-change\` Phase 02 shows the new copy on row 4
- [ ] Diff label shows \`products/shipped.md\`