### PR TITLE
feat(j0di3): Full backend integration — proxies, UI surfaces, admin console

### DIFF
--- a/src/components/ai-assistant/AITeachingAssistant.tsx
+++ b/src/components/ai-assistant/AITeachingAssistant.tsx
@@ -5,6 +5,8 @@ interface Message {
     role: "user" | "assistant";
     content: string;
     timestamp: Date;
+    messageId?: string;
+    feedback?: "up" | "down";
 }
 
 interface LessonContext {
@@ -100,6 +102,7 @@ export default function AITeachingAssistant({
                 role: "assistant",
                 content: data.response || data.explanation || data.answer || JSON.stringify(data),
                 timestamp: new Date(),
+                messageId: data.message_id,
             };
             setMessages((prev) => [...prev, assistantMessageObj]);
         } catch (err) {
@@ -113,6 +116,21 @@ export default function AITeachingAssistant({
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
         sendMessage();
+    };
+
+    const sendFeedback = async (index: number, rating: "up" | "down") => {
+        const msg = messages[index];
+        if (!msg?.messageId || msg.feedback) return;
+        setMessages((prev) => prev.map((m, i) => (i === index ? { ...m, feedback: rating } : m)));
+        try {
+            await fetch("/api/j0di3/learning/feedback", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ message_id: msg.messageId, rating }),
+            });
+        } catch {
+            // non-critical — optimistic update stays
+        }
     };
 
     if (!isOpen) return null;
@@ -178,13 +196,41 @@ export default function AITeachingAssistant({
                                 </div>
                                 <div
                                     className={clsx(
-                                        "tw-text-xs tw-mt-1",
+                                        "tw-text-xs tw-mt-1 tw-flex tw-items-center tw-gap-2",
                                         msg.role === "user"
                                             ? "tw-text-white tw-opacity-70"
                                             : "tw-text-ink/60"
                                     )}
                                 >
-                                    {msg.timestamp.toLocaleTimeString()}
+                                    <span>{msg.timestamp.toLocaleTimeString()}</span>
+                                    {msg.role === "assistant" && msg.messageId && (
+                                        <span className="tw-flex tw-gap-1">
+                                            <button
+                                                type="button"
+                                                onClick={() => sendFeedback(index, "up")}
+                                                disabled={!!msg.feedback}
+                                                className={clsx(
+                                                    "tw-px-1 tw-rounded hover:tw-bg-navy/10",
+                                                    msg.feedback === "up" && "tw-text-navy-deep"
+                                                )}
+                                                aria-label="Helpful"
+                                            >
+                                                👍
+                                            </button>
+                                            <button
+                                                type="button"
+                                                onClick={() => sendFeedback(index, "down")}
+                                                disabled={!!msg.feedback}
+                                                className={clsx(
+                                                    "tw-px-1 tw-rounded hover:tw-bg-navy/10",
+                                                    msg.feedback === "down" && "tw-text-red-dark"
+                                                )}
+                                                aria-label="Not helpful"
+                                            >
+                                                👎
+                                            </button>
+                                        </span>
+                                    )}
                                 </div>
                             </div>
                         </div>

--- a/src/components/profile/ProfileSettings.tsx
+++ b/src/components/profile/ProfileSettings.tsx
@@ -1,28 +1,225 @@
-const ProfileSettings = () => (
-    <div className="tw-space-y-6">
-        <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
-            <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
-                Notifications
-            </h3>
-            <div className="tw-space-y-3">
-                <Toggle label="Email notifications for course updates" defaultChecked={true} />
-                <Toggle label="Weekly progress reports" defaultChecked={true} />
-                <Toggle label="New assignment alerts" defaultChecked={false} />
-            </div>
-        </div>
+import { useEffect, useState } from "react";
 
-        <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
-            <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
-                Privacy
-            </h3>
-            <div className="tw-space-y-3">
-                <Toggle label="Make profile visible to other veterans" defaultChecked={false} />
-                <Toggle label="Show progress on leaderboards" defaultChecked={true} />
-                <Toggle label="Display GitHub stats on profile" defaultChecked={true} />
+interface Placement {
+    id?: string;
+    company?: string;
+    role?: string;
+    start_date?: string;
+    status?: string;
+}
+
+interface MosRelevance {
+    mos?: string;
+    target_role?: string;
+    relevance?: number;
+    matched_skills?: string[];
+    gap_skills?: string[];
+}
+
+const ProfileSettings = () => {
+    const [placements, setPlacements] = useState<Placement[] | null>(null);
+    const [mosRel, setMosRel] = useState<MosRelevance | null>(null);
+    const [busy, setBusy] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const [pRes, mRes] = await Promise.all([
+                    fetch("/api/j0di3/troops/placements"),
+                    fetch("/api/j0di3/troops/mos-relevance"),
+                ]);
+                if (pRes.ok) {
+                    const body = await pRes.json();
+                    setPlacements(Array.isArray(body) ? body : (body.placements ?? []));
+                }
+                if (mRes.ok) {
+                    setMosRel(await mRes.json());
+                }
+            } catch {
+                // non-critical
+            }
+        })();
+    }, []);
+
+    const exportData = async () => {
+        setBusy("export");
+        try {
+            const res = await fetch("/api/j0di3/troops/export");
+            if (!res.ok) {
+                setMessage("Export failed.");
+                return;
+            }
+            const body = await res.json();
+            const blob = new Blob([JSON.stringify(body, null, 2)], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "j0di3-export.json";
+            a.click();
+            URL.revokeObjectURL(url);
+            setMessage("Export downloaded.");
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    const wipeResumeHistory = async () => {
+        if (!window.confirm("Erase all resume history from J0dI3? This cannot be undone.")) return;
+        setBusy("resume");
+        try {
+            const res = await fetch("/api/j0di3/troops/resume-history", { method: "DELETE" });
+            setMessage(res.ok ? "Resume history erased." : "Wipe failed.");
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    const deleteTroop = async () => {
+        if (
+            !window.confirm(
+                "Delete your J0dI3 troop profile? This removes all your J0dI3 progress permanently."
+            )
+        )
+            return;
+        setBusy("delete");
+        try {
+            const res = await fetch("/api/j0di3/troops/delete", { method: "DELETE" });
+            setMessage(res.ok ? "J0dI3 troop profile deleted." : "Delete failed.");
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    return (
+        <div className="tw-space-y-6">
+            {message && (
+                <div className="tw-rounded-md tw-border tw-border-navy/10 tw-bg-navy-sky/20 tw-px-4 tw-py-2 tw-text-sm tw-text-navy-deep">
+                    {message}
+                </div>
+            )}
+
+            <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
+                <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                    Notifications
+                </h3>
+                <div className="tw-space-y-3">
+                    <Toggle label="Email notifications for course updates" defaultChecked={true} />
+                    <Toggle label="Weekly progress reports" defaultChecked={true} />
+                    <Toggle label="New assignment alerts" defaultChecked={false} />
+                </div>
+            </div>
+
+            <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
+                <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                    Privacy
+                </h3>
+                <div className="tw-space-y-3">
+                    <Toggle label="Make profile visible to other veterans" defaultChecked={false} />
+                    <Toggle label="Show progress on leaderboards" defaultChecked={true} />
+                    <Toggle label="Display GitHub stats on profile" defaultChecked={true} />
+                </div>
+            </div>
+
+            {mosRel && (mosRel.relevance != null || mosRel.target_role) && (
+                <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
+                    <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                        MOS → role relevance
+                    </h3>
+                    <div className="tw-text-sm tw-text-ink/80 tw-space-y-1">
+                        {mosRel.mos && (
+                            <div>
+                                <strong>MOS:</strong> {mosRel.mos}
+                            </div>
+                        )}
+                        {mosRel.target_role && (
+                            <div>
+                                <strong>Target:</strong> {mosRel.target_role}
+                            </div>
+                        )}
+                        {mosRel.relevance != null && (
+                            <div>
+                                <strong>Relevance:</strong> {Math.round(mosRel.relevance * 100)}%
+                            </div>
+                        )}
+                        {mosRel.matched_skills && mosRel.matched_skills.length > 0 && (
+                            <div>
+                                <strong>Matched:</strong> {mosRel.matched_skills.join(", ")}
+                            </div>
+                        )}
+                        {mosRel.gap_skills && mosRel.gap_skills.length > 0 && (
+                            <div>
+                                <strong>Gaps:</strong> {mosRel.gap_skills.join(", ")}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            {placements && placements.length > 0 && (
+                <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
+                    <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                        Placements
+                    </h3>
+                    <ul className="tw-space-y-2">
+                        {placements.map((p, i) => (
+                            <li
+                                key={p.id || i}
+                                className="tw-flex tw-items-center tw-justify-between tw-text-sm"
+                            >
+                                <div>
+                                    <span className="tw-font-semibold tw-text-ink">
+                                        {p.role || "Role"}
+                                    </span>
+                                    {p.company && (
+                                        <span className="tw-text-ink/60"> @ {p.company}</span>
+                                    )}
+                                </div>
+                                {p.status && (
+                                    <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-[10px] tw-text-navy-deep">
+                                        {p.status}
+                                    </span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
+            <div className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-6 tw-shadow-sm">
+                <h3 className="tw-mb-4 tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                    Data
+                </h3>
+                <div className="tw-flex tw-flex-wrap tw-gap-3">
+                    <button
+                        type="button"
+                        onClick={exportData}
+                        disabled={busy === "export"}
+                        className="tw-rounded-md tw-border tw-border-navy/10 tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-ink hover:tw-bg-navy/5 disabled:tw-opacity-50"
+                    >
+                        {busy === "export" ? "Exporting..." : "Export J0dI3 data"}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={wipeResumeHistory}
+                        disabled={busy === "resume"}
+                        className="tw-rounded-md tw-border tw-border-red tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-red-dark hover:tw-bg-cream disabled:tw-opacity-50"
+                    >
+                        {busy === "resume" ? "Erasing..." : "Erase resume history"}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={deleteTroop}
+                        disabled={busy === "delete"}
+                        className="tw-rounded-md tw-bg-red tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-white hover:tw-bg-red-dark disabled:tw-opacity-50"
+                    >
+                        {busy === "delete" ? "Deleting..." : "Delete J0dI3 troop profile"}
+                    </button>
+                </div>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 function Toggle({ label, defaultChecked }: { label: string; defaultChecked: boolean }) {
     return (

--- a/src/components/profile/TroopDashboard.tsx
+++ b/src/components/profile/TroopDashboard.tsx
@@ -52,10 +52,31 @@ interface ProgressData {
     overall_total: number;
 }
 
+interface XpData {
+    total_xp?: number;
+    level?: number | string;
+    xp_to_next_level?: number;
+}
+
+interface StreakData {
+    current_streak?: number;
+    longest_streak?: number;
+}
+
+interface TodayData {
+    xp_earned?: number;
+    lessons_completed?: number;
+    challenges_completed?: number;
+    minutes_active?: number;
+}
+
 export default function TroopDashboard() {
     const [data, setData] = useState<DashboardData | null>(null);
     const [warmups, setWarmups] = useState<WarmupChallenge[]>([]);
     const [progress, setProgress] = useState<ProgressData | null>(null);
+    const [xp, setXp] = useState<XpData | null>(null);
+    const [streak, setStreak] = useState<StreakData | null>(null);
+    const [today, setToday] = useState<TodayData | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [isLoadingWarmups, setIsLoadingWarmups] = useState(true);
     const [isLoadingProgress, setIsLoadingProgress] = useState(true);
@@ -133,11 +154,41 @@ export default function TroopDashboard() {
         }
     }, []);
 
+    const fetchXp = useCallback(async () => {
+        try {
+            const res = await fetch("/api/j0di3/troops/xp");
+            if (res.ok) setXp(await res.json());
+        } catch {
+            // non-critical
+        }
+    }, []);
+
+    const fetchStreak = useCallback(async () => {
+        try {
+            const res = await fetch("/api/j0di3/troops/streak");
+            if (res.ok) setStreak(await res.json());
+        } catch {
+            // non-critical
+        }
+    }, []);
+
+    const fetchToday = useCallback(async () => {
+        try {
+            const res = await fetch("/api/j0di3/troops/today");
+            if (res.ok) setToday(await res.json());
+        } catch {
+            // non-critical
+        }
+    }, []);
+
     useEffect(() => {
         fetchDashboard();
         fetchWarmups();
         fetchProgress();
-    }, [fetchDashboard, fetchWarmups, fetchProgress]);
+        fetchXp();
+        fetchStreak();
+        fetchToday();
+    }, [fetchDashboard, fetchWarmups, fetchProgress, fetchXp, fetchStreak, fetchToday]);
 
     if (isLoading) {
         return (
@@ -164,6 +215,9 @@ export default function TroopDashboard() {
 
     return (
         <div className="tw-space-y-6">
+            {/* Today / XP / Streak summary */}
+            <TodayStrip xp={xp} streak={streak} today={today} />
+
             {/* Reps tray — confidence loop entry point */}
             <RepsTray warmups={warmups} loading={isLoadingWarmups} />
 
@@ -366,6 +420,58 @@ export default function TroopDashboard() {
                     </div>
                 </div>
             )}
+        </div>
+    );
+}
+
+function TodayStrip({
+    xp,
+    streak,
+    today,
+}: {
+    xp: XpData | null;
+    streak: StreakData | null;
+    today: TodayData | null;
+}) {
+    const tiles: { label: string; value: string | number; sub?: string }[] = [];
+    if (xp?.total_xp != null) {
+        tiles.push({
+            label: "XP",
+            value: xp.total_xp,
+            sub: xp.level != null ? `Level ${xp.level}` : undefined,
+        });
+    }
+    if (streak?.current_streak != null) {
+        tiles.push({
+            label: "Streak",
+            value: `${streak.current_streak}d`,
+            sub:
+                streak.longest_streak != null && streak.longest_streak > 0
+                    ? `Best ${streak.longest_streak}d`
+                    : undefined,
+        });
+    }
+    if (today?.xp_earned != null) {
+        tiles.push({ label: "XP Today", value: today.xp_earned });
+    }
+    if (today?.minutes_active != null) {
+        tiles.push({ label: "Active Today", value: `${today.minutes_active}m` });
+    }
+    if (tiles.length === 0) return null;
+    return (
+        <div className="tw-grid tw-grid-cols-2 md:tw-grid-cols-4 tw-gap-3">
+            {tiles.map((tile) => (
+                <div
+                    key={tile.label}
+                    className="tw-rounded-md tw-border tw-border-primary/20 tw-bg-white tw-p-4 tw-shadow-sm"
+                >
+                    <div className="tw-font-mono tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-primary">
+                        {tile.label}
+                    </div>
+                    <div className="tw-text-2xl tw-font-bold tw-text-ink tw-mt-1">{tile.value}</div>
+                    {tile.sub && <div className="tw-text-xs tw-text-ink/60">{tile.sub}</div>}
+                </div>
+            ))}
         </div>
     );
 }

--- a/src/lib/j0di3-proxy.ts
+++ b/src/lib/j0di3-proxy.ts
@@ -1,43 +1,72 @@
 import axios from "axios";
 import type { NextApiRequest, NextApiResponse } from "next";
 import j0di3 from "@/lib/j0di3-client";
-import { type AuthenticatedRequest, requireAuth } from "@/lib/rbac";
+import { type AuthenticatedRequest, requireAuth, requireRole } from "@/lib/rbac";
 
 type Method = "GET" | "POST" | "PATCH" | "DELETE";
 
-export function j0di3Proxy(method: Method, path: string | ((req: NextApiRequest) => string)) {
+interface ProxyOptions {
+    injectTroopId?: boolean;
+}
+
+async function dispatch(
+    req: AuthenticatedRequest,
+    res: NextApiResponse,
+    method: Method,
+    url: string,
+    injectTroopId: boolean
+) {
+    const troopId = req.user!.troopId;
+    if (injectTroopId && !troopId) {
+        return res
+            .status(400)
+            .json({ error: "No J0dI3 troop profile linked. Please sign out and back in." });
+    }
+
+    try {
+        const body =
+            method !== "GET"
+                ? injectTroopId
+                    ? { ...req.body, troop_id: troopId }
+                    : req.body
+                : undefined;
+
+        const params =
+            method === "GET"
+                ? injectTroopId
+                    ? { ...req.query, troop_id: troopId }
+                    : req.query
+                : undefined;
+
+        const { data } = await j0di3({ method, url, data: body, params });
+        res.json(data);
+    } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+            const status = error.response.status;
+            const message =
+                error.response.data?.detail || error.response.data?.error || "J0dI3 request failed";
+            return res.status(status).json({ error: message });
+        }
+        console.error("[j0di3-proxy] Unexpected error:", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+}
+
+export function j0di3Proxy(
+    method: Method,
+    path: string | ((req: NextApiRequest) => string),
+    options: ProxyOptions = {}
+) {
+    const injectTroopId = options.injectTroopId !== false;
     return requireAuth(async (req: AuthenticatedRequest, res: NextApiResponse) => {
         const url = typeof path === "function" ? path(req) : path;
-        const troopId = req.user!.troopId;
+        return dispatch(req, res, method, url, injectTroopId);
+    });
+}
 
-        if (!troopId) {
-            return res
-                .status(400)
-                .json({ error: "No J0dI3 troop profile linked. Please sign out and back in." });
-        }
-
-        try {
-            const body = method !== "GET" ? { ...req.body, troop_id: troopId } : undefined;
-
-            const { data } = await j0di3({
-                method,
-                url,
-                data: body,
-                params: method === "GET" ? { ...req.query, troop_id: troopId } : undefined,
-            });
-
-            res.json(data);
-        } catch (error: unknown) {
-            if (axios.isAxiosError(error) && error.response) {
-                const status = error.response.status;
-                const message =
-                    error.response.data?.detail ||
-                    error.response.data?.error ||
-                    "J0dI3 request failed";
-                return res.status(status).json({ error: message });
-            }
-            console.error("[j0di3-proxy] Unexpected error:", error);
-            return res.status(500).json({ error: "Internal server error" });
-        }
+export function j0di3AdminProxy(method: Method, path: string | ((req: NextApiRequest) => string)) {
+    return requireRole("ADMIN")(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+        const url = typeof path === "function" ? path(req) : path;
+        return dispatch(req, res, method, url, false);
     });
 }

--- a/src/pages/admin/j0di3/budget.tsx
+++ b/src/pages/admin/j0di3/budget.tsx
@@ -1,0 +1,140 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface BudgetPayload {
+    total_spent?: number;
+    monthly_limit?: number;
+    period?: string;
+    by_provider?: { provider?: string; spent?: number; calls?: number }[];
+    by_pillar?: { pillar?: string; spent?: number; calls?: number }[];
+}
+
+const BudgetAdmin: PageWithLayout = () => {
+    const [data, setData] = useState<BudgetPayload | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            const res = await fetch("/api/j0di3/admin/budget");
+            if (res.ok) setData(await res.json());
+        })();
+    }, []);
+
+    return (
+        <>
+            <SEO title="Budget — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                ]}
+                currentPage="Budget"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-6">
+                <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Budget</h1>
+
+                {data && (
+                    <>
+                        <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-3 tw-gap-3">
+                            <Tile label="Spent" value={`$${(data.total_spent ?? 0).toFixed(2)}`} />
+                            {data.monthly_limit != null && (
+                                <Tile
+                                    label="Monthly limit"
+                                    value={`$${data.monthly_limit.toFixed(2)}`}
+                                />
+                            )}
+                            {data.period && <Tile label="Period" value={data.period} />}
+                        </div>
+
+                        {data.by_provider && data.by_provider.length > 0 && (
+                            <Section
+                                title="By provider"
+                                rows={data.by_provider}
+                                keyName="provider"
+                            />
+                        )}
+                        {data.by_pillar && data.by_pillar.length > 0 && (
+                            <Section title="By pillar" rows={data.by_pillar} keyName="pillar" />
+                        )}
+                    </>
+                )}
+            </div>
+        </>
+    );
+};
+
+function Tile({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4">
+            <div className="tw-font-mono tw-text-[10px] tw-uppercase tw-text-navy/60">{label}</div>
+            <div className="tw-text-2xl tw-font-bold tw-text-ink tw-mt-1">{value}</div>
+        </div>
+    );
+}
+
+function Section({
+    title,
+    rows,
+    keyName,
+}: {
+    title: string;
+    rows: { spent?: number; calls?: number; [k: string]: unknown }[];
+    keyName: string;
+}) {
+    return (
+        <section>
+            <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                {title}
+            </h2>
+            <table className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-overflow-hidden">
+                <thead className="tw-bg-navy/5">
+                    <tr className="tw-text-left tw-text-xs tw-uppercase tw-text-navy/60">
+                        <th className="tw-px-4 tw-py-2">{keyName}</th>
+                        <th className="tw-px-4 tw-py-2 tw-text-right">Calls</th>
+                        <th className="tw-px-4 tw-py-2 tw-text-right">Spent</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map((r, i) => (
+                        <tr key={i} className="tw-border-t tw-border-navy/10 tw-text-sm">
+                            <td className="tw-px-4 tw-py-2 tw-text-ink">
+                                {String(r[keyName] ?? "—")}
+                            </td>
+                            <td className="tw-px-4 tw-py-2 tw-text-right tw-text-ink/70">
+                                {r.calls ?? "—"}
+                            </td>
+                            <td className="tw-px-4 tw-py-2 tw-text-right tw-text-ink/70">
+                                ${(r.spent ?? 0).toFixed(2)}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </section>
+    );
+}
+
+BudgetAdmin.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default BudgetAdmin;

--- a/src/pages/admin/j0di3/cohorts/[id].tsx
+++ b/src/pages/admin/j0di3/cohorts/[id].tsx
@@ -1,0 +1,192 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface Cohort {
+    id?: string;
+    name?: string;
+    start_date?: string;
+    end_date?: string;
+    status?: string;
+}
+
+interface RosterEntry {
+    troop_id?: string;
+    name?: string;
+    email?: string;
+    branch?: string;
+    current_module?: number;
+    status?: string;
+}
+
+const CohortDetail: PageWithLayout = () => {
+    const router = useRouter();
+    const id = typeof router.query.id === "string" ? router.query.id : null;
+
+    const [cohort, setCohort] = useState<Cohort | null>(null);
+    const [roster, setRoster] = useState<RosterEntry[]>([]);
+    const [bulkText, setBulkText] = useState("");
+    const [busy, setBusy] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+
+    const load = async () => {
+        if (!id) return;
+        const [cRes, rRes] = await Promise.all([
+            fetch(`/api/j0di3/admin/cohorts/${id}`),
+            fetch(`/api/j0di3/admin/cohorts/${id}/roster`),
+        ]);
+        if (cRes.ok) setCohort(await cRes.json());
+        if (rRes.ok) {
+            const body = await rRes.json();
+            setRoster(Array.isArray(body) ? body : (body.troops ?? []));
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, [id]);
+
+    const addBulk = async () => {
+        if (!id || !bulkText.trim()) return;
+        const emails = bulkText
+            .split(/[\s,]+/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+        if (emails.length === 0) return;
+        setBusy(true);
+        setMessage(null);
+        try {
+            const res = await fetch(`/api/j0di3/admin/cohorts/${id}/troops-bulk`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ emails }),
+            });
+            if (res.ok) {
+                setMessage(`Added ${emails.length} troops.`);
+                setBulkText("");
+                await load();
+            } else {
+                const err = await res.json();
+                setMessage(err.error || "Add failed.");
+            }
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <>
+            <SEO title={`${cohort?.name ?? "Cohort"} — J0dI3 Admin`} />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                    { path: "/admin/j0di3/cohorts", label: "cohorts" },
+                ]}
+                currentPage={cohort?.name ?? "Cohort"}
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-6">
+                <h1 className="tw-text-3xl tw-font-bold tw-text-ink">{cohort?.name || "Cohort"}</h1>
+
+                <section className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-4">
+                    <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                        Bulk add troops
+                    </h2>
+                    <textarea
+                        value={bulkText}
+                        onChange={(e) => setBulkText(e.target.value)}
+                        rows={3}
+                        placeholder="Comma- or newline-separated emails"
+                        className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                    />
+                    <button
+                        type="button"
+                        onClick={addBulk}
+                        disabled={busy || !bulkText.trim()}
+                        className="tw-mt-2 tw-rounded-md tw-bg-primary tw-px-5 tw-py-2 tw-text-sm tw-font-medium tw-text-white disabled:tw-opacity-50"
+                    >
+                        {busy ? "Adding..." : "Add troops"}
+                    </button>
+                    {message && <p className="tw-mt-2 tw-text-sm tw-text-ink/70">{message}</p>}
+                </section>
+
+                <section>
+                    <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                        Roster ({roster.length})
+                    </h2>
+                    <table className="tw-w-full tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-overflow-hidden">
+                        <thead className="tw-bg-navy/5">
+                            <tr className="tw-text-left tw-text-xs tw-uppercase tw-text-navy/60">
+                                <th className="tw-px-4 tw-py-2">Name</th>
+                                <th className="tw-px-4 tw-py-2">Email</th>
+                                <th className="tw-px-4 tw-py-2">Branch</th>
+                                <th className="tw-px-4 tw-py-2">Module</th>
+                                <th className="tw-px-4 tw-py-2">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {roster.length === 0 && (
+                                <tr>
+                                    <td
+                                        colSpan={5}
+                                        className="tw-px-4 tw-py-6 tw-text-center tw-text-ink/60"
+                                    >
+                                        Empty roster.
+                                    </td>
+                                </tr>
+                            )}
+                            {roster.map((r) => (
+                                <tr
+                                    key={r.troop_id}
+                                    className="tw-border-t tw-border-navy/10 tw-text-sm"
+                                >
+                                    <td className="tw-px-4 tw-py-2 tw-font-medium tw-text-ink">
+                                        {r.name || "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {r.email || "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {r.branch || "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {r.current_module ?? "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {r.status || "—"}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </section>
+            </div>
+        </>
+    );
+};
+
+CohortDetail.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default CohortDetail;

--- a/src/pages/admin/j0di3/cohorts/index.tsx
+++ b/src/pages/admin/j0di3/cohorts/index.tsx
@@ -1,0 +1,203 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface Cohort {
+    id?: string;
+    name?: string;
+    start_date?: string;
+    end_date?: string;
+    size?: number;
+    status?: string;
+}
+
+const CohortsAdmin: PageWithLayout = () => {
+    const [cohorts, setCohorts] = useState<Cohort[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [name, setName] = useState("");
+    const [startDate, setStartDate] = useState("");
+    const [creating, setCreating] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = async () => {
+        setIsLoading(true);
+        try {
+            const res = await fetch("/api/j0di3/admin/cohorts");
+            if (res.ok) {
+                const body = await res.json();
+                setCohorts(Array.isArray(body) ? body : (body.cohorts ?? []));
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, []);
+
+    const create = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        setCreating(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/j0di3/admin/cohorts", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name, start_date: startDate || undefined }),
+            });
+            if (!res.ok) {
+                const err = await res.json();
+                setError(err.error || "Create failed");
+                return;
+            }
+            setName("");
+            setStartDate("");
+            await load();
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    return (
+        <>
+            <SEO title="Cohorts — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin", label: "admin" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                ]}
+                currentPage="Cohorts"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-6">
+                <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Cohorts</h1>
+
+                <form
+                    onSubmit={create}
+                    className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-4 tw-flex tw-flex-wrap tw-gap-3 tw-items-end"
+                >
+                    <div className="tw-flex-1 tw-min-w-[200px]">
+                        <label
+                            htmlFor="cohort-name"
+                            className="tw-block tw-text-xs tw-font-medium tw-text-ink/80 tw-mb-1"
+                        >
+                            Cohort name
+                        </label>
+                        <input
+                            id="cohort-name"
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="Cohort 12"
+                            className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                        />
+                    </div>
+                    <div>
+                        <label
+                            htmlFor="cohort-start"
+                            className="tw-block tw-text-xs tw-font-medium tw-text-ink/80 tw-mb-1"
+                        >
+                            Start date
+                        </label>
+                        <input
+                            id="cohort-start"
+                            type="date"
+                            value={startDate}
+                            onChange={(e) => setStartDate(e.target.value)}
+                            className="tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                        />
+                    </div>
+                    <button
+                        type="submit"
+                        disabled={creating || !name.trim()}
+                        className="tw-rounded-md tw-bg-primary tw-px-5 tw-py-2 tw-text-sm tw-font-medium tw-text-white disabled:tw-opacity-50"
+                    >
+                        {creating ? "Creating..." : "Create cohort"}
+                    </button>
+                </form>
+
+                {error && <p className="tw-text-red-dark tw-text-sm">{error}</p>}
+
+                {isLoading ? (
+                    <p className="tw-text-ink/60">Loading...</p>
+                ) : (
+                    <table className="tw-w-full tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-overflow-hidden">
+                        <thead className="tw-bg-navy/5">
+                            <tr className="tw-text-left tw-text-xs tw-uppercase tw-text-navy/60">
+                                <th className="tw-px-4 tw-py-2">Name</th>
+                                <th className="tw-px-4 tw-py-2">Start</th>
+                                <th className="tw-px-4 tw-py-2">Size</th>
+                                <th className="tw-px-4 tw-py-2">Status</th>
+                                <th className="tw-px-4 tw-py-2 tw-text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {cohorts.length === 0 && (
+                                <tr>
+                                    <td
+                                        colSpan={5}
+                                        className="tw-px-4 tw-py-6 tw-text-center tw-text-ink/60"
+                                    >
+                                        No cohorts yet.
+                                    </td>
+                                </tr>
+                            )}
+                            {cohorts.map((c) => (
+                                <tr key={c.id} className="tw-border-t tw-border-navy/10 tw-text-sm">
+                                    <td className="tw-px-4 tw-py-2 tw-font-medium tw-text-ink">
+                                        {c.name || c.id}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {c.start_date || "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {c.size ?? "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {c.status || "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-right">
+                                        <Link
+                                            href={`/admin/j0di3/cohorts/${c.id}`}
+                                            className="tw-text-xs tw-text-primary hover:tw-underline"
+                                        >
+                                            Open →
+                                        </Link>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </>
+    );
+};
+
+CohortsAdmin.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default CohortsAdmin;

--- a/src/pages/admin/j0di3/funnel.tsx
+++ b/src/pages/admin/j0di3/funnel.tsx
@@ -1,0 +1,103 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface FunnelPayload {
+    stages?: { name?: string; count?: number; rate?: number }[];
+    overall?: Record<string, number | string>;
+}
+
+const FunnelAdmin: PageWithLayout = () => {
+    const [data, setData] = useState<FunnelPayload | null>(null);
+    const [placements, setPlacements] = useState<FunnelPayload | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            const [f, p] = await Promise.all([
+                fetch("/api/j0di3/admin/funnel"),
+                fetch("/api/j0di3/admin/funnel/placements"),
+            ]);
+            if (f.ok) setData(await f.json());
+            if (p.ok) setPlacements(await p.json());
+        })();
+    }, []);
+
+    return (
+        <>
+            <SEO title="Funnel — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                ]}
+                currentPage="Funnel"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-8">
+                <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Funnel</h1>
+
+                <FunnelTable title="Engagement funnel" data={data} />
+                <FunnelTable title="Placement funnel" data={placements} />
+            </div>
+        </>
+    );
+};
+
+function FunnelTable({ title, data }: { title: string; data: FunnelPayload | null }) {
+    if (!data) return null;
+    const stages = data.stages ?? [];
+    return (
+        <section>
+            <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-3">
+                {title}
+            </h2>
+            {stages.length === 0 ? (
+                <p className="tw-text-ink/60 tw-text-sm">No funnel data.</p>
+            ) : (
+                <ul className="tw-space-y-2">
+                    {stages.map((s, i) => (
+                        <li
+                            key={i}
+                            className="tw-flex tw-items-center tw-gap-3 tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-px-4 tw-py-2"
+                        >
+                            <span className="tw-w-6 tw-font-mono tw-text-xs tw-text-ink/60">
+                                {i + 1}.
+                            </span>
+                            <span className="tw-flex-1 tw-font-medium tw-text-ink">{s.name}</span>
+                            <span className="tw-text-ink/70 tw-text-sm">{s.count}</span>
+                            {s.rate != null && (
+                                <span className="tw-text-xs tw-text-primary tw-w-12 tw-text-right">
+                                    {Math.round(s.rate * 100)}%
+                                </span>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </section>
+    );
+}
+
+FunnelAdmin.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default FunnelAdmin;

--- a/src/pages/admin/j0di3/index.tsx
+++ b/src/pages/admin/j0di3/index.tsx
@@ -1,0 +1,117 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface Stats {
+    troops_total?: number;
+    troops_active?: number;
+    challenges_completed_today?: number;
+    lessons_completed_today?: number;
+    [key: string]: unknown;
+}
+
+const links = [
+    { href: "/admin/j0di3/cohorts", label: "Cohorts", icon: "fa-users" },
+    { href: "/admin/j0di3/lessons", label: "Lessons review", icon: "fa-book-open" },
+    { href: "/admin/j0di3/placements", label: "Placements", icon: "fa-briefcase" },
+    { href: "/admin/j0di3/learning-feedback", label: "Learning feedback", icon: "fa-comment" },
+    { href: "/admin/j0di3/funnel", label: "Funnel", icon: "fa-chart-line" },
+    { href: "/admin/j0di3/budget", label: "Budget", icon: "fa-dollar-sign" },
+    { href: "/admin/j0di3/troops-stuck", label: "Stuck troops", icon: "fa-exclamation-triangle" },
+];
+
+const J0di3AdminHome: PageWithLayout = () => {
+    const [stats, setStats] = useState<Stats | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const res = await fetch("/api/j0di3/admin/stats");
+                if (res.ok) setStats(await res.json());
+            } catch {
+                // non-critical
+            }
+        })();
+    }, []);
+
+    return (
+        <>
+            <SEO title="J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin", label: "admin" },
+                ]}
+                currentPage="J0dI3"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-8">
+                <header>
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink">J0dI3 Admin</h1>
+                    <p className="tw-mt-2 tw-text-ink/70">
+                        Cohorts, lessons review, placements, telemetry.
+                    </p>
+                </header>
+
+                {stats && (
+                    <div className="tw-grid tw-grid-cols-2 md:tw-grid-cols-4 tw-gap-3">
+                        {Object.entries(stats)
+                            .filter(([, v]) => typeof v === "number")
+                            .slice(0, 8)
+                            .map(([k, v]) => (
+                                <div
+                                    key={k}
+                                    className="tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4"
+                                >
+                                    <div className="tw-font-mono tw-text-[10px] tw-uppercase tw-text-navy/60">
+                                        {k.replace(/_/g, " ")}
+                                    </div>
+                                    <div className="tw-text-2xl tw-font-bold tw-text-ink tw-mt-1">
+                                        {v as number}
+                                    </div>
+                                </div>
+                            ))}
+                    </div>
+                )}
+
+                <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4">
+                    {links.map((l) => (
+                        <Link
+                            key={l.href}
+                            href={l.href}
+                            className="tw-flex tw-items-center tw-gap-3 tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4 hover:tw-border-primary"
+                        >
+                            <i className={`fas ${l.icon} tw-text-2xl tw-text-primary`} />
+                            <span className="tw-font-medium tw-text-ink">{l.label}</span>
+                        </Link>
+                    ))}
+                </div>
+            </div>
+        </>
+    );
+};
+
+J0di3AdminHome.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default J0di3AdminHome;

--- a/src/pages/admin/j0di3/learning-feedback.tsx
+++ b/src/pages/admin/j0di3/learning-feedback.tsx
@@ -1,0 +1,142 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface FeedbackItem {
+    id?: string;
+    message_id?: string;
+    troop_id?: string;
+    rating?: "up" | "down";
+    content?: string;
+    question?: string;
+    reviewed?: boolean;
+    created_at?: string;
+}
+
+const LearningFeedbackAdmin: PageWithLayout = () => {
+    const [items, setItems] = useState<FeedbackItem[]>([]);
+    const [busy, setBusy] = useState<string | null>(null);
+
+    const load = async () => {
+        const res = await fetch("/api/j0di3/admin/learning/feedback");
+        if (res.ok) {
+            const body = await res.json();
+            setItems(Array.isArray(body) ? body : (body.items ?? body.feedback ?? []));
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, []);
+
+    const markReviewed = async (id: string, action: "approve" | "reject") => {
+        setBusy(id);
+        try {
+            const res = await fetch(`/api/j0di3/admin/learning/feedback/${id}/review`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ action }),
+            });
+            if (res.ok) await load();
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    return (
+        <>
+            <SEO title="Learning feedback — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                ]}
+                currentPage="Learning feedback"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-4">
+                <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Learning feedback</h1>
+
+                <ul className="tw-space-y-3">
+                    {items.length === 0 && (
+                        <li className="tw-text-ink/60">No feedback to review.</li>
+                    )}
+                    {items.map((f) => {
+                        const id = f.id || f.message_id || "";
+                        return (
+                            <li
+                                key={id}
+                                className="tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4"
+                            >
+                                <div className="tw-flex tw-items-center tw-justify-between tw-mb-2">
+                                    <span
+                                        className={`tw-text-xs tw-font-bold ${f.rating === "up" ? "tw-text-navy-deep" : "tw-text-red-dark"}`}
+                                    >
+                                        {f.rating === "up" ? "👍" : "👎"} {f.rating}
+                                    </span>
+                                    {f.reviewed && (
+                                        <span className="tw-text-xs tw-text-ink/60">reviewed</span>
+                                    )}
+                                </div>
+                                {f.question && (
+                                    <div className="tw-text-sm tw-text-ink/80 tw-mb-1">
+                                        <strong>Q:</strong> {f.question}
+                                    </div>
+                                )}
+                                {f.content && (
+                                    <div className="tw-text-sm tw-text-ink/70 tw-whitespace-pre-wrap">
+                                        {f.content}
+                                    </div>
+                                )}
+                                {!f.reviewed && (
+                                    <div className="tw-flex tw-gap-2 tw-mt-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => markReviewed(id, "approve")}
+                                            disabled={busy === id}
+                                            className="tw-text-xs tw-rounded tw-border tw-border-primary tw-px-2 tw-py-1 tw-text-primary disabled:tw-opacity-50"
+                                        >
+                                            Approve
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => markReviewed(id, "reject")}
+                                            disabled={busy === id}
+                                            className="tw-text-xs tw-rounded tw-border tw-border-red tw-px-2 tw-py-1 tw-text-red-dark disabled:tw-opacity-50"
+                                        >
+                                            Reject
+                                        </button>
+                                    </div>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        </>
+    );
+};
+
+LearningFeedbackAdmin.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default LearningFeedbackAdmin;

--- a/src/pages/admin/j0di3/lessons/index.tsx
+++ b/src/pages/admin/j0di3/lessons/index.tsx
@@ -1,0 +1,165 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface ReviewItem {
+    lesson_id?: string;
+    id?: string;
+    title?: string;
+    module?: number;
+    status?: string;
+    claimed_by?: string;
+    updated_at?: string;
+}
+
+const LessonsAdmin: PageWithLayout = () => {
+    const [queue, setQueue] = useState<ReviewItem[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [busy, setBusy] = useState<string | null>(null);
+
+    const load = async () => {
+        setIsLoading(true);
+        try {
+            const res = await fetch("/api/j0di3/admin/lessons/review-queue");
+            if (res.ok) {
+                const body = await res.json();
+                setQueue(Array.isArray(body) ? body : (body.items ?? body.lessons ?? []));
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, []);
+
+    const action = async (id: string, kind: "claim" | "release" | "force-release") => {
+        setBusy(`${id}:${kind}`);
+        try {
+            const res = await fetch(`/api/j0di3/admin/lessons/${id}/${kind}`, { method: "POST" });
+            if (res.ok) await load();
+        } finally {
+            setBusy(null);
+        }
+    };
+
+    return (
+        <>
+            <SEO title="Lesson review — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                ]}
+                currentPage="Lessons review"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-6">
+                <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Lesson review queue</h1>
+
+                {isLoading ? (
+                    <p className="tw-text-ink/60">Loading...</p>
+                ) : (
+                    <table className="tw-w-full tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-overflow-hidden">
+                        <thead className="tw-bg-navy/5">
+                            <tr className="tw-text-left tw-text-xs tw-uppercase tw-text-navy/60">
+                                <th className="tw-px-4 tw-py-2">Title</th>
+                                <th className="tw-px-4 tw-py-2">Module</th>
+                                <th className="tw-px-4 tw-py-2">Status</th>
+                                <th className="tw-px-4 tw-py-2">Claimed by</th>
+                                <th className="tw-px-4 tw-py-2 tw-text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {queue.length === 0 && (
+                                <tr>
+                                    <td
+                                        colSpan={5}
+                                        className="tw-px-4 tw-py-6 tw-text-center tw-text-ink/60"
+                                    >
+                                        Queue clear.
+                                    </td>
+                                </tr>
+                            )}
+                            {queue.map((q) => {
+                                const id = q.id || q.lesson_id || "";
+                                return (
+                                    <tr
+                                        key={id}
+                                        className="tw-border-t tw-border-navy/10 tw-text-sm"
+                                    >
+                                        <td className="tw-px-4 tw-py-2 tw-font-medium tw-text-ink">
+                                            {q.title || id}
+                                        </td>
+                                        <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                            {q.module ?? "—"}
+                                        </td>
+                                        <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                            {q.status || "—"}
+                                        </td>
+                                        <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                            {q.claimed_by || "—"}
+                                        </td>
+                                        <td className="tw-px-4 tw-py-2 tw-text-right">
+                                            <div className="tw-flex tw-justify-end tw-gap-2">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => action(id, "claim")}
+                                                    disabled={busy === `${id}:claim`}
+                                                    className="tw-text-xs tw-rounded tw-border tw-border-primary tw-px-2 tw-py-1 tw-text-primary hover:tw-bg-primary/5 disabled:tw-opacity-50"
+                                                >
+                                                    Claim
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => action(id, "release")}
+                                                    disabled={busy === `${id}:release`}
+                                                    className="tw-text-xs tw-rounded tw-border tw-border-navy/10 tw-px-2 tw-py-1 tw-text-ink/80 hover:tw-bg-navy/5 disabled:tw-opacity-50"
+                                                >
+                                                    Release
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => action(id, "force-release")}
+                                                    disabled={busy === `${id}:force-release`}
+                                                    className="tw-text-xs tw-rounded tw-border tw-border-red tw-px-2 tw-py-1 tw-text-red-dark hover:tw-bg-cream disabled:tw-opacity-50"
+                                                >
+                                                    Force release
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </>
+    );
+};
+
+LessonsAdmin.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default LessonsAdmin;

--- a/src/pages/admin/j0di3/placements/[id].tsx
+++ b/src/pages/admin/j0di3/placements/[id].tsx
@@ -1,0 +1,199 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface Placement {
+    id?: string;
+    troop_id?: string;
+    company?: string;
+    role?: string;
+    start_date?: string;
+    salary?: number;
+    status?: string;
+    notes?: string;
+}
+
+const PlacementDetail: PageWithLayout = () => {
+    const router = useRouter();
+    const id = typeof router.query.id === "string" ? router.query.id : null;
+    const [data, setData] = useState<Placement | null>(null);
+    const [saving, setSaving] = useState(false);
+    const [message, setMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!id) return;
+        (async () => {
+            const res = await fetch(`/api/j0di3/admin/placements/${id}`);
+            if (res.ok) setData(await res.json());
+        })();
+    }, [id]);
+
+    const save = async () => {
+        if (!id || !data) return;
+        setSaving(true);
+        try {
+            const res = await fetch(`/api/j0di3/admin/placements/${id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(data),
+            });
+            setMessage(res.ok ? "Saved." : "Save failed.");
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const remove = async () => {
+        if (!id || !window.confirm("Delete this placement?")) return;
+        const res = await fetch(`/api/j0di3/admin/placements/${id}`, { method: "DELETE" });
+        if (res.ok) router.push("/admin/j0di3/placements");
+    };
+
+    if (!data) {
+        return (
+            <div className="tw-container tw-py-12">
+                <p className="tw-text-ink/60">Loading...</p>
+            </div>
+        );
+    }
+
+    return (
+        <>
+            <SEO title="Edit placement — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                    { path: "/admin/j0di3/placements", label: "placements" },
+                ]}
+                currentPage={data.company || "Placement"}
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-max-w-2xl tw-space-y-6">
+                <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Edit placement</h1>
+
+                <div className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 tw-gap-3 tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-4">
+                    <Field
+                        label="Company"
+                        value={data.company ?? ""}
+                        onChange={(v) => setData({ ...data, company: v })}
+                    />
+                    <Field
+                        label="Role"
+                        value={data.role ?? ""}
+                        onChange={(v) => setData({ ...data, role: v })}
+                    />
+                    <Field
+                        label="Start date"
+                        type="date"
+                        value={data.start_date ?? ""}
+                        onChange={(v) => setData({ ...data, start_date: v })}
+                    />
+                    <Field
+                        label="Salary"
+                        type="number"
+                        value={data.salary != null ? String(data.salary) : ""}
+                        onChange={(v) => setData({ ...data, salary: v ? Number(v) : undefined })}
+                    />
+                    <Field
+                        label="Status"
+                        value={data.status ?? ""}
+                        onChange={(v) => setData({ ...data, status: v })}
+                    />
+                    <div className="sm:tw-col-span-2">
+                        <label
+                            htmlFor="notes"
+                            className="tw-block tw-text-xs tw-font-medium tw-text-ink/80 tw-mb-1"
+                        >
+                            Notes
+                        </label>
+                        <textarea
+                            id="notes"
+                            value={data.notes ?? ""}
+                            onChange={(e) => setData({ ...data, notes: e.target.value })}
+                            rows={3}
+                            className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                        />
+                    </div>
+                </div>
+
+                <div className="tw-flex tw-gap-3">
+                    <button
+                        type="button"
+                        onClick={save}
+                        disabled={saving}
+                        className="tw-rounded-md tw-bg-primary tw-px-5 tw-py-2 tw-text-sm tw-font-medium tw-text-white disabled:tw-opacity-50"
+                    >
+                        {saving ? "Saving..." : "Save"}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={remove}
+                        className="tw-rounded-md tw-border tw-border-red tw-px-5 tw-py-2 tw-text-sm tw-font-medium tw-text-red-dark hover:tw-bg-cream"
+                    >
+                        Delete
+                    </button>
+                    {message && (
+                        <span className="tw-self-center tw-text-sm tw-text-ink/70">{message}</span>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+};
+
+function Field({
+    label,
+    value,
+    onChange,
+    type = "text",
+}: {
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    type?: string;
+}) {
+    const id = `field-${label.toLowerCase().replace(/\s+/g, "-")}`;
+    return (
+        <div>
+            <label
+                htmlFor={id}
+                className="tw-block tw-text-xs tw-font-medium tw-text-ink/80 tw-mb-1"
+            >
+                {label}
+            </label>
+            <input
+                id={id}
+                type={type}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+            />
+        </div>
+    );
+}
+
+PlacementDetail.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default PlacementDetail;

--- a/src/pages/admin/j0di3/placements/index.tsx
+++ b/src/pages/admin/j0di3/placements/index.tsx
@@ -1,0 +1,239 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface Placement {
+    id?: string;
+    troop_id?: string;
+    troop_name?: string;
+    company?: string;
+    role?: string;
+    start_date?: string;
+    salary?: number;
+    status?: string;
+}
+
+const PlacementsAdmin: PageWithLayout = () => {
+    const [items, setItems] = useState<Placement[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [form, setForm] = useState<Placement>({});
+    const [creating, setCreating] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = async () => {
+        setIsLoading(true);
+        try {
+            const res = await fetch("/api/j0di3/admin/placements");
+            if (res.ok) {
+                const body = await res.json();
+                setItems(Array.isArray(body) ? body : (body.placements ?? []));
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, []);
+
+    const create = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!form.troop_id || !form.company || !form.role) return;
+        setCreating(true);
+        setError(null);
+        try {
+            const res = await fetch("/api/j0di3/admin/placements", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(form),
+            });
+            if (!res.ok) {
+                const err = await res.json();
+                setError(err.error || "Create failed");
+                return;
+            }
+            setForm({});
+            await load();
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    return (
+        <>
+            <SEO title="Placements — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                ]}
+                currentPage="Placements"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-6">
+                <div className="tw-flex tw-items-center tw-justify-between">
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Placements</h1>
+                    <a
+                        href="/api/j0di3/admin/placements/export.csv"
+                        className="tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm tw-font-medium tw-text-ink hover:tw-bg-navy/5"
+                    >
+                        Export CSV
+                    </a>
+                </div>
+
+                <form
+                    onSubmit={create}
+                    className="tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-p-4 tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 md:tw-grid-cols-4 tw-gap-3"
+                >
+                    <Field
+                        label="Troop ID"
+                        value={form.troop_id ?? ""}
+                        onChange={(v) => setForm({ ...form, troop_id: v })}
+                    />
+                    <Field
+                        label="Company"
+                        value={form.company ?? ""}
+                        onChange={(v) => setForm({ ...form, company: v })}
+                    />
+                    <Field
+                        label="Role"
+                        value={form.role ?? ""}
+                        onChange={(v) => setForm({ ...form, role: v })}
+                    />
+                    <Field
+                        label="Start date"
+                        type="date"
+                        value={form.start_date ?? ""}
+                        onChange={(v) => setForm({ ...form, start_date: v })}
+                    />
+                    <Field
+                        label="Salary"
+                        type="number"
+                        value={form.salary != null ? String(form.salary) : ""}
+                        onChange={(v) => setForm({ ...form, salary: v ? Number(v) : undefined })}
+                    />
+                    <div className="md:tw-col-span-3 tw-flex tw-items-end">
+                        <button
+                            type="submit"
+                            disabled={creating || !form.troop_id || !form.company || !form.role}
+                            className="tw-rounded-md tw-bg-primary tw-px-5 tw-py-2 tw-text-sm tw-font-medium tw-text-white disabled:tw-opacity-50"
+                        >
+                            {creating ? "Creating..." : "Create placement"}
+                        </button>
+                    </div>
+                </form>
+
+                {error && <p className="tw-text-sm tw-text-red-dark">{error}</p>}
+
+                {isLoading ? (
+                    <p className="tw-text-ink/60">Loading...</p>
+                ) : (
+                    <table className="tw-w-full tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-overflow-hidden">
+                        <thead className="tw-bg-navy/5">
+                            <tr className="tw-text-left tw-text-xs tw-uppercase tw-text-navy/60">
+                                <th className="tw-px-4 tw-py-2">Troop</th>
+                                <th className="tw-px-4 tw-py-2">Company</th>
+                                <th className="tw-px-4 tw-py-2">Role</th>
+                                <th className="tw-px-4 tw-py-2">Start</th>
+                                <th className="tw-px-4 tw-py-2">Status</th>
+                                <th className="tw-px-4 tw-py-2 tw-text-right">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {items.length === 0 && (
+                                <tr>
+                                    <td
+                                        colSpan={6}
+                                        className="tw-px-4 tw-py-6 tw-text-center tw-text-ink/60"
+                                    >
+                                        No placements.
+                                    </td>
+                                </tr>
+                            )}
+                            {items.map((p) => (
+                                <tr key={p.id} className="tw-border-t tw-border-navy/10 tw-text-sm">
+                                    <td className="tw-px-4 tw-py-2 tw-font-medium tw-text-ink">
+                                        {p.troop_name || p.troop_id}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">{p.company}</td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">{p.role}</td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {p.start_date || "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                        {p.status || "—"}
+                                    </td>
+                                    <td className="tw-px-4 tw-py-2 tw-text-right">
+                                        <Link
+                                            href={`/admin/j0di3/placements/${p.id}`}
+                                            className="tw-text-xs tw-text-primary hover:tw-underline"
+                                        >
+                                            Edit →
+                                        </Link>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                )}
+            </div>
+        </>
+    );
+};
+
+function Field({
+    label,
+    value,
+    onChange,
+    type = "text",
+}: {
+    label: string;
+    value: string;
+    onChange: (v: string) => void;
+    type?: string;
+}) {
+    const id = `field-${label.toLowerCase().replace(/\s+/g, "-")}`;
+    return (
+        <div>
+            <label
+                htmlFor={id}
+                className="tw-block tw-text-xs tw-font-medium tw-text-ink/80 tw-mb-1"
+            >
+                {label}
+            </label>
+            <input
+                id={id}
+                type={type}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="tw-w-full tw-rounded-md tw-border tw-border-navy/10 tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+            />
+        </div>
+    );
+}
+
+PlacementsAdmin.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default PlacementsAdmin;

--- a/src/pages/admin/j0di3/troops-stuck.tsx
+++ b/src/pages/admin/j0di3/troops-stuck.tsx
@@ -1,0 +1,128 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useEffect, useState } from "react";
+import { requireAdminSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface StuckTroop {
+    troop_id?: string;
+    name?: string;
+    email?: string;
+    current_module?: number;
+    last_activity?: string;
+    days_stuck?: number;
+    reason?: string;
+}
+
+const StuckTroopsAdmin: PageWithLayout = () => {
+    const [items, setItems] = useState<StuckTroop[]>([]);
+
+    useEffect(() => {
+        (async () => {
+            const res = await fetch("/api/j0di3/admin/troops/stuck");
+            if (res.ok) {
+                const body = await res.json();
+                setItems(Array.isArray(body) ? body : (body.troops ?? []));
+            }
+        })();
+    }, []);
+
+    const triggerSlack = async () => {
+        const res = await fetch("/api/j0di3/admin/slack/daily-grind", { method: "POST" });
+        window.alert(res.ok ? "Daily grind sent." : "Send failed.");
+    };
+
+    return (
+        <>
+            <SEO title="Stuck troops — J0dI3 Admin" />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/admin/j0di3", label: "j0di3" },
+                ]}
+                currentPage="Stuck troops"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-6">
+                <div className="tw-flex tw-items-center tw-justify-between">
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Stuck troops</h1>
+                    <button
+                        type="button"
+                        onClick={triggerSlack}
+                        className="tw-rounded-md tw-bg-primary tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-white"
+                    >
+                        Send daily grind to Slack
+                    </button>
+                </div>
+
+                <table className="tw-w-full tw-rounded-lg tw-border tw-border-navy/10 tw-bg-white tw-overflow-hidden">
+                    <thead className="tw-bg-navy/5">
+                        <tr className="tw-text-left tw-text-xs tw-uppercase tw-text-navy/60">
+                            <th className="tw-px-4 tw-py-2">Troop</th>
+                            <th className="tw-px-4 tw-py-2">Module</th>
+                            <th className="tw-px-4 tw-py-2">Last activity</th>
+                            <th className="tw-px-4 tw-py-2">Days stuck</th>
+                            <th className="tw-px-4 tw-py-2">Reason</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {items.length === 0 && (
+                            <tr>
+                                <td
+                                    colSpan={5}
+                                    className="tw-px-4 tw-py-6 tw-text-center tw-text-ink/60"
+                                >
+                                    Nobody's stuck right now.
+                                </td>
+                            </tr>
+                        )}
+                        {items.map((t) => (
+                            <tr
+                                key={t.troop_id}
+                                className="tw-border-t tw-border-navy/10 tw-text-sm"
+                            >
+                                <td className="tw-px-4 tw-py-2 tw-font-medium tw-text-ink">
+                                    {t.name || t.email || t.troop_id}
+                                </td>
+                                <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                    {t.current_module ?? "—"}
+                                </td>
+                                <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                    {t.last_activity || "—"}
+                                </td>
+                                <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                    {t.days_stuck ?? "—"}
+                                </td>
+                                <td className="tw-px-4 tw-py-2 tw-text-ink/70">
+                                    {t.reason || "—"}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+        </>
+    );
+};
+
+StuckTroopsAdmin.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAdminSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default StuckTroopsAdmin;

--- a/src/pages/api/j0di3/admin/budget.ts
+++ b/src/pages/api/j0di3/admin/budget.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/budget");

--- a/src/pages/api/j0di3/admin/challenges/[id]/hidden.ts
+++ b/src/pages/api/j0di3/admin/challenges/[id]/hidden.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("PATCH", (req) => `/api/v1/admin/challenges/${req.query.id}/hidden`);

--- a/src/pages/api/j0di3/admin/cohorts/[id]/index.ts
+++ b/src/pages/api/j0di3/admin/cohorts/[id]/index.ts
@@ -1,0 +1,13 @@
+import type { NextApiResponse } from "next";
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+import { requireRole } from "@/lib/rbac";
+
+const getHandler = j0di3AdminProxy("GET", (req) => `/api/v1/admin/cohorts/${req.query.id}`);
+const patchHandler = j0di3AdminProxy("PATCH", (req) => `/api/v1/admin/cohorts/${req.query.id}`);
+
+export default requireRole("ADMIN")(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method === "GET") return getHandler(req, res);
+    if (req.method === "PATCH") return patchHandler(req, res);
+    return res.status(405).json({ error: "Method not allowed" });
+});

--- a/src/pages/api/j0di3/admin/cohorts/[id]/roster.ts
+++ b/src/pages/api/j0di3/admin/cohorts/[id]/roster.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", (req) => `/api/v1/admin/cohorts/${req.query.id}/roster`);

--- a/src/pages/api/j0di3/admin/cohorts/[id]/troops-bulk.ts
+++ b/src/pages/api/j0di3/admin/cohorts/[id]/troops-bulk.ts
@@ -1,0 +1,6 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy(
+    "POST",
+    (req) => `/api/v1/admin/cohorts/${req.query.id}/troops/bulk`
+);

--- a/src/pages/api/j0di3/admin/cohorts/index.ts
+++ b/src/pages/api/j0di3/admin/cohorts/index.ts
@@ -1,0 +1,13 @@
+import type { NextApiResponse } from "next";
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+import { requireRole } from "@/lib/rbac";
+
+const getHandler = j0di3AdminProxy("GET", "/api/v1/admin/cohorts");
+const postHandler = j0di3AdminProxy("POST", "/api/v1/admin/cohorts");
+
+export default requireRole("ADMIN")(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method === "GET") return getHandler(req, res);
+    if (req.method === "POST") return postHandler(req, res);
+    return res.status(405).json({ error: "Method not allowed" });
+});

--- a/src/pages/api/j0di3/admin/events/rollup.ts
+++ b/src/pages/api/j0di3/admin/events/rollup.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/events/rollup");

--- a/src/pages/api/j0di3/admin/funnel.ts
+++ b/src/pages/api/j0di3/admin/funnel.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/funnel");

--- a/src/pages/api/j0di3/admin/funnel/placements.ts
+++ b/src/pages/api/j0di3/admin/funnel/placements.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/funnel/placements");

--- a/src/pages/api/j0di3/admin/learning/curriculum-ingest.ts
+++ b/src/pages/api/j0di3/admin/learning/curriculum-ingest.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("POST", "/api/v1/learning/curriculum/ingest");

--- a/src/pages/api/j0di3/admin/learning/feedback/[id]/review.ts
+++ b/src/pages/api/j0di3/admin/learning/feedback/[id]/review.ts
@@ -1,0 +1,6 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy(
+    "PATCH",
+    (req) => `/api/v1/admin/learning/feedback/${req.query.id}/review`
+);

--- a/src/pages/api/j0di3/admin/learning/feedback/index.ts
+++ b/src/pages/api/j0di3/admin/learning/feedback/index.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/learning/feedback");

--- a/src/pages/api/j0di3/admin/lessons/[id]/claim.ts
+++ b/src/pages/api/j0di3/admin/lessons/[id]/claim.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("POST", (req) => `/api/v1/admin/lessons/${req.query.id}/claim`);

--- a/src/pages/api/j0di3/admin/lessons/[id]/force-release.ts
+++ b/src/pages/api/j0di3/admin/lessons/[id]/force-release.ts
@@ -1,0 +1,6 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy(
+    "POST",
+    (req) => `/api/v1/admin/lessons/${req.query.id}/force-release`
+);

--- a/src/pages/api/j0di3/admin/lessons/[id]/index.ts
+++ b/src/pages/api/j0di3/admin/lessons/[id]/index.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("PATCH", (req) => `/api/v1/admin/lessons/${req.query.id}`);

--- a/src/pages/api/j0di3/admin/lessons/[id]/release.ts
+++ b/src/pages/api/j0di3/admin/lessons/[id]/release.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("POST", (req) => `/api/v1/admin/lessons/${req.query.id}/release`);

--- a/src/pages/api/j0di3/admin/lessons/[id]/review-history.ts
+++ b/src/pages/api/j0di3/admin/lessons/[id]/review-history.ts
@@ -1,0 +1,6 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy(
+    "GET",
+    (req) => `/api/v1/admin/lessons/${req.query.id}/review-history`
+);

--- a/src/pages/api/j0di3/admin/lessons/bulk-review.ts
+++ b/src/pages/api/j0di3/admin/lessons/bulk-review.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("POST", "/api/v1/admin/lessons/bulk-review");

--- a/src/pages/api/j0di3/admin/lessons/heat-map.ts
+++ b/src/pages/api/j0di3/admin/lessons/heat-map.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/lessons/heat-map");

--- a/src/pages/api/j0di3/admin/lessons/review-queue.ts
+++ b/src/pages/api/j0di3/admin/lessons/review-queue.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/lessons/review-queue");

--- a/src/pages/api/j0di3/admin/placements/[id].ts
+++ b/src/pages/api/j0di3/admin/placements/[id].ts
@@ -1,0 +1,18 @@
+import type { NextApiResponse } from "next";
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+import { requireRole } from "@/lib/rbac";
+
+const getHandler = j0di3AdminProxy("GET", (req) => `/api/v1/admin/placements/${req.query.id}`);
+const patchHandler = j0di3AdminProxy("PATCH", (req) => `/api/v1/admin/placements/${req.query.id}`);
+const deleteHandler = j0di3AdminProxy(
+    "DELETE",
+    (req) => `/api/v1/admin/placements/${req.query.id}`
+);
+
+export default requireRole("ADMIN")(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method === "GET") return getHandler(req, res);
+    if (req.method === "PATCH") return patchHandler(req, res);
+    if (req.method === "DELETE") return deleteHandler(req, res);
+    return res.status(405).json({ error: "Method not allowed" });
+});

--- a/src/pages/api/j0di3/admin/placements/export.csv.ts
+++ b/src/pages/api/j0di3/admin/placements/export.csv.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+import type { NextApiResponse } from "next";
+import j0di3 from "@/lib/j0di3-client";
+import { type AuthenticatedRequest, requireRole } from "@/lib/rbac";
+
+export default requireRole("ADMIN")(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+
+    try {
+        const response = await j0di3.get("/api/v1/admin/placements/export.csv", {
+            responseType: "arraybuffer",
+            params: req.query,
+        });
+        res.setHeader("Content-Type", response.headers["content-type"] || "text/csv");
+        res.setHeader(
+            "Content-Disposition",
+            response.headers["content-disposition"] || "attachment; filename=placements.csv"
+        );
+        return res.send(Buffer.from(response.data));
+    } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+            return res.status(error.response.status).json({ error: "Export failed" });
+        }
+        console.error("[admin/placements/export.csv] error:", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+});

--- a/src/pages/api/j0di3/admin/placements/index.ts
+++ b/src/pages/api/j0di3/admin/placements/index.ts
@@ -1,0 +1,13 @@
+import type { NextApiResponse } from "next";
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+import { requireRole } from "@/lib/rbac";
+
+const getHandler = j0di3AdminProxy("GET", "/api/v1/admin/placements");
+const postHandler = j0di3AdminProxy("POST", "/api/v1/admin/placements");
+
+export default requireRole("ADMIN")(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method === "GET") return getHandler(req, res);
+    if (req.method === "POST") return postHandler(req, res);
+    return res.status(405).json({ error: "Method not allowed" });
+});

--- a/src/pages/api/j0di3/admin/slack/daily-grind.ts
+++ b/src/pages/api/j0di3/admin/slack/daily-grind.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("POST", "/api/v1/admin/slack/daily-grind");

--- a/src/pages/api/j0di3/admin/stats.ts
+++ b/src/pages/api/j0di3/admin/stats.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/stats");

--- a/src/pages/api/j0di3/admin/troops/[id]/access-token-rotate.ts
+++ b/src/pages/api/j0di3/admin/troops/[id]/access-token-rotate.ts
@@ -1,0 +1,6 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy(
+    "POST",
+    (req) => `/api/v1/troops/${req.query.id}/access-token/rotate`
+);

--- a/src/pages/api/j0di3/admin/troops/stuck.ts
+++ b/src/pages/api/j0di3/admin/troops/stuck.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("GET", "/api/v1/admin/troops/stuck");

--- a/src/pages/api/j0di3/admin/troops/test-cleanup.ts
+++ b/src/pages/api/j0di3/admin/troops/test-cleanup.ts
@@ -1,0 +1,3 @@
+import { j0di3AdminProxy } from "@/lib/j0di3-proxy";
+
+export default j0di3AdminProxy("POST", "/api/v1/admin/troops/test-cleanup");

--- a/src/pages/api/j0di3/challenges/[id]/coach.ts
+++ b/src/pages/api/j0di3/challenges/[id]/coach.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("POST", (req) => `/api/v1/challenges/${req.query.id}/coach`);

--- a/src/pages/api/j0di3/events.ts
+++ b/src/pages/api/j0di3/events.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("POST", "/api/v1/events/");

--- a/src/pages/api/j0di3/jobs/mos/[code].ts
+++ b/src/pages/api/j0di3/jobs/mos/[code].ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", (req) => `/api/v1/jobs/mos/${req.query.code}`);

--- a/src/pages/api/j0di3/jobs/resume/download/[sessionId].ts
+++ b/src/pages/api/j0di3/jobs/resume/download/[sessionId].ts
@@ -1,0 +1,33 @@
+import axios from "axios";
+import type { NextApiResponse } from "next";
+import j0di3 from "@/lib/j0di3-client";
+import { type AuthenticatedRequest, requireAuth } from "@/lib/rbac";
+
+export default requireAuth(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+
+    const sessionId = req.query.sessionId;
+    if (typeof sessionId !== "string") {
+        return res.status(400).json({ error: "Missing sessionId" });
+    }
+
+    try {
+        const response = await j0di3.get(`/api/v1/jobs/resume/download/${sessionId}`, {
+            responseType: "arraybuffer",
+        });
+        const contentType = response.headers["content-type"] || "application/octet-stream";
+        const disposition =
+            response.headers["content-disposition"] || `attachment; filename="resume-${sessionId}"`;
+        res.setHeader("Content-Type", contentType);
+        res.setHeader("Content-Disposition", disposition);
+        return res.send(Buffer.from(response.data));
+    } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+            return res.status(error.response.status).json({
+                error: "Download failed",
+            });
+        }
+        console.error("[resume/download] error:", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+});

--- a/src/pages/api/j0di3/jobs/resume/military-translate.ts
+++ b/src/pages/api/j0di3/jobs/resume/military-translate.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("POST", "/api/v1/jobs/resume/military-translate");

--- a/src/pages/api/j0di3/jobs/resume/roles.ts
+++ b/src/pages/api/j0di3/jobs/resume/roles.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", "/api/v1/jobs/resume/roles");

--- a/src/pages/api/j0di3/jobs/resume/upload-and-score.ts
+++ b/src/pages/api/j0di3/jobs/resume/upload-and-score.ts
@@ -1,0 +1,52 @@
+import axios from "axios";
+import FormData from "form-data";
+import type { NextApiResponse } from "next";
+import j0di3 from "@/lib/j0di3-client";
+import { type AuthenticatedRequest, requireAuth } from "@/lib/rbac";
+
+export const config = {
+    api: { bodyParser: { sizeLimit: "5mb" } },
+};
+
+interface UploadAndScoreRequest {
+    file: string;
+    filename?: string;
+    contentType?: string;
+    target_role?: string;
+}
+
+export default requireAuth(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
+    const troopId = req.user!.troopId;
+    if (!troopId) return res.status(400).json({ error: "No J0dI3 troop profile linked." });
+
+    const { file, filename, contentType, target_role } = req.body as UploadAndScoreRequest;
+    if (!file) return res.status(400).json({ error: "Missing file" });
+
+    try {
+        const buffer = Buffer.from(file, "base64");
+        const form = new FormData();
+        form.append("file", buffer, {
+            filename: filename || "resume.pdf",
+            contentType: contentType || "application/pdf",
+        });
+        form.append("troop_id", troopId);
+        if (target_role) form.append("target_role", target_role);
+
+        const { data } = await j0di3.post("/api/v1/jobs/resume/upload-and-score", form, {
+            headers: form.getHeaders(),
+            maxContentLength: Number.POSITIVE_INFINITY,
+            maxBodyLength: Number.POSITIVE_INFINITY,
+        });
+        return res.json(data);
+    } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+            return res.status(error.response.status).json({
+                error: error.response.data?.detail || "J0dI3 upload failed",
+            });
+        }
+        console.error("[resume/upload-and-score] error:", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+});

--- a/src/pages/api/j0di3/jobs/resume/upload.ts
+++ b/src/pages/api/j0di3/jobs/resume/upload.ts
@@ -1,0 +1,50 @@
+import axios from "axios";
+import FormData from "form-data";
+import type { NextApiResponse } from "next";
+import j0di3 from "@/lib/j0di3-client";
+import { type AuthenticatedRequest, requireAuth } from "@/lib/rbac";
+
+export const config = {
+    api: { bodyParser: { sizeLimit: "5mb" } },
+};
+
+interface UploadRequest {
+    file: string; // base64
+    filename?: string;
+    contentType?: string;
+}
+
+export default requireAuth(async (req: AuthenticatedRequest, res: NextApiResponse) => {
+    if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
+    const troopId = req.user!.troopId;
+    if (!troopId) return res.status(400).json({ error: "No J0dI3 troop profile linked." });
+
+    const { file, filename, contentType } = req.body as UploadRequest;
+    if (!file) return res.status(400).json({ error: "Missing file" });
+
+    try {
+        const buffer = Buffer.from(file, "base64");
+        const form = new FormData();
+        form.append("file", buffer, {
+            filename: filename || "resume.pdf",
+            contentType: contentType || "application/pdf",
+        });
+        form.append("troop_id", troopId);
+
+        const { data } = await j0di3.post("/api/v1/jobs/resume/upload", form, {
+            headers: form.getHeaders(),
+            maxContentLength: Number.POSITIVE_INFINITY,
+            maxBodyLength: Number.POSITIVE_INFINITY,
+        });
+        return res.json(data);
+    } catch (error: unknown) {
+        if (axios.isAxiosError(error) && error.response) {
+            return res.status(error.response.status).json({
+                error: error.response.data?.detail || "J0dI3 upload failed",
+            });
+        }
+        console.error("[resume/upload] error:", error);
+        return res.status(500).json({ error: "Internal server error" });
+    }
+});

--- a/src/pages/api/j0di3/learning/feedback.ts
+++ b/src/pages/api/j0di3/learning/feedback.ts
@@ -1,0 +1,6 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("POST", (req) => {
+    const id = req.query.message_id || req.body?.message_id;
+    return `/api/v1/learning/messages/${id}/feedback`;
+});

--- a/src/pages/api/j0di3/learning/module/[module].ts
+++ b/src/pages/api/j0di3/learning/module/[module].ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", (req) => `/api/v1/learning/module/${req.query.module}`);

--- a/src/pages/api/j0di3/lessons/[id]/complete.ts
+++ b/src/pages/api/j0di3/lessons/[id]/complete.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("POST", (req) => `/api/v1/lessons/${req.query.id}/complete`);

--- a/src/pages/api/j0di3/lessons/[id]/index.ts
+++ b/src/pages/api/j0di3/lessons/[id]/index.ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", (req) => `/api/v1/lessons/${req.query.id}`);

--- a/src/pages/api/j0di3/lessons/module/[module].ts
+++ b/src/pages/api/j0di3/lessons/module/[module].ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", (req) => `/api/v1/lessons/module/${req.query.module}`);

--- a/src/pages/api/j0di3/lessons/recall-due.ts
+++ b/src/pages/api/j0di3/lessons/recall-due.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/lessons/recall-due/${(req as AuthenticatedRequest).user!.troopId}`
+);

--- a/src/pages/api/j0di3/lessons/sub/[module]/[sub].ts
+++ b/src/pages/api/j0di3/lessons/sub/[module]/[sub].ts
@@ -1,0 +1,6 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/lessons/sub/${req.query.module}/${req.query.sub}`
+);

--- a/src/pages/api/j0di3/tasks/[id].ts
+++ b/src/pages/api/j0di3/tasks/[id].ts
@@ -1,0 +1,3 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+
+export default j0di3Proxy("GET", (req) => `/api/v1/tasks/${req.query.id}`);

--- a/src/pages/api/j0di3/troops/budget.ts
+++ b/src/pages/api/j0di3/troops/budget.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/budget`
+);

--- a/src/pages/api/j0di3/troops/delete.ts
+++ b/src/pages/api/j0di3/troops/delete.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "DELETE",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}`
+);

--- a/src/pages/api/j0di3/troops/export.ts
+++ b/src/pages/api/j0di3/troops/export.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/export`
+);

--- a/src/pages/api/j0di3/troops/mentor-candidates.ts
+++ b/src/pages/api/j0di3/troops/mentor-candidates.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/mentor-candidates`
+);

--- a/src/pages/api/j0di3/troops/mos-relevance.ts
+++ b/src/pages/api/j0di3/troops/mos-relevance.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/mos-relevance`
+);

--- a/src/pages/api/j0di3/troops/pair-candidates.ts
+++ b/src/pages/api/j0di3/troops/pair-candidates.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/pair-candidates`
+);

--- a/src/pages/api/j0di3/troops/placements.ts
+++ b/src/pages/api/j0di3/troops/placements.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/placements`
+);

--- a/src/pages/api/j0di3/troops/resume-history.ts
+++ b/src/pages/api/j0di3/troops/resume-history.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "DELETE",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/resume-history`
+);

--- a/src/pages/api/j0di3/troops/streak.ts
+++ b/src/pages/api/j0di3/troops/streak.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/streak`
+);

--- a/src/pages/api/j0di3/troops/today.ts
+++ b/src/pages/api/j0di3/troops/today.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/today`
+);

--- a/src/pages/api/j0di3/troops/xp.ts
+++ b/src/pages/api/j0di3/troops/xp.ts
@@ -1,0 +1,7 @@
+import { j0di3Proxy } from "@/lib/j0di3-proxy";
+import type { AuthenticatedRequest } from "@/lib/rbac";
+
+export default j0di3Proxy(
+    "GET",
+    (req) => `/api/v1/troops/${(req as AuthenticatedRequest).user!.troopId}/xp`
+);

--- a/src/pages/challenges/[id].tsx
+++ b/src/pages/challenges/[id].tsx
@@ -48,6 +48,9 @@ const ChallengeDetailPage: PageWithLayout = () => {
     const [isLoadingHint, setIsLoadingHint] = useState(false);
     const [solutionText, setSolutionText] = useState<string | null>(null);
     const [showSolution, setShowSolution] = useState(false);
+    const [coachReply, setCoachReply] = useState<string | null>(null);
+    const [coachQuestion, setCoachQuestion] = useState("");
+    const [isCoaching, setIsCoaching] = useState(false);
 
     const fetchChallenge = useCallback(async () => {
         if (!id) return;
@@ -140,6 +143,26 @@ const ChallengeDetailPage: PageWithLayout = () => {
             // non-critical
         } finally {
             setIsLoadingHint(false);
+        }
+    };
+
+    const handleCoach = async () => {
+        if (!challenge || !coachQuestion.trim()) return;
+        setIsCoaching(true);
+        try {
+            const res = await fetch(`/api/j0di3/challenges/${challenge.id}/coach`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ question: coachQuestion, code }),
+            });
+            if (res.ok) {
+                const body = await res.json();
+                setCoachReply(body.reply || body.message || body.coaching || "No reply.");
+            }
+        } catch {
+            // non-critical
+        } finally {
+            setIsCoaching(false);
         }
     };
 
@@ -303,6 +326,38 @@ const ChallengeDetailPage: PageWithLayout = () => {
                             )}
                         </div>
 
+                        <div className="tw-mb-4 tw-rounded-md tw-border tw-border-navy/10 tw-bg-navy/5 tw-p-3">
+                            <label
+                                htmlFor="coach-input"
+                                className="tw-block tw-text-xs tw-font-semibold tw-text-navy/70 tw-uppercase tw-mb-2"
+                            >
+                                Ask the coach
+                            </label>
+                            <div className="tw-flex tw-gap-2">
+                                <input
+                                    id="coach-input"
+                                    type="text"
+                                    value={coachQuestion}
+                                    onChange={(e) => setCoachQuestion(e.target.value)}
+                                    placeholder="Where am I stuck?"
+                                    className="tw-flex-1 tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-px-3 tw-py-2 tw-text-sm focus:tw-border-primary focus:tw-outline-none"
+                                />
+                                <button
+                                    type="button"
+                                    onClick={handleCoach}
+                                    disabled={isCoaching || !coachQuestion.trim()}
+                                    className="tw-rounded-md tw-bg-navy-deep tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-white disabled:tw-opacity-50"
+                                >
+                                    {isCoaching ? "Thinking..." : "Ask"}
+                                </button>
+                            </div>
+                            {coachReply && (
+                                <p className="tw-mt-3 tw-text-sm tw-text-ink tw-whitespace-pre-wrap">
+                                    {coachReply}
+                                </p>
+                            )}
+                        </div>
+
                         {hints.length > 0 && (
                             <div className="tw-mb-4 tw-space-y-2">
                                 {hints.map((hint, i) => (
@@ -358,9 +413,7 @@ const ChallengeDetailPage: PageWithLayout = () => {
                                             />
                                             <span
                                                 className={`tw-font-semibold ${
-                                                    passed
-                                                        ? "tw-text-ink"
-                                                        : "tw-text-red-dark"
+                                                    passed ? "tw-text-ink" : "tw-text-red-dark"
                                                 }`}
                                             >
                                                 {passed ? "Challenge Passed!" : "Not quite right"}

--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -1,0 +1,193 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { requireAuthSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface Candidate {
+    troop_id?: string;
+    id?: string;
+    name?: string;
+    callsign?: string;
+    branch?: string;
+    mos?: string;
+    current_module?: number;
+    skill_level?: string;
+    target_role?: string;
+    match_score?: number;
+    reason?: string;
+}
+
+const CommunityPage: PageWithLayout = () => {
+    const [pairs, setPairs] = useState<Candidate[]>([]);
+    const [mentors, setMentors] = useState<Candidate[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const [pRes, mRes] = await Promise.all([
+                    fetch("/api/j0di3/troops/pair-candidates"),
+                    fetch("/api/j0di3/troops/mentor-candidates"),
+                ]);
+                if (pRes.ok) {
+                    const body = await pRes.json();
+                    setPairs(Array.isArray(body) ? body : (body.candidates ?? []));
+                }
+                if (mRes.ok) {
+                    const body = await mRes.json();
+                    setMentors(Array.isArray(body) ? body : (body.candidates ?? []));
+                }
+            } catch {
+                // non-critical
+            } finally {
+                setIsLoading(false);
+            }
+        })();
+    }, []);
+
+    return (
+        <>
+            <SEO title="Community" />
+            <Breadcrumb
+                pages={[{ path: "/", label: "home" }]}
+                currentPage="Community"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-8">
+                <header>
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Community</h1>
+                    <p className="tw-mt-2 tw-text-ink/70">
+                        Pair up with peers at your level or get a mentor a few modules ahead.
+                    </p>
+                </header>
+
+                {isLoading && <p className="tw-text-ink/60">Loading candidates...</p>}
+
+                {!isLoading && (
+                    <>
+                        <CandidateSection
+                            title="Pair candidates"
+                            subtitle="Same level, same module — pair-program together."
+                            candidates={pairs}
+                        />
+                        <CandidateSection
+                            title="Mentor candidates"
+                            subtitle="A few modules ahead — ask for review and guidance."
+                            candidates={mentors}
+                        />
+                    </>
+                )}
+            </div>
+        </>
+    );
+};
+
+function CandidateSection({
+    title,
+    subtitle,
+    candidates,
+}: {
+    title: string;
+    subtitle: string;
+    candidates: Candidate[];
+}) {
+    return (
+        <section>
+            <div className="tw-mb-3">
+                <h2 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60">
+                    {title}
+                </h2>
+                <p className="tw-text-sm tw-text-ink/70 tw-mt-1">{subtitle}</p>
+            </div>
+            {candidates.length === 0 ? (
+                <p className="tw-text-sm tw-text-ink/60">
+                    No matches right now. Check back after you complete more work.
+                </p>
+            ) : (
+                <ul className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-3">
+                    {candidates.map((c, i) => {
+                        const callsign = c.callsign || c.troop_id || c.id || "";
+                        return (
+                            <li
+                                key={callsign || i}
+                                className="tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4"
+                            >
+                                <div className="tw-flex tw-items-start tw-justify-between tw-gap-2">
+                                    <div>
+                                        <div className="tw-text-sm tw-font-semibold tw-text-ink">
+                                            {c.name || c.callsign || "Troop"}
+                                        </div>
+                                        {c.target_role && (
+                                            <div className="tw-text-xs tw-text-ink/60">
+                                                {c.target_role}
+                                            </div>
+                                        )}
+                                    </div>
+                                    {c.match_score != null && (
+                                        <span className="tw-rounded-full tw-bg-primary/10 tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-bold tw-text-primary">
+                                            {Math.round(c.match_score * 100)}%
+                                        </span>
+                                    )}
+                                </div>
+                                <div className="tw-flex tw-flex-wrap tw-gap-1 tw-mt-2">
+                                    {c.branch && (
+                                        <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-navy-deep">
+                                            {c.branch}
+                                        </span>
+                                    )}
+                                    {c.mos && (
+                                        <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-navy-deep">
+                                            {c.mos}
+                                        </span>
+                                    )}
+                                    {c.current_module != null && (
+                                        <span className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-ink">
+                                            Module {c.current_module}
+                                        </span>
+                                    )}
+                                </div>
+                                {c.reason && (
+                                    <p className="tw-text-xs tw-text-ink/70 tw-mt-2 tw-line-clamp-2">
+                                        {c.reason}
+                                    </p>
+                                )}
+                                {callsign && (
+                                    <Link
+                                        href={`/p/${callsign}`}
+                                        className="tw-mt-3 tw-inline-block tw-text-xs tw-font-medium tw-text-primary hover:tw-underline"
+                                    >
+                                        View profile →
+                                    </Link>
+                                )}
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </section>
+    );
+}
+
+CommunityPage.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAuthSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default CommunityPage;

--- a/src/pages/jobs/mos/[code].tsx
+++ b/src/pages/jobs/mos/[code].tsx
@@ -1,0 +1,157 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { requireAuthSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface MosPayload {
+    code?: string;
+    title?: string;
+    branch?: string;
+    description?: string;
+    skills?: string[];
+    target_roles?: { role?: string; relevance?: number }[];
+    salary_range?: { min?: number; max?: number; currency?: string };
+}
+
+const MosPage: PageWithLayout = () => {
+    const router = useRouter();
+    const codeParam = router.query.code;
+    const code = typeof codeParam === "string" ? codeParam : null;
+
+    const [data, setData] = useState<MosPayload | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!code) return;
+        (async () => {
+            try {
+                const res = await fetch(`/api/j0di3/jobs/mos/${code}`);
+                if (!res.ok) {
+                    setError("MOS not found.");
+                    return;
+                }
+                setData(await res.json());
+            } catch {
+                setError("MOS not found.");
+            } finally {
+                setIsLoading(false);
+            }
+        })();
+    }, [code]);
+
+    return (
+        <>
+            <SEO title={`MOS ${code ?? ""}`} />
+            <Breadcrumb
+                pages={[{ path: "/", label: "home" }]}
+                currentPage={`MOS ${code ?? ""}`}
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-max-w-3xl tw-space-y-6">
+                {isLoading && <p className="tw-text-ink/60">Loading MOS data...</p>}
+                {error && <p className="tw-text-red-dark">{error}</p>}
+
+                {data && (
+                    <>
+                        <header>
+                            <p className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-primary">
+                                {data.branch || "MOS"}
+                            </p>
+                            <h1 className="tw-text-3xl tw-font-bold tw-text-ink">
+                                {data.code} — {data.title}
+                            </h1>
+                        </header>
+
+                        {data.description && (
+                            <p className="tw-text-ink/80 tw-whitespace-pre-wrap">
+                                {data.description}
+                            </p>
+                        )}
+
+                        {data.skills && data.skills.length > 0 && (
+                            <section>
+                                <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                                    Skills
+                                </h2>
+                                <div className="tw-flex tw-flex-wrap tw-gap-2">
+                                    {data.skills.map((s) => (
+                                        <span
+                                            key={s}
+                                            className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-xs tw-text-navy-deep"
+                                        >
+                                            {s}
+                                        </span>
+                                    ))}
+                                </div>
+                            </section>
+                        )}
+
+                        {data.target_roles && data.target_roles.length > 0 && (
+                            <section>
+                                <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                                    Adjacent tech roles
+                                </h2>
+                                <ul className="tw-space-y-1 tw-text-sm">
+                                    {data.target_roles.map((r, i) => (
+                                        <li
+                                            key={i}
+                                            className="tw-flex tw-justify-between tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-px-3 tw-py-2"
+                                        >
+                                            <span className="tw-font-medium tw-text-ink">
+                                                {r.role}
+                                            </span>
+                                            {r.relevance != null && (
+                                                <span className="tw-text-ink/60">
+                                                    {Math.round(r.relevance * 100)}% match
+                                                </span>
+                                            )}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </section>
+                        )}
+
+                        {data.salary_range && (
+                            <section>
+                                <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                                    Salary range
+                                </h2>
+                                <p className="tw-text-ink/80">
+                                    {data.salary_range.currency || "$"}
+                                    {data.salary_range.min?.toLocaleString() ?? "?"} –{" "}
+                                    {data.salary_range.currency || "$"}
+                                    {data.salary_range.max?.toLocaleString() ?? "?"}
+                                </p>
+                            </section>
+                        )}
+                    </>
+                )}
+            </div>
+        </>
+    );
+};
+
+MosPage.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAuthSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default MosPage;

--- a/src/pages/lessons/index.tsx
+++ b/src/pages/lessons/index.tsx
@@ -1,0 +1,128 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { requireAuthSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface RecallItem {
+    lesson_id?: string;
+    id?: string;
+    title?: string;
+    module?: number;
+    due_at?: string;
+}
+
+const LessonsIndex: PageWithLayout = () => {
+    const [recall, setRecall] = useState<RecallItem[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const res = await fetch("/api/j0di3/lessons/recall-due");
+                if (res.ok) {
+                    const body = await res.json();
+                    setRecall(Array.isArray(body) ? body : (body.items ?? body.lessons ?? []));
+                }
+            } catch {
+                // non-critical
+            } finally {
+                setIsLoading(false);
+            }
+        })();
+    }, []);
+
+    const modules = Array.from({ length: 25 }, (_, i) => i + 1);
+
+    return (
+        <>
+            <SEO title="Lessons" />
+            <Breadcrumb
+                pages={[{ path: "/", label: "home" }]}
+                currentPage="Lessons"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-8">
+                <header>
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink">Lessons</h1>
+                    <p className="tw-mt-2 tw-text-ink/70">
+                        Jump into a module or knock out a recall card.
+                    </p>
+                </header>
+
+                {!isLoading && recall.length > 0 && (
+                    <section className="tw-rounded-lg tw-border tw-border-primary/20 tw-bg-white tw-p-6 tw-shadow-sm">
+                        <h2 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-primary tw-mb-3">
+                            Recall — due now
+                        </h2>
+                        <ul className="tw-grid tw-grid-cols-1 sm:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-3">
+                            {recall.slice(0, 9).map((r) => {
+                                const id = r.lesson_id || r.id || "";
+                                return (
+                                    <li key={id || r.title}>
+                                        <Link
+                                            href={`/lessons/lesson/${id}`}
+                                            className="tw-block tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-3 hover:tw-border-primary"
+                                        >
+                                            <div className="tw-text-sm tw-font-semibold tw-text-ink">
+                                                {r.title || `Lesson ${id}`}
+                                            </div>
+                                            {r.module != null && (
+                                                <div className="tw-text-xs tw-text-ink/60 tw-mt-1">
+                                                    Module {r.module}
+                                                </div>
+                                            )}
+                                        </Link>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </section>
+                )}
+
+                <section>
+                    <h2 className="tw-font-mono tw-text-xs tw-font-bold tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-3">
+                        Curriculum modules
+                    </h2>
+                    <div className="tw-grid tw-grid-cols-2 sm:tw-grid-cols-3 md:tw-grid-cols-5 tw-gap-3">
+                        {modules.map((m) => (
+                            <Link
+                                key={m}
+                                href={`/lessons/module/${m}`}
+                                className="tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4 tw-text-center hover:tw-border-primary tw-transition-colors"
+                            >
+                                <div className="tw-font-mono tw-text-xs tw-text-navy/60 tw-uppercase">
+                                    Module
+                                </div>
+                                <div className="tw-text-2xl tw-font-bold tw-text-ink">{m}</div>
+                            </Link>
+                        ))}
+                    </div>
+                </section>
+            </div>
+        </>
+    );
+};
+
+LessonsIndex.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAuthSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default LessonsIndex;

--- a/src/pages/lessons/lesson/[id].tsx
+++ b/src/pages/lessons/lesson/[id].tsx
@@ -1,0 +1,141 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { requireAuthSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface LessonPayload {
+    id?: string;
+    title?: string;
+    module?: number;
+    summary?: string;
+    content?: string;
+    markdown?: string;
+    body?: string;
+    completed?: boolean;
+}
+
+const LessonPage: PageWithLayout = () => {
+    const router = useRouter();
+    const idParam = router.query.id;
+    const id = typeof idParam === "string" ? idParam : null;
+
+    const [lesson, setLesson] = useState<LessonPayload | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isCompleting, setIsCompleting] = useState(false);
+    const [completed, setCompleted] = useState(false);
+
+    useEffect(() => {
+        if (!id) return;
+        (async () => {
+            setIsLoading(true);
+            try {
+                const res = await fetch(`/api/j0di3/lessons/${id}`);
+                if (res.ok) {
+                    const body = (await res.json()) as LessonPayload;
+                    setLesson(body);
+                    setCompleted(!!body.completed);
+                }
+            } catch {
+                // non-critical
+            } finally {
+                setIsLoading(false);
+            }
+        })();
+    }, [id]);
+
+    const markComplete = async () => {
+        if (!id) return;
+        setIsCompleting(true);
+        try {
+            const res = await fetch(`/api/j0di3/lessons/${id}/complete`, { method: "POST" });
+            if (res.ok) setCompleted(true);
+        } finally {
+            setIsCompleting(false);
+        }
+    };
+
+    const body = lesson?.content || lesson?.markdown || lesson?.body || "";
+
+    return (
+        <>
+            <SEO title={lesson?.title ?? "Lesson"} />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/lessons", label: "lessons" },
+                ]}
+                currentPage={lesson?.title ?? "Lesson"}
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-max-w-3xl tw-space-y-6">
+                {isLoading && <p className="tw-text-ink/60">Loading lesson...</p>}
+
+                {!isLoading && lesson && (
+                    <>
+                        <header>
+                            {lesson.module != null && (
+                                <p className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-primary">
+                                    <Link href={`/lessons/module/${lesson.module}`}>
+                                        Module {lesson.module}
+                                    </Link>
+                                </p>
+                            )}
+                            <h1 className="tw-text-3xl tw-font-bold tw-text-ink tw-mt-1">
+                                {lesson.title || "Lesson"}
+                            </h1>
+                            {lesson.summary && (
+                                <p className="tw-mt-2 tw-text-ink/70">{lesson.summary}</p>
+                            )}
+                        </header>
+
+                        {body && (
+                            <article className="tw-prose tw-max-w-none tw-text-ink tw-whitespace-pre-wrap">
+                                {body}
+                            </article>
+                        )}
+
+                        <div className="tw-pt-4 tw-border-t tw-border-navy/10">
+                            <button
+                                type="button"
+                                onClick={markComplete}
+                                disabled={isCompleting || completed}
+                                className="tw-rounded-md tw-bg-primary tw-px-6 tw-py-2 tw-font-medium tw-text-white disabled:tw-opacity-50"
+                            >
+                                {completed
+                                    ? "Completed"
+                                    : isCompleting
+                                      ? "Marking..."
+                                      : "Mark complete"}
+                            </button>
+                        </div>
+                    </>
+                )}
+            </div>
+        </>
+    );
+};
+
+LessonPage.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAuthSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default LessonPage;

--- a/src/pages/lessons/module/[module].tsx
+++ b/src/pages/lessons/module/[module].tsx
@@ -1,0 +1,156 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { requireAuthSSR } from "@/lib/auth-guards";
+
+type PageProps = {
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+interface Lesson {
+    id?: string;
+    lesson_id?: string;
+    title?: string;
+    summary?: string;
+    sub_section?: number | string;
+    duration_minutes?: number;
+    difficulty?: string;
+    completed?: boolean;
+}
+
+interface ModulePayload {
+    module?: number;
+    title?: string;
+    summary?: string;
+    lessons?: Lesson[];
+}
+
+const ModuleLessonsPage: PageWithLayout = () => {
+    const router = useRouter();
+    const moduleParam = router.query.module;
+    const module = typeof moduleParam === "string" ? Number(moduleParam) : null;
+
+    const [data, setData] = useState<ModulePayload | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!module) return;
+        (async () => {
+            setIsLoading(true);
+            try {
+                const res = await fetch(`/api/j0di3/lessons/module/${module}`);
+                if (!res.ok) {
+                    setError("Failed to load module.");
+                    return;
+                }
+                const body = await res.json();
+                setData(body);
+            } catch {
+                setError("Failed to load module.");
+            } finally {
+                setIsLoading(false);
+            }
+        })();
+    }, [module]);
+
+    const lessons = data?.lessons ?? [];
+
+    return (
+        <>
+            <SEO title={`Module ${module ?? ""} — Lessons`} />
+            <Breadcrumb
+                pages={[
+                    { path: "/", label: "home" },
+                    { path: "/lessons", label: "lessons" },
+                ]}
+                currentPage={`Module ${module ?? ""}`}
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-space-y-6">
+                {isLoading && <p className="tw-text-ink/60">Loading module...</p>}
+                {error && <p className="tw-text-red-dark">{error}</p>}
+
+                {!isLoading && !error && (
+                    <>
+                        <header>
+                            <p className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-primary">
+                                Module {module}
+                            </p>
+                            <h1 className="tw-text-3xl tw-font-bold tw-text-ink">
+                                {data?.title ?? `Module ${module}`}
+                            </h1>
+                            {data?.summary && (
+                                <p className="tw-mt-2 tw-text-ink/70">{data.summary}</p>
+                            )}
+                        </header>
+
+                        {lessons.length === 0 && (
+                            <p className="tw-text-ink/60">No lessons in this module yet.</p>
+                        )}
+
+                        <ul className="tw-space-y-2">
+                            {lessons.map((l, i) => {
+                                const id = l.id || l.lesson_id || "";
+                                return (
+                                    <li key={id || i}>
+                                        <Link
+                                            href={`/lessons/lesson/${id}`}
+                                            className="tw-block tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4 hover:tw-border-primary tw-transition-colors"
+                                        >
+                                            <div className="tw-flex tw-items-start tw-justify-between tw-gap-3">
+                                                <div>
+                                                    <div className="tw-text-sm tw-font-semibold tw-text-ink">
+                                                        {l.title || `Lesson ${id}`}
+                                                    </div>
+                                                    {l.summary && (
+                                                        <div className="tw-text-xs tw-text-ink/60 tw-mt-1 tw-line-clamp-2">
+                                                            {l.summary}
+                                                        </div>
+                                                    )}
+                                                </div>
+                                                <div className="tw-flex tw-items-center tw-gap-2 tw-flex-shrink-0">
+                                                    {l.duration_minutes != null && (
+                                                        <span className="tw-text-xs tw-text-ink/60">
+                                                            {l.duration_minutes}m
+                                                        </span>
+                                                    )}
+                                                    {l.completed && (
+                                                        <span className="tw-rounded-full tw-bg-gold-light tw-px-2 tw-py-0.5 tw-text-[10px] tw-font-medium tw-text-ink">
+                                                            done
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            </div>
+                                        </Link>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </>
+                )}
+            </div>
+        </>
+    );
+};
+
+ModuleLessonsPage.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const guard = await requireAuthSSR(context);
+    if (!guard.ok) return guard.result;
+    return {
+        props: {
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default ModuleLessonsPage;

--- a/src/pages/p/[callsign].tsx
+++ b/src/pages/p/[callsign].tsx
@@ -1,0 +1,187 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { GetServerSideProps, NextPage } from "next";
+import j0di3 from "@/lib/j0di3-client";
+
+interface PublicTroop {
+    callsign?: string;
+    name?: string;
+    branch?: string;
+    mos?: string;
+    skill_level?: string;
+    target_role?: string;
+    current_module?: number;
+    github_username?: string;
+    bio?: string;
+    skills?: string[];
+    placements?: { company?: string; role?: string; status?: string }[];
+    badges?: string[];
+    stats?: {
+        challenges_completed?: number;
+        lessons_completed?: number;
+        current_streak?: number;
+        total_xp?: number;
+    };
+}
+
+type PageProps = {
+    troop: PublicTroop | null;
+    layout?: { headerShadow: boolean; headerFluid: boolean; footerMode: string };
+};
+
+type PageWithLayout = NextPage<PageProps> & { Layout?: typeof Layout01 };
+
+const PublicProfilePage: PageWithLayout = ({ troop }) => {
+    if (!troop) {
+        return (
+            <div className="tw-container tw-py-16 tw-text-center">
+                <h1 className="tw-text-2xl tw-font-bold tw-text-ink">Troop not found</h1>
+            </div>
+        );
+    }
+
+    const stats = troop.stats || {};
+
+    return (
+        <>
+            <SEO title={`${troop.name || troop.callsign} — VWC`} />
+            <Breadcrumb
+                pages={[{ path: "/", label: "home" }]}
+                currentPage={troop.callsign || troop.name || "Troop"}
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-12 tw-max-w-3xl tw-space-y-6">
+                <header>
+                    <p className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-primary">
+                        @{troop.callsign}
+                    </p>
+                    <h1 className="tw-text-3xl tw-font-bold tw-text-ink">
+                        {troop.name || troop.callsign}
+                    </h1>
+                    <div className="tw-flex tw-flex-wrap tw-gap-2 tw-mt-3">
+                        {troop.branch && <Pill>{troop.branch}</Pill>}
+                        {troop.mos && <Pill>{troop.mos}</Pill>}
+                        {troop.skill_level && <Pill>{troop.skill_level}</Pill>}
+                        {troop.target_role && <Pill>{troop.target_role}</Pill>}
+                    </div>
+                </header>
+
+                {troop.bio && <p className="tw-text-ink/80">{troop.bio}</p>}
+
+                {(stats.challenges_completed != null ||
+                    stats.lessons_completed != null ||
+                    stats.current_streak != null ||
+                    stats.total_xp != null) && (
+                    <section className="tw-grid tw-grid-cols-2 md:tw-grid-cols-4 tw-gap-3">
+                        {stats.total_xp != null && <StatTile label="XP" value={stats.total_xp} />}
+                        {stats.current_streak != null && (
+                            <StatTile label="Streak" value={`${stats.current_streak}d`} />
+                        )}
+                        {stats.challenges_completed != null && (
+                            <StatTile label="Challenges" value={stats.challenges_completed} />
+                        )}
+                        {stats.lessons_completed != null && (
+                            <StatTile label="Lessons" value={stats.lessons_completed} />
+                        )}
+                    </section>
+                )}
+
+                {troop.skills && troop.skills.length > 0 && (
+                    <section>
+                        <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                            Skills
+                        </h2>
+                        <div className="tw-flex tw-flex-wrap tw-gap-2">
+                            {troop.skills.map((s) => (
+                                <Pill key={s}>{s}</Pill>
+                            ))}
+                        </div>
+                    </section>
+                )}
+
+                {troop.badges && troop.badges.length > 0 && (
+                    <section>
+                        <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                            Badges
+                        </h2>
+                        <div className="tw-flex tw-flex-wrap tw-gap-2">
+                            {troop.badges.map((b) => (
+                                <span
+                                    key={b}
+                                    className="tw-rounded-full tw-bg-gold-light tw-px-3 tw-py-1 tw-text-xs tw-font-medium tw-text-ink"
+                                >
+                                    {b}
+                                </span>
+                            ))}
+                        </div>
+                    </section>
+                )}
+
+                {troop.placements && troop.placements.length > 0 && (
+                    <section>
+                        <h2 className="tw-font-mono tw-text-xs tw-uppercase tw-tracking-widest tw-text-navy/60 tw-mb-2">
+                            Placements
+                        </h2>
+                        <ul className="tw-space-y-1 tw-text-sm tw-text-ink/80">
+                            {troop.placements.map((p, i) => (
+                                <li key={i}>
+                                    {p.role || "Role"}
+                                    {p.company && <> @ {p.company}</>}
+                                    {p.status && (
+                                        <span className="tw-text-ink/60"> · {p.status}</span>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                )}
+            </div>
+        </>
+    );
+};
+
+function Pill({ children }: { children: React.ReactNode }) {
+    return (
+        <span className="tw-rounded-full tw-bg-navy-sky tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium tw-text-navy-deep">
+            {children}
+        </span>
+    );
+}
+
+function StatTile({ label, value }: { label: string; value: string | number }) {
+    return (
+        <div className="tw-rounded-md tw-border tw-border-navy/10 tw-bg-white tw-p-4">
+            <div className="tw-font-mono tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-primary">
+                {label}
+            </div>
+            <div className="tw-text-2xl tw-font-bold tw-text-ink tw-mt-1">{value}</div>
+        </div>
+    );
+}
+
+PublicProfilePage.Layout = Layout01;
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async (context) => {
+    const callsign = context.params?.callsign as string;
+    let troop: PublicTroop | null = null;
+
+    try {
+        const { data } = await j0di3.get(`/p/${callsign}`);
+        troop = data as PublicTroop;
+    } catch {
+        // 404 / network — render not-found state
+    }
+
+    if (!troop) return { notFound: true };
+
+    return {
+        props: {
+            troop,
+            layout: { headerShadow: true, headerFluid: false, footerMode: "light" },
+        },
+    };
+};
+
+export default PublicProfilePage;


### PR DESCRIPTION
## Summary

Wires every J0dI3 backend endpoint into the VWC app and builds the UI surfaces that consume them. Brings the J0dI3 integration from ~37 endpoints live to all ~90.

- **Proxies (56 new routes under `/api/j0di3`)** — every endpoint from the backend list. Admin endpoints gated by a new `j0di3AdminProxy` helper (requires ADMIN role).
- **User-facing UI** — new `/lessons` surface (module + lesson + recall), `/community` pairing, `/p/[callsign]` public profile, `/jobs/mos/[code]` MOS detail. Existing surfaces extended: TroopDashboard now shows xp/streak/today tiles, AITeachingAssistant gets thumbs-up/down feedback, challenge detail page adds an "Ask the coach" prompt, ProfileSettings exposes placements/MOS-relevance/export/wipe/delete.
- **Admin console at `/admin/j0di3/*`** — dashboard, cohorts CRUD + roster + bulk add, lesson review queue with claim/release/force-release, placements CRUD with CSV export, learning feedback approve/reject, funnel (engagement + placement), budget with provider/pillar breakdowns, stuck-troop list with daily-grind Slack trigger.

## Verification

- `npm test` — 380/380 passing
- `npm run lint` — clean (37 pre-existing `key={i}` warnings, no new errors)
- `npm run typecheck` — only pre-existing errors remain (`swagger-ui-react` and `next-swagger-doc` are uninstalled on master; 4 test files have stale assertions). Zero new errors from this PR.
- `npm run build` — blocked at the swagger spec generation step on master (`next-swagger-doc` missing). Not introduced by this PR; should be fixed in a follow-up.

## Caveats

1. UI consumes optimistic JSON shapes — components fall back gracefully if J0dI3 returns different field names than guessed (`body.items ?? body.lessons ?? []` patterns throughout). First end-to-end test against the live backend will surface naming mismatches; fixes will be 1-line schema updates per component.
2. ResumeScorer was not rebuilt — its existing client-side PDF text extraction still works. The new `/upload` and `/upload-and-score` proxies are wired and available for a future direct-PDF version.
3. Build verification is blocked by a pre-existing `next-swagger-doc` dependency miss on master — recommend resolving that separately so this PR's routes can be confirmed in CI.

## Test plan

- [ ] Sign in and visit `/profile/<your-id>` → J0dI3 tab loads; xp/streak/today tiles render if backend returns data
- [ ] Visit `/lessons` → module grid and recall-due card render
- [ ] Visit `/lessons/module/1` → module lessons list loads
- [ ] Visit `/community` → pair + mentor candidate lists load
- [ ] Visit `/p/<some-callsign>` → public troop profile renders
- [ ] Visit `/jobs/mos/<code>` → MOS detail loads
- [ ] In a challenge, use "Ask the coach" — reply renders
- [ ] In the AI assistant, send a question and click 👍/👎 — request fires
- [ ] As an admin, visit `/admin/j0di3` → dashboard loads; navigate to each subpage
- [ ] As an admin, create a cohort, add troops in bulk, view roster
- [ ] As an admin, view lesson review queue, claim and release a lesson
- [ ] As an admin, create a placement, edit it, export CSV
- [ ] As a non-admin, attempt to hit `/api/j0di3/admin/*` → 403