### PR TITLE
feat(profile): Back profile tab state with URL query

### DIFF
--- a/__tests__/lib/profile-tabs.test.ts
+++ b/__tests__/lib/profile-tabs.test.ts
@@ -1,0 +1,26 @@
+import { resolveProfileTab } from "@/lib/profile-tabs";
+import { PROFILE_TABS } from "@/types/profile";
+
+describe("resolveProfileTab", () => {
+    it("returns each valid tab id unchanged", () => {
+        for (const tab of PROFILE_TABS) {
+            expect(resolveProfileTab(tab.id)).toBe(tab.id);
+        }
+    });
+
+    it("defaults to command-center when the value is absent", () => {
+        expect(resolveProfileTab(undefined)).toBe("command-center");
+    });
+
+    it("defaults to command-center for garbage values", () => {
+        expect(resolveProfileTab("not-a-tab")).toBe("command-center");
+        expect(resolveProfileTab("")).toBe("command-center");
+        expect(resolveProfileTab("SETTINGS")).toBe("command-center");
+    });
+
+    it("uses the first entry when the query value is an array", () => {
+        expect(resolveProfileTab(["settings", "arsenal"])).toBe("settings");
+        expect(resolveProfileTab(["bogus", "settings"])).toBe("command-center");
+        expect(resolveProfileTab([])).toBe("command-center");
+    });
+});

--- a/src/lib/profile-tabs.ts
+++ b/src/lib/profile-tabs.ts
@@ -1,0 +1,15 @@
+import { PROFILE_TABS, type ProfileTab } from "@/types/profile";
+
+const VALID_TAB_IDS = new Set<string>(PROFILE_TABS.map((tab) => tab.id));
+
+/**
+ * Resolves a `?tab=` query value to a valid ProfileTab.
+ * Falls back to "command-center" when the value is absent or invalid.
+ */
+export function resolveProfileTab(queryValue: string | string[] | undefined): ProfileTab {
+    const value = Array.isArray(queryValue) ? queryValue[0] : queryValue;
+    if (value && VALID_TAB_IDS.has(value)) {
+        return value as ProfileTab;
+    }
+    return "command-center";
+}

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -4,9 +4,9 @@ import { useMount } from "@hooks";
 import Layout01 from "@layout/layout-01";
 import Spinner from "@ui/spinner";
 import type { GetServerSideProps, NextPage } from "next";
+import { useRouter } from "next/router";
 import { getServerSession } from "next-auth/next";
 import { signOut } from "next-auth/react";
-import { useState } from "react";
 import {
     ActivityFeed,
     GitHubReadme,
@@ -25,6 +25,7 @@ import useGitHubProfile from "@/hooks/use-github-profile";
 import useLearningStats from "@/hooks/use-learning-stats";
 import useProfileForm from "@/hooks/use-profile-form";
 import prisma from "@/lib/prisma";
+import { resolveProfileTab } from "@/lib/profile-tabs";
 import { options } from "@/pages/api/auth/options";
 import type { ProfileTab, ProfileUser } from "@/types/profile";
 
@@ -44,7 +45,10 @@ type PageWithLayout = NextPage<PageProps> & {
 
 const MemberProfile: PageWithLayout = ({ user, isOwner }) => {
     const mounted = useMount();
-    const [activeTab, setActiveTab] = useState<ProfileTab>("command-center");
+    const router = useRouter();
+    const requestedTab = resolveProfileTab(router.query.tab);
+    // Settings is owner-only; fall back for non-owners deep-linking ?tab=settings
+    const activeTab = requestedTab === "settings" && !isOwner ? "command-center" : requestedTab;
 
     // Pass the target user's ID to hooks so they fetch that member's data
     const targetId = isOwner ? undefined : user.id;
@@ -59,6 +63,10 @@ const MemberProfile: PageWithLayout = ({ user, isOwner }) => {
             </div>
         );
     }
+
+    const handleTabChange = (tab: ProfileTab) => {
+        void router.push({ query: { ...router.query, tab } }, undefined, { shallow: true });
+    };
 
     const handleLogout = async () => {
         try {
@@ -101,7 +109,7 @@ const MemberProfile: PageWithLayout = ({ user, isOwner }) => {
                     onLogout={handleLogout}
                 />
 
-                <ProfileNav activeTab={activeTab} onTabChange={setActiveTab} isOwner={isOwner} />
+                <ProfileNav activeTab={activeTab} onTabChange={handleTabChange} isOwner={isOwner} />
 
                 {/* Command Center — GitHub overview */}
                 {activeTab === "command-center" && (


### PR DESCRIPTION
## Problem

`src/pages/profile/[id].tsx` held the active tab in `useState`, so a page reload always reset the view to "command-center", tabs could not be deep-linked, and browser back/forward did not move between tabs (#1057).

## Solution

- New pure helper `resolveProfileTab(queryValue)` in `src/lib/profile-tabs.ts`: validates `?tab=` against `PROFILE_TABS` ids and falls back to `command-center` for absent, invalid, or array garbage values (first array entry is considered).
- The page derives `activeTab` from `router.query.tab` on every render — the URL is the single source of truth, so reload, deep links, and back/forward all work.
- Tab clicks call `router.push({ query: { ...router.query, tab } }, undefined, { shallow: true })` so `getServerSideProps` does not re-run.
- Non-owners deep-linking the owner-only `?tab=settings` fall back to `command-center` instead of rendering an empty pane.

## Verification

- `npm run typecheck` — 7 pre-existing errors in unrelated `__tests__/pages/api/j0di3/*` files, identical count on master baseline; no errors in changed files
- `npm run lint` — 25 errors / 491 warnings, identical to master baseline; changed files introduce no new diagnostics
- `npm test` — 42 files, 388 tests passed (includes new `__tests__/lib/profile-tabs.test.ts` covering valid/absent/invalid/array query values)
- `npm run build` — succeeds; `/profile/[id]` compiles as SSR route

Closes #1057