### PR TITLE
fix(j0di3): Capture and forward X-Troop-Token on troop-scoped calls

### DIFF
--- a/__tests__/lib/j0di3/ensure-troop.test.ts
+++ b/__tests__/lib/j0di3/ensure-troop.test.ts
@@ -32,9 +32,10 @@ describe("ensureTroop", () => {
         expect(result).toBeNull();
     });
 
-    it("returns existing troopId if user already has one", async () => {
+    it("returns existing troopId if user already has one with an access token", async () => {
         mockFindUnique.mockResolvedValue({
             troopId: "existing-troop-uuid",
+            troopAccessToken: "existing-token",
             name: "Test User",
             email: "test@example.com",
             branch: null,
@@ -50,9 +51,38 @@ describe("ensureTroop", () => {
         expect(mockPost).not.toHaveBeenCalled();
     });
 
-    it("registers a new troop with J0dI3 when user has no troopId", async () => {
+    it("rotates a new access token when user has troopId but no token", async () => {
+        mockFindUnique.mockResolvedValue({
+            troopId: "existing-troop-uuid",
+            troopAccessToken: null,
+            name: "Test User",
+            email: "test@example.com",
+            branch: null,
+            mos: null,
+            skillLevel: null,
+            cohortId: null,
+            enrollments: [],
+        });
+
+        mockPost.mockResolvedValue({ data: { access_token: "rotated-token" } });
+        mockUpdate.mockResolvedValue({});
+
+        const result = await ensureTroop("user-rotate");
+
+        expect(result).toBe("existing-troop-uuid");
+        expect(mockPost).toHaveBeenCalledWith(
+            "/api/v1/troops/existing-troop-uuid/access-token/rotate"
+        );
+        expect(mockUpdate).toHaveBeenCalledWith({
+            where: { id: "user-rotate" },
+            data: { troopAccessToken: "rotated-token" },
+        });
+    });
+
+    it("registers a new troop with J0dI3 and stores access_token when user has no troopId", async () => {
         mockFindUnique.mockResolvedValue({
             troopId: null,
+            troopAccessToken: null,
             name: "New User",
             email: "new@example.com",
             branch: "Army",
@@ -62,7 +92,9 @@ describe("ensureTroop", () => {
             enrollments: [{ id: "enrollment-1" }],
         });
 
-        mockPost.mockResolvedValue({ data: { id: "new-troop-uuid" } });
+        mockPost.mockResolvedValue({
+            data: { id: "new-troop-uuid", access_token: "fresh-token" },
+        });
         mockUpdate.mockResolvedValue({});
 
         const result = await ensureTroop("user-456");
@@ -78,13 +110,14 @@ describe("ensureTroop", () => {
         });
         expect(mockUpdate).toHaveBeenCalledWith({
             where: { id: "user-456" },
-            data: { troopId: "new-troop-uuid" },
+            data: { troopId: "new-troop-uuid", troopAccessToken: "fresh-token" },
         });
     });
 
     it("sends enrolled: false when user has no active enrollments", async () => {
         mockFindUnique.mockResolvedValue({
             troopId: null,
+            troopAccessToken: null,
             name: "User",
             email: "user@example.com",
             branch: null,
@@ -94,7 +127,7 @@ describe("ensureTroop", () => {
             enrollments: [],
         });
 
-        mockPost.mockResolvedValue({ data: { id: "troop-uuid" } });
+        mockPost.mockResolvedValue({ data: { id: "troop-uuid", access_token: "token" } });
         mockUpdate.mockResolvedValue({});
 
         await ensureTroop("user-789");
@@ -112,6 +145,7 @@ describe("ensureTroop", () => {
     it("returns null and logs error when J0dI3 registration fails", async () => {
         mockFindUnique.mockResolvedValue({
             troopId: null,
+            troopAccessToken: null,
             name: "User",
             email: "user@example.com",
             branch: null,

--- a/__tests__/lib/j0di3/j0di3-proxy.test.ts
+++ b/__tests__/lib/j0di3/j0di3-proxy.test.ts
@@ -35,6 +35,7 @@ function createMockReqRes(
             email: "test@test.com",
             role: "STUDENT",
             troopId: "troop-uuid-123",
+            troopToken: "troop-token-abc",
         },
         ...overrides,
     } as unknown as NextApiRequest;
@@ -61,6 +62,7 @@ describe("j0di3Proxy", () => {
             url: "/api/v1/learning/explain",
             data: { question: "What is React?", troop_id: "troop-uuid-123" },
             params: undefined,
+            headers: { "X-Troop-Token": "troop-token-abc" },
         });
         expect(res.json).toHaveBeenCalledWith({ response: "React is a library" });
     });
@@ -78,6 +80,7 @@ describe("j0di3Proxy", () => {
             url: "/api/v1/challenges/recommended",
             data: undefined,
             params: expect.objectContaining({ troop_id: "troop-uuid-123" }),
+            headers: { "X-Troop-Token": "troop-token-abc" },
         });
     });
 
@@ -107,6 +110,19 @@ describe("j0di3Proxy", () => {
         expect(res.status).toHaveBeenCalledWith(400);
         expect(res.json).toHaveBeenCalledWith(
             expect.objectContaining({ error: expect.stringContaining("No J0dI3 troop profile") })
+        );
+    });
+
+    it("returns 400 when user has troopId but no troopToken", async () => {
+        const handler = j0di3Proxy("POST", "/api/v1/learning/explain");
+        const { req, res } = createMockReqRes();
+        (req as any).user.troopToken = null;
+
+        await handler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith(
+            expect.objectContaining({ error: expect.stringContaining("troop access token") })
         );
     });
 

--- a/prisma/migrations/20260528000000_add_troop_access_token_to_user/migration.sql
+++ b/prisma/migrations/20260528000000_add_troop_access_token_to_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "troopAccessToken" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,7 +62,8 @@ model User {
   notes         Note[]
 
   // J0dI3 AI backend
-  troopId       String?         // J0dI3 troop UUID
+  troopId          String?      // J0dI3 troop UUID
+  troopAccessToken String?      // J0dI3 X-Troop-Token, minted on registration or via admin rotate
 
   // E-commerce relationships
   orders        Order[]

--- a/src/lib/ensure-troop.ts
+++ b/src/lib/ensure-troop.ts
@@ -2,14 +2,18 @@ import j0di3 from "@/lib/j0di3-client";
 import prisma from "@/lib/prisma";
 
 /**
- * Ensures a user has a linked J0dI3 troop profile.
- * If not, registers them with the J0dI3 backend and stores the troopId.
+ * Ensures a user has a linked J0dI3 troop profile *and* a stored access token.
+ * On first sign-in: registers with J0dI3 and stores both the troopId and the
+ * one-shot access_token returned by the registration response.
+ * For users who already have a troopId but no token (pre-dating the auth
+ * contract change), rotates a new token via the admin endpoint.
  */
 export async function ensureTroop(userId: string): Promise<string | null> {
     const dbUser = await prisma.user.findUnique({
         where: { id: userId },
         select: {
             troopId: true,
+            troopAccessToken: true,
             name: true,
             email: true,
             branch: true,
@@ -25,7 +29,29 @@ export async function ensureTroop(userId: string): Promise<string | null> {
     });
 
     if (!dbUser) return null;
-    if (dbUser.troopId) return dbUser.troopId;
+
+    if (dbUser.troopId && dbUser.troopAccessToken) {
+        return dbUser.troopId;
+    }
+
+    if (dbUser.troopId && !dbUser.troopAccessToken) {
+        try {
+            const { data } = await j0di3.post(
+                `/api/v1/troops/${dbUser.troopId}/access-token/rotate`
+            );
+            const token = data?.access_token || data?.troop_access_token || data?.token;
+            if (token) {
+                await prisma.user.update({
+                    where: { id: userId },
+                    data: { troopAccessToken: token },
+                });
+            }
+            return dbUser.troopId;
+        } catch (error) {
+            console.error("[ensureTroop] Failed to rotate troop access token:", error);
+            return dbUser.troopId;
+        }
+    }
 
     try {
         const { data } = await j0di3.post("/api/v1/troops/", {
@@ -37,9 +63,11 @@ export async function ensureTroop(userId: string): Promise<string | null> {
             enrolled: dbUser.enrollments.length > 0,
         });
 
+        const token = data?.access_token || data?.troop_access_token || data?.token || null;
+
         await prisma.user.update({
             where: { id: userId },
-            data: { troopId: data.id },
+            data: { troopId: data.id, troopAccessToken: token },
         });
 
         return data.id;

--- a/src/lib/j0di3-proxy.ts
+++ b/src/lib/j0di3-proxy.ts
@@ -17,10 +17,18 @@ async function dispatch(
     injectTroopId: boolean
 ) {
     const troopId = req.user!.troopId;
+    const troopToken = req.user!.troopToken;
+
     if (injectTroopId && !troopId) {
         return res
             .status(400)
             .json({ error: "No J0dI3 troop profile linked. Please sign out and back in." });
+    }
+
+    if (injectTroopId && !troopToken) {
+        return res.status(400).json({
+            error: "Missing J0dI3 troop access token. Please sign out and back in to refresh.",
+        });
     }
 
     try {
@@ -38,7 +46,9 @@ async function dispatch(
                     : req.query
                 : undefined;
 
-        const { data } = await j0di3({ method, url, data: body, params });
+        const headers = injectTroopId && troopToken ? { "X-Troop-Token": troopToken } : undefined;
+
+        const { data } = await j0di3({ method, url, data: body, params, headers });
         res.json(data);
     } catch (error: unknown) {
         if (axios.isAxiosError(error) && error.response) {

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -12,6 +12,7 @@ export interface AuthenticatedRequest extends NextApiRequest {
         email: string;
         role: Role;
         troopId: string | null;
+        troopToken: string | null;
     };
 }
 
@@ -34,10 +35,10 @@ export function requireAuth(
             return res.status(401).json({ error: "Unauthorized - Please sign in" });
         }
 
-        // Fetch troopId from database
+        // Fetch troopId and troopAccessToken from database
         const dbUser = await prisma.user.findUnique({
             where: { id: session.user.id },
-            select: { troopId: true },
+            select: { troopId: true, troopAccessToken: true },
         });
 
         req.user = {
@@ -46,6 +47,7 @@ export function requireAuth(
             email: session.user.email || "",
             role: (session.user.role as Role) || "STUDENT",
             troopId: dbUser?.troopId || null,
+            troopToken: dbUser?.troopAccessToken || null,
         };
 
         return handler(req, res);


### PR DESCRIPTION
## Summary

Production is returning 403 `TROOP_ACCESS_DENIED` on every J0dI3 call because the backend added a per-troop session header — `X-Troop-Token` — that our proxy doesn't send. This PR captures the token at troop registration, backfills it for existing users, and forwards it on every troop-scoped request.

## Root cause

The J0dI3 backend's `_check_troop_access` middleware now requires two headers on troop-scoped resources:
- `X-API-Key` (unchanged) — service identity, already sent.
- `X-Troop-Token` (new) — per-user troop session, **missing**.

Admin-scoped clients skip the check, which is why admin endpoints aren't affected.

The token is minted once on `POST /api/v1/troops/` (returned as `access_token`) and can be re-minted via `POST /api/v1/troops/{troop_id}/access-token/rotate` (admin scope).

## Fix

- **Schema** (`prisma/schema.prisma` + migration) — adds `User.troopAccessToken String?`.
- **`ensureTroop`** (`src/lib/ensure-troop.ts`) — captures `access_token` on new registration. For existing users with `troopId` but no token, calls the admin rotate endpoint once and persists. Reads `access_token`/`troop_access_token`/`token` defensively in case backend naming differs.
- **`requireAuth`** (`src/lib/rbac.ts`) — loads `troopAccessToken` from DB and exposes as `req.user.troopToken`.
- **`j0di3Proxy` dispatch** (`src/lib/j0di3-proxy.ts`) — injects `X-Troop-Token` on troop-scoped calls. Returns 400 with a re-auth hint if the token is missing. `j0di3AdminProxy` skips the header.

## Backfill plan

`ensureTroop` is fired from the NextAuth session callback (`src/pages/api/auth/options.ts:125`) on every session refresh, so existing users self-heal transparently — no manual migration script, no forced sign-out. Worst case: a user's first J0dI3 call after deploy still 400s; the next session refresh rotates a token and subsequent calls succeed.

## Verification

- `npm test` — 382/382 passing (added 2 new tests: rotate-on-backfill, missing-token 400 path)
- `npm run lint` — clean on touched files
- `npm run typecheck` — only the same pre-existing errors as master (swagger / 4 test files)

## Test plan

- [ ] Apply migration to a staging Postgres: `npx prisma migrate deploy` adds the `troopAccessToken` column
- [ ] Sign in as a user with an existing `troopId` but no `troopAccessToken` → next request to `/api/j0di3/troops/dashboard` succeeds (after session refresh fires `ensureTroop` → rotate)
- [ ] Sign in as a brand-new user → `ensureTroop` registers and stores token in the same Prisma update
- [ ] Verify `/api/j0di3/troops/dashboard` request has `X-Troop-Token` header in upstream call (check backend logs or proxy with a probe)
- [ ] Verify `/api/j0di3/admin/*` calls do NOT send `X-Troop-Token` (admin scope)
- [ ] If a user's token gets revoked, the response is 403 from J0dI3 (forwarded by `dispatch`) — user can sign out and back in to re-rotate

## Notes

- This PR does not change the API-key header (`X-API-Key` stays). The 403 was purely about the missing troop token.
- The `ensureTroop` field-name fallback (`access_token || troop_access_token || token`) is defensive — drop to just `access_token` once the backend response shape is confirmed.