### PR TITLE
fix(certificates): Verify certificates by printed certificate number

### DIFF
--- a/__tests__/api/certificates/verify.test.ts
+++ b/__tests__/api/certificates/verify.test.ts
@@ -1,0 +1,122 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import type { Mock } from "vitest";
+import handler from "@/pages/api/certificates/verify";
+
+vi.mock("@/lib/prisma", () => ({
+    default: {
+        certificate: {
+            findUnique: vi.fn(),
+        },
+    },
+}));
+
+import prisma from "@/lib/prisma";
+
+const mockFindUnique = prisma.certificate.findUnique as Mock;
+
+const LEGACY_ID = "clx1a2b3c4d5e6f7g8h9i0j1k";
+const CERT_NUMBER = "VWC-2026-000123";
+
+const certificateRow = {
+    id: LEGACY_ID,
+    certificateNumber: CERT_NUMBER,
+    issuedAt: new Date("2026-05-01T00:00:00.000Z"),
+    user: {
+        id: "user-1",
+        name: "Jane Doe",
+        email: "jane@example.com",
+    },
+    course: {
+        id: "course-1",
+        title: "Foundations of Software Engineering",
+        description: "Core engineering fundamentals",
+        difficulty: "BEGINNER",
+        estimatedHours: 40,
+        category: "Engineering",
+    },
+};
+
+function createMockReqRes(
+    method = "GET",
+    query: Record<string, string> = {}
+): { req: NextApiRequest; res: NextApiResponse } {
+    const req = { method, query } as unknown as NextApiRequest;
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+    } as unknown as NextApiResponse;
+    return { req, res };
+}
+
+describe("GET /api/certificates/verify", () => {
+    beforeEach(() => {
+        mockFindUnique.mockReset();
+    });
+
+    it("verifies a certificate by its printed certificate number", async () => {
+        mockFindUnique.mockResolvedValueOnce(certificateRow);
+        const { req, res } = createMockReqRes("GET", { number: CERT_NUMBER });
+
+        await handler(req, res);
+
+        expect(mockFindUnique).toHaveBeenCalledTimes(1);
+        expect(mockFindUnique.mock.calls[0][0].where).toEqual({
+            certificateNumber: CERT_NUMBER,
+        });
+
+        const body = (res.json as Mock).mock.calls[0][0];
+        expect(body.valid).toBe(true);
+        expect(body.certificate.certificateNumber).toBe(CERT_NUMBER);
+        expect(body.certificate.student.name).toBe("Jane Doe");
+        expect(body.certificate.course.title).toBe("Foundations of Software Engineering");
+        expect(body.certificate.issuedAt).toEqual(certificateRow.issuedAt);
+    });
+
+    it("returns valid:false for an unknown certificate number without an id fallback", async () => {
+        mockFindUnique.mockResolvedValue(null);
+        const { req, res } = createMockReqRes("GET", { number: "VWC-2099-999999" });
+
+        await handler(req, res);
+
+        // Not cuid-shaped, so no second lookup by id
+        expect(mockFindUnique).toHaveBeenCalledTimes(1);
+        const body = (res.json as Mock).mock.calls[0][0];
+        expect(body.valid).toBe(false);
+    });
+
+    it("falls back to row id lookup for legacy cuid-shaped numbers", async () => {
+        mockFindUnique
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({ ...certificateRow, certificateNumber: null });
+        const { req, res } = createMockReqRes("GET", { number: LEGACY_ID });
+
+        await handler(req, res);
+
+        expect(mockFindUnique).toHaveBeenCalledTimes(2);
+        expect(mockFindUnique.mock.calls[0][0].where).toEqual({ certificateNumber: LEGACY_ID });
+        expect(mockFindUnique.mock.calls[1][0].where).toEqual({ id: LEGACY_ID });
+
+        const body = (res.json as Mock).mock.calls[0][0];
+        expect(body.valid).toBe(true);
+        // Legacy rows have no certificateNumber; the id they printed is returned
+        expect(body.certificate.certificateNumber).toBe(LEGACY_ID);
+    });
+
+    it("returns 400 when the number query parameter is missing", async () => {
+        const { req, res } = createMockReqRes("GET");
+
+        await handler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(mockFindUnique).not.toHaveBeenCalled();
+    });
+
+    it("returns 405 for non-GET methods", async () => {
+        const { req, res } = createMockReqRes("POST", { number: CERT_NUMBER });
+
+        await handler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(405);
+        expect(res.json).toHaveBeenCalledWith({ error: "Method not allowed" });
+    });
+});

--- a/public/swagger-spec.json
+++ b/public/swagger-spec.json
@@ -157,6 +157,70 @@
           }
         }
       }
+    },
+    "/api/certificates/verify": {
+      "get": {
+        "summary": "Verify a certificate",
+        "description": "Public endpoint to verify a certificate by its printed certificate number (e.g. VWC-2026-000123). Legacy certificate ids are also accepted. No authentication required.",
+        "tags": [
+          "Certificates"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "number",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Printed certificate number (VWC-YYYY-XXXXXX) or legacy certificate id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Verification result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "valid": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "certificate": {
+                      "type": "object",
+                      "properties": {
+                        "certificateNumber": {
+                          "type": "string"
+                        },
+                        "student": {
+                          "type": "object"
+                        },
+                        "course": {
+                          "type": "object"
+                        },
+                        "issuedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required query parameter"
+          },
+          "405": {
+            "description": "Method not allowed"
+          }
+        }
+      }
     }
   },
   "tags": []

--- a/src/lib/certificates.ts
+++ b/src/lib/certificates.ts
@@ -104,36 +104,52 @@ export async function checkCertificateEligibility(
     return { eligible: true };
 }
 
+// Shape of Prisma cuid row ids (e.g. "clxyz..."); legacy certificates printed these
+const CUID_PATTERN = /^c[a-z0-9]{20,}$/;
+
 /**
- * Get certificate by certificate number (from ID)
- * Certificate number is derived from the certificate ID
+ * Get certificate by its printed certificate number (e.g. VWC-2026-000123).
+ * Falls back to looking up by row id for legacy certificates that were
+ * issued before certificateNumber existed and printed the cuid id instead.
  */
 export async function getCertificateByNumber(certificateNumber: string): Promise<any> {
-    // For now, certificate number is the same as the ID
-    // In production, you might want to use a more sophisticated mapping
-    const certificate = await prisma.certificate.findUnique({
-        where: { id: certificateNumber },
-        include: {
-            user: {
-                select: {
-                    id: true,
-                    name: true,
-                    email: true,
-                },
-            },
-            course: {
-                select: {
-                    id: true,
-                    title: true,
-                    description: true,
-                    difficulty: true,
-                    estimatedHours: true,
-                },
+    const include = {
+        user: {
+            select: {
+                id: true,
+                name: true,
+                email: true,
             },
         },
+        course: {
+            select: {
+                id: true,
+                title: true,
+                description: true,
+                difficulty: true,
+                estimatedHours: true,
+                category: true,
+            },
+        },
+    };
+
+    const certificate = await prisma.certificate.findUnique({
+        where: { certificateNumber },
+        include,
     });
 
-    return certificate;
+    if (certificate) {
+        return certificate;
+    }
+
+    if (CUID_PATTERN.test(certificateNumber)) {
+        return prisma.certificate.findUnique({
+            where: { id: certificateNumber },
+            include,
+        });
+    }
+
+    return null;
 }
 
 /**
@@ -142,7 +158,7 @@ export async function getCertificateByNumber(certificateNumber: string): Promise
 export function formatCertificateData(certificate: any) {
     return {
         id: certificate.id,
-        certificateNumber: certificate.id, // Using ID as certificate number
+        certificateNumber: certificate.certificateNumber ?? certificate.id,
         studentName: certificate.user.name || certificate.user.email,
         courseName: certificate.course.title,
         courseDescription: certificate.course.description,

--- a/src/pages/api/certificates/verify.ts
+++ b/src/pages/api/certificates/verify.ts
@@ -1,19 +1,49 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import prisma from "@/lib/prisma";
+import { getCertificateByNumber } from "@/lib/certificates";
 
 /**
- * GET /api/certificates/verify?number=CERT_NUMBER
- *
- * Verify a certificate by its certificate number
- * This endpoint is public to allow employers and others to verify certificates
- * No authentication required
- *
- * Query params:
- * - number: Certificate number (same as certificate ID)
- *
- * Returns:
- * - valid: boolean indicating if certificate exists
- * - certificate: Certificate details if valid
+ * @swagger
+ * /api/certificates/verify:
+ *   get:
+ *     summary: Verify a certificate
+ *     description: Public endpoint to verify a certificate by its printed certificate number (e.g. VWC-2026-000123). Legacy certificate ids are also accepted. No authentication required.
+ *     tags:
+ *       - Certificates
+ *     parameters:
+ *       - in: query
+ *         name: number
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Printed certificate number (VWC-YYYY-XXXXXX) or legacy certificate id
+ *     responses:
+ *       200:
+ *         description: Verification result
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 valid:
+ *                   type: boolean
+ *                 message:
+ *                   type: string
+ *                 certificate:
+ *                   type: object
+ *                   properties:
+ *                     certificateNumber:
+ *                       type: string
+ *                     student:
+ *                       type: object
+ *                     course:
+ *                       type: object
+ *                     issuedAt:
+ *                       type: string
+ *                       format: date-time
+ *       400:
+ *         description: Missing required query parameter
+ *       405:
+ *         description: Method not allowed
  */
 async function handleGet(req: NextApiRequest, res: NextApiResponse) {
     try {
@@ -25,29 +55,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
             });
         }
 
-        // Look up certificate by ID (which is the certificate number)
-        const certificate = await prisma.certificate.findUnique({
-            where: { id: number },
-            include: {
-                user: {
-                    select: {
-                        id: true,
-                        name: true,
-                        email: true,
-                    },
-                },
-                course: {
-                    select: {
-                        id: true,
-                        title: true,
-                        description: true,
-                        difficulty: true,
-                        estimatedHours: true,
-                        category: true,
-                    },
-                },
-            },
-        });
+        const certificate = await getCertificateByNumber(number);
 
         if (!certificate) {
             return res.json({
@@ -61,7 +69,7 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
             valid: true,
             message: "Certificate is valid and authenticated.",
             certificate: {
-                certificateNumber: certificate.id,
+                certificateNumber: certificate.certificateNumber ?? certificate.id,
                 student: {
                     name: certificate.user.name || "Unknown",
                     email: certificate.user.email,

--- a/src/pages/verify/[number].tsx
+++ b/src/pages/verify/[number].tsx
@@ -1,0 +1,186 @@
+import Breadcrumb from "@components/breadcrumb";
+import SEO from "@components/seo/page-seo";
+import Layout01 from "@layout/layout-01";
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import React, { useEffect, useState } from "react";
+
+type VerifiedCertificate = {
+    certificateNumber: string;
+    student: {
+        name: string;
+        email: string;
+    };
+    course: {
+        title: string;
+        description: string;
+        difficulty: string;
+        estimatedHours: number;
+        category: string;
+    };
+    issuedAt: string;
+};
+
+type PageProps = {
+    layout?: {
+        headerShadow: boolean;
+        headerFluid: boolean;
+        footerMode: string;
+    };
+};
+
+type PageWithLayout = NextPage<PageProps> & {
+    Layout?: typeof Layout01;
+};
+
+const VerifyCertificatePage: PageWithLayout = () => {
+    const router = useRouter();
+    const { number } = router.query;
+    const [certificate, setCertificate] = useState<VerifiedCertificate | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (!number || typeof number !== "string") return;
+
+        const verifyCertificate = async () => {
+            try {
+                const response = await fetch(
+                    `/api/certificates/verify?number=${encodeURIComponent(number)}`
+                );
+                const data = await response.json();
+
+                if (response.ok && data.valid && data.certificate) {
+                    setCertificate(data.certificate);
+                }
+            } catch {
+                // Treated as invalid below
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        verifyCertificate();
+    }, [number]);
+
+    const formatDate = (dateString: string) => {
+        const date = new Date(dateString);
+        return date.toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+        });
+    };
+
+    if (loading) {
+        return (
+            <div className="tw-container tw-py-16">
+                <div className="tw-text-center">
+                    <div className="tw-mx-auto tw-h-32 tw-w-32 tw-animate-spin tw-rounded-full tw-border-b-2 tw-border-primary" />
+                    <p className="tw-mt-4 tw-text-gray-300">Verifying certificate...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (!certificate) {
+        return (
+            <>
+                <SEO
+                    title="Certificate Verification"
+                    description="Verify the authenticity of a Vets Who Code certificate"
+                />
+                <Breadcrumb
+                    pages={[{ path: "/", label: "home" }]}
+                    currentPage="Verify Certificate"
+                    showTitle={false}
+                />
+                <div className="tw-container tw-py-16">
+                    <div className="tw-text-center">
+                        <h1 className="tw-mb-4 tw-text-4xl tw-font-bold tw-text-ink">
+                            Certificate Not Valid
+                        </h1>
+                        <p className="tw-mb-8 tw-text-gray-300">
+                            We could not verify a certificate with the number{" "}
+                            <span className="tw-font-semibold">{number}</span>. Check the number
+                            printed on the certificate and try again.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => router.push("/")}
+                            className="tw-rounded-md tw-bg-primary tw-px-6 tw-py-3 tw-font-semibold tw-text-white tw-transition-colors hover:tw-bg-primary-dark"
+                        >
+                            Go Home
+                        </button>
+                    </div>
+                </div>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <SEO
+                title={`Verified Certificate - ${certificate.course.title}`}
+                description={`Verified certificate of completion for ${certificate.student.name} - ${certificate.course.title}`}
+            />
+            <Breadcrumb
+                pages={[{ path: "/", label: "home" }]}
+                currentPage="Verify Certificate"
+                showTitle={false}
+            />
+
+            <div className="tw-container tw-py-16">
+                <div className="tw-mx-auto tw-max-w-2xl tw-rounded-lg tw-bg-white tw-p-12 tw-shadow-2xl">
+                    <div className="tw-border-8 tw-border-double tw-border-primary tw-p-8">
+                        <div className="tw-mb-8 tw-text-center">
+                            <h1 className="tw-mb-2 tw-text-4xl tw-font-bold tw-text-ink">
+                                Certificate Verified
+                            </h1>
+                            <div className="tw-mx-auto tw-my-4 tw-h-1 tw-w-32 tw-bg-primary" />
+                            <p className="tw-text-xl tw-text-gray-300">Vets Who Code</p>
+                        </div>
+
+                        <div className="tw-mb-8 tw-text-center">
+                            <p className="tw-mb-6 tw-text-lg tw-text-gray-200">
+                                This certifies that
+                            </p>
+                            <h2 className="tw-mb-6 tw-text-3xl tw-font-bold tw-text-primary">
+                                {certificate.student.name}
+                            </h2>
+                            <p className="tw-mb-6 tw-text-lg tw-text-gray-200">
+                                successfully completed the course
+                            </p>
+                            <h3 className="tw-mb-6 tw-text-2xl tw-font-semibold tw-text-ink">
+                                {certificate.course.title}
+                            </h3>
+                            <p className="tw-text-sm tw-text-gray-300">Date of Completion</p>
+                            <p className="tw-font-semibold tw-text-ink">
+                                {formatDate(certificate.issuedAt)}
+                            </p>
+                        </div>
+
+                        <div className="tw-mt-8 tw-text-center">
+                            <p className="tw-text-xs tw-text-gray-500">
+                                Certificate Number: {certificate.certificateNumber}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="tw-mx-auto tw-mt-8 tw-max-w-2xl tw-rounded-lg tw-bg-navy-sky/20 tw-p-6">
+                    <h3 className="tw-mb-2 tw-text-lg tw-font-semibold tw-text-navy-deep">
+                        Certificate Verification
+                    </h3>
+                    <p className="tw-text-sm tw-text-navy-deep">
+                        This certificate has been verified as authentic and was issued by Vets Who
+                        Code.
+                    </p>
+                </div>
+            </div>
+        </>
+    );
+};
+
+VerifyCertificatePage.Layout = Layout01;
+
+export default VerifyCertificatePage;


### PR DESCRIPTION
## Problem

Certificate verification was broken end to end:

- Certificates are issued with a human-readable `certificateNumber` (`VWC-YYYY-XXXXXX`), and the PDF prints "Certificate No: <number>" plus "Verify at: vetswhocode.io/verify/<number>".
- But every verification path queried by the Prisma row id: `/api/certificates/verify` used `findUnique({ where: { id: number } })`, `getCertificateByNumber` in `src/lib/certificates.ts` did the same, and `formatCertificateData` returned the cuid as the certificate number.
- The printed `/verify/<number>` URL had no matching route at all, so every printed link 404'd.

## Solution

- `getCertificateByNumber` now queries the `certificateNumber` column first. If that misses and the input matches the cuid shape of row ids, it falls back to an id lookup so legacy certificates (null `certificateNumber`, printed the cuid) keep verifying.
- `/api/certificates/verify` reuses the lib lookup instead of its own query, returns `certificate.certificateNumber` (falling back to the id for legacy rows), and now has a `@swagger` block.
- `formatCertificateData` returns the real certificate number.
- New public page `src/pages/verify/[number].tsx` resolves the printed URL: it calls `/api/certificates/verify?number=...` and renders the verified state (student, course, completion date, certificate number) or a clear invalid state, following the visual conventions of `src/pages/certificates/[certificateId].tsx`.
- The URL printed in `pdf-certificate.ts` is unchanged — already-printed certificates keep working.

## Verification

- `npm run typecheck` — no errors in changed files; the 7 reported errors are pre-existing in untouched `__tests__/**/j0di3/*` files (verified identical on a clean master checkout).
- `npm run lint` — changed files have 0 errors (2 pre-existing `any` warnings on existing signatures in `certificates.ts`); repo-wide errors are pre-existing in untouched files.
- `npm test` — 42 files / 389 tests pass, including new `__tests__/api/certificates/verify.test.ts` (printed number resolves valid with correct student/course, unknown number returns valid:false with no id fallback, legacy cuid id falls back to id lookup, missing param 400, non-GET 405).
- `npm run build` — succeeds; `/verify/[number]` and `/api/certificates/verify` present in route output.

Closes #1148