### PR TITLE
feat(j0di3): Forward Idempotency-Key and X-Request-ID through proxy

### DIFF
--- a/__tests__/lib/j0di3/j0di3-proxy.test.ts
+++ b/__tests__/lib/j0di3/j0di3-proxy.test.ts
@@ -15,16 +15,17 @@ vi.mock("axios", () => ({
     },
 }));
 
-import j0di3 from "@/lib/j0di3-client";
 import axios from "axios";
+import j0di3 from "@/lib/j0di3-client";
 import { j0di3Proxy } from "@/lib/j0di3-proxy";
 
 const mockJ0di3 = j0di3 as unknown as Mock;
 const mockIsAxiosError = axios.isAxiosError as Mock;
 
-function createMockReqRes(
-    overrides: Partial<NextApiRequest> = {}
-): { req: NextApiRequest; res: NextApiResponse } {
+function createMockReqRes(overrides: Partial<NextApiRequest> = {}): {
+    req: NextApiRequest;
+    res: NextApiResponse;
+} {
     const req = {
         method: "POST",
         body: { question: "What is React?" },
@@ -43,6 +44,7 @@ function createMockReqRes(
     const res = {
         status: vi.fn().mockReturnThis(),
         json: vi.fn().mockReturnThis(),
+        setHeader: vi.fn().mockReturnThis(),
     } as unknown as NextApiResponse;
 
     return { req, res };
@@ -98,6 +100,44 @@ describe("j0di3Proxy", () => {
         expect(mockJ0di3).toHaveBeenCalledWith(
             expect.objectContaining({ url: "/api/v1/challenges/challenge-42/hint" })
         );
+    });
+
+    it("forwards Idempotency-Key and X-Request-ID headers when supplied", async () => {
+        mockJ0di3.mockResolvedValue({ data: { ok: true } });
+
+        const handler = j0di3Proxy("POST", "/api/v1/challenges/c-1/submit");
+        const { req, res } = createMockReqRes({
+            headers: {
+                "idempotency-key": "idem-key-789",
+                "x-request-id": "req-id-456",
+            } as unknown as NextApiRequest["headers"],
+        });
+
+        await handler(req, res);
+
+        expect(mockJ0di3).toHaveBeenCalledWith(
+            expect.objectContaining({
+                headers: {
+                    "X-Troop-Token": "troop-token-abc",
+                    "Idempotency-Key": "idem-key-789",
+                    "X-Request-ID": "req-id-456",
+                },
+            })
+        );
+    });
+
+    it("echoes the J0dI3 X-Request-ID back on the response", async () => {
+        mockJ0di3.mockResolvedValue({
+            data: { ok: true },
+            headers: { "x-request-id": "echoed-req-id" },
+        });
+
+        const handler = j0di3Proxy("POST", "/api/v1/challenges/c-1/submit");
+        const { req, res } = createMockReqRes();
+
+        await handler(req, res);
+
+        expect(res.setHeader).toHaveBeenCalledWith("X-Request-ID", "echoed-req-id");
     });
 
     it("returns 400 when user has no troopId", async () => {

--- a/src/lib/j0di3-proxy.ts
+++ b/src/lib/j0di3-proxy.ts
@@ -46,10 +46,29 @@ async function dispatch(
                     : req.query
                 : undefined;
 
-        const headers = injectTroopId && troopToken ? { "X-Troop-Token": troopToken } : undefined;
+        const headers: Record<string, string> = {};
+        if (injectTroopId && troopToken) {
+            headers["X-Troop-Token"] = troopToken;
+        }
+        // Forward idempotency + correlation headers when the caller supplies them.
+        const idempotencyKey = req.headers?.["idempotency-key"];
+        if (typeof idempotencyKey === "string") {
+            headers["Idempotency-Key"] = idempotencyKey;
+        }
+        const requestId = req.headers?.["x-request-id"];
+        if (typeof requestId === "string") {
+            headers["X-Request-ID"] = requestId;
+        }
 
-        const { data } = await j0di3({ method, url, data: body, params, headers });
-        res.json(data);
+        const response = await j0di3({ method, url, data: body, params, headers });
+
+        // J0dI3 echoes X-Request-ID back; surface it for support correlation.
+        const echoedRequestId = response.headers?.["x-request-id"];
+        if (typeof echoedRequestId === "string") {
+            res.setHeader("X-Request-ID", echoedRequestId);
+        }
+
+        res.json(response.data);
     } catch (error: unknown) {
         if (axios.isAxiosError(error) && error.response) {
             const status = error.response.status;


### PR DESCRIPTION
## Summary

J0dI3's mutating endpoints (`submit`, `score`, `rewrite`, …) accept an `Idempotency-Key` for safe retries and echo `X-Request-ID` for support correlation, but the Next.js proxy was dropping both headers on every call. This wires them through the shared `dispatch()` so every troop and admin route benefits without per-endpoint changes.

## What changed

- `src/lib/j0di3-proxy.ts` — `dispatch()` now forwards an incoming `Idempotency-Key` and `X-Request-ID` request header to J0dI3 when present, and surfaces J0dI3's echoed `X-Request-ID` back on the proxied response.
- `__tests__/lib/j0di3/j0di3-proxy.test.ts` — added two regression tests: header forwarding alongside `X-Troop-Token`, and response-side `X-Request-ID` echo.

## Test plan

- [x] `npm test` — full suite, 384/384 pass (9 in the proxy file)
- [x] `npm run build` — passes (the CI-gated check)
- [x] `npx biome lint` on changed files — 0 errors

## Notes

- This is a proxy-layer enhancement, not a new endpoint. An audit confirmed the troop-facing J0dI3 surface was already fully wired; this header passthrough was the one genuine gap.
- No new env vars, routes, Swagger annotations, or Prisma migrations.