### PR TITLE
fix(lms): Gate course completion and certificates on graded assignments

### DIFF
--- a/__tests__/pages/api/lms/progress.test.ts
+++ b/__tests__/pages/api/lms/progress.test.ts
@@ -1,0 +1,270 @@
+import { NextApiResponse } from "next";
+import type { Mock } from "vitest";
+
+vi.mock("@/lib/rbac", () => ({
+    requireAuth: vi.fn((handler) => handler),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+    default: {
+        lesson: {
+            findUnique: vi.fn(),
+            count: vi.fn(),
+        },
+        progress: {
+            findUnique: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            count: vi.fn(),
+        },
+        assignment: {
+            findMany: vi.fn(),
+        },
+        enrollment: {
+            updateMany: vi.fn(),
+            findUnique: vi.fn(),
+        },
+        user: {
+            findUnique: vi.fn(),
+        },
+        course: {
+            findUnique: vi.fn(),
+        },
+        certificate: {
+            create: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/certificates", () => ({
+    checkCertificateEligibility: vi.fn(),
+    generateCertificateNumber: vi.fn(),
+}));
+
+vi.mock("@/lib/pdf-certificate", () => ({
+    generateCertificatePDF: vi.fn(),
+    generateCertificateFilename: vi.fn(),
+}));
+
+vi.mock("@/lib/send-certificate-email", () => ({
+    sendCertificateEmail: vi.fn(),
+}));
+
+vi.mock("cloudinary", () => ({
+    v2: {
+        config: vi.fn(),
+        uploader: {
+            upload_stream: vi.fn((_options, callback) => ({
+                end: vi.fn(() =>
+                    callback(null, { secure_url: "https://cdn.example.com/cert.pdf" })
+                ),
+            })),
+        },
+    },
+}));
+
+import { checkCertificateEligibility, generateCertificateNumber } from "@/lib/certificates";
+import { generateCertificateFilename, generateCertificatePDF } from "@/lib/pdf-certificate";
+import prisma from "@/lib/prisma";
+import { AuthenticatedRequest } from "@/lib/rbac";
+import { sendCertificateEmail } from "@/lib/send-certificate-email";
+import handler from "@/pages/api/lms/progress/index";
+
+const mockLessonFindUnique = prisma.lesson.findUnique as Mock;
+const mockLessonCount = prisma.lesson.count as Mock;
+const mockProgressFindUnique = prisma.progress.findUnique as Mock;
+const mockProgressCreate = prisma.progress.create as Mock;
+const mockProgressCount = prisma.progress.count as Mock;
+const mockAssignmentFindMany = prisma.assignment.findMany as Mock;
+const mockEnrollmentUpdateMany = prisma.enrollment.updateMany as Mock;
+const mockEnrollmentFindUnique = prisma.enrollment.findUnique as Mock;
+const mockUserFindUnique = prisma.user.findUnique as Mock;
+const mockCourseFindUnique = prisma.course.findUnique as Mock;
+const mockCertificateCreate = prisma.certificate.create as Mock;
+const mockCheckEligibility = checkCertificateEligibility as Mock;
+const mockGenerateNumber = generateCertificateNumber as Mock;
+const mockGeneratePDF = generateCertificatePDF as Mock;
+const mockGenerateFilename = generateCertificateFilename as Mock;
+const mockSendEmail = sendCertificateEmail as Mock;
+
+function createMockReqRes(body: Record<string, unknown>): {
+    req: AuthenticatedRequest;
+    res: NextApiResponse;
+} {
+    const req = {
+        method: "POST",
+        body,
+        user: { id: "user-1" },
+    } as unknown as AuthenticatedRequest;
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+    } as unknown as NextApiResponse;
+    return { req, res };
+}
+
+function getResponseBody(res: NextApiResponse) {
+    return (res.json as Mock).mock.calls[0][0];
+}
+
+describe("POST /api/lms/progress course completion gating", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockLessonFindUnique.mockResolvedValue({
+            id: "lesson-1",
+            module: {
+                courseId: "course-1",
+                course: {
+                    enrollments: [{ id: "enrollment-1" }],
+                },
+            },
+        });
+        mockProgressFindUnique.mockResolvedValue(null);
+        mockProgressCreate.mockResolvedValue({
+            id: "progress-1",
+            completed: true,
+            lesson: { id: "lesson-1", title: "Lesson 1", order: 1, moduleId: "module-1" },
+        });
+        mockLessonCount.mockResolvedValue(2);
+        mockProgressCount.mockResolvedValue(2);
+        mockEnrollmentUpdateMany.mockResolvedValue({ count: 1 });
+
+        // Certificate generation happy path
+        mockCheckEligibility.mockResolvedValue({ eligible: true });
+        mockUserFindUnique.mockResolvedValue({
+            id: "user-1",
+            name: "Test Vet",
+            email: "vet@example.com",
+        });
+        mockCourseFindUnique.mockResolvedValue({
+            id: "course-1",
+            title: "Test Course",
+            estimatedHours: 10,
+        });
+        mockEnrollmentFindUnique.mockResolvedValue({ completedAt: new Date() });
+        mockGenerateNumber.mockResolvedValue("VWC-2026-000001");
+        mockGeneratePDF.mockResolvedValue(new Uint8Array([1, 2, 3]));
+        mockGenerateFilename.mockReturnValue("certificate.pdf");
+        mockCertificateCreate.mockResolvedValue({ id: "cert-1" });
+        mockSendEmail.mockResolvedValue(undefined);
+    });
+
+    it("does not complete the course or issue a certificate when an assignment is ungraded", async () => {
+        mockAssignmentFindMany.mockResolvedValue([
+            { id: "assignment-1", title: "Capstone Project", submissions: [] },
+        ]);
+
+        const { req, res } = createMockReqRes({ lessonId: "lesson-1", completed: true });
+        await handler(req, res);
+
+        expect(mockEnrollmentUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ status: "ACTIVE", completedAt: null }),
+            })
+        );
+        expect(mockCheckEligibility).not.toHaveBeenCalled();
+        expect(mockCertificateCreate).not.toHaveBeenCalled();
+        expect(mockSendEmail).not.toHaveBeenCalled();
+
+        const body = getResponseBody(res);
+        expect(body.courseProgress.percentage).toBe(100);
+        expect(body.courseProgress.isComplete).toBe(false);
+        expect(body.courseProgress.pendingAssignments).toEqual({
+            count: 1,
+            titles: ["Capstone Project"],
+        });
+        expect(body.certificate).toBeUndefined();
+    });
+
+    it("does not complete the course when a submission exists but is not GRADED", async () => {
+        // Submissions are filtered to GRADED in the query, so a SUBMITTED-only
+        // assignment comes back with an empty submissions array
+        mockAssignmentFindMany.mockResolvedValue([
+            { id: "assignment-1", title: "Homework 1", submissions: [] },
+            { id: "assignment-2", title: "Final Project", submissions: [{ id: "sub-2" }] },
+        ]);
+
+        const { req, res } = createMockReqRes({ lessonId: "lesson-1", completed: true });
+        await handler(req, res);
+
+        expect(mockAssignmentFindMany).toHaveBeenCalledWith({
+            where: { courseId: "course-1" },
+            select: {
+                id: true,
+                title: true,
+                submissions: {
+                    where: { userId: "user-1", status: "GRADED" },
+                    select: { id: true },
+                },
+            },
+        });
+        expect(mockCertificateCreate).not.toHaveBeenCalled();
+
+        const body = getResponseBody(res);
+        expect(body.courseProgress.isComplete).toBe(false);
+        expect(body.courseProgress.pendingAssignments).toEqual({
+            count: 1,
+            titles: ["Homework 1"],
+        });
+    });
+
+    it("completes the course and issues a certificate when every assignment is GRADED", async () => {
+        mockAssignmentFindMany.mockResolvedValue([
+            { id: "assignment-1", title: "Homework 1", submissions: [{ id: "sub-1" }] },
+            { id: "assignment-2", title: "Final Project", submissions: [{ id: "sub-2" }] },
+        ]);
+
+        const { req, res } = createMockReqRes({ lessonId: "lesson-1", completed: true });
+        await handler(req, res);
+
+        expect(mockEnrollmentUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ status: "COMPLETED" }),
+            })
+        );
+        expect(mockCertificateCreate).toHaveBeenCalled();
+        expect(mockSendEmail).toHaveBeenCalled();
+
+        const body = getResponseBody(res);
+        expect(body.courseProgress.isComplete).toBe(true);
+        expect(body.courseProgress.pendingAssignments).toBeUndefined();
+        expect(body.certificate).toEqual({
+            generated: true,
+            url: "https://cdn.example.com/cert.pdf",
+        });
+    });
+
+    it("keeps current behavior for a course with zero assignments", async () => {
+        mockAssignmentFindMany.mockResolvedValue([]);
+
+        const { req, res } = createMockReqRes({ lessonId: "lesson-1", completed: true });
+        await handler(req, res);
+
+        expect(mockEnrollmentUpdateMany).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ status: "COMPLETED" }),
+            })
+        );
+        expect(mockCertificateCreate).toHaveBeenCalled();
+
+        const body = getResponseBody(res);
+        expect(body.courseProgress.isComplete).toBe(true);
+        expect(body.courseProgress.pendingAssignments).toBeUndefined();
+    });
+
+    it("does not check assignments while lessons are below 100%", async () => {
+        mockProgressCount.mockResolvedValue(1);
+
+        const { req, res } = createMockReqRes({ lessonId: "lesson-1", completed: true });
+        await handler(req, res);
+
+        expect(mockAssignmentFindMany).not.toHaveBeenCalled();
+        expect(mockCertificateCreate).not.toHaveBeenCalled();
+
+        const body = getResponseBody(res);
+        expect(body.courseProgress.percentage).toBe(50);
+        expect(body.courseProgress.isComplete).toBe(false);
+        expect(body.courseProgress.pendingAssignments).toBeUndefined();
+    });
+});

--- a/src/pages/api/lms/progress/index.ts
+++ b/src/pages/api/lms/progress/index.ts
@@ -14,23 +14,65 @@ cloudinary.config({
 });
 
 /**
- * GET /api/lms/progress
- * Fetch user's lesson progress (optionally filtered by courseId or moduleId)
- *
- * Query params:
- * - courseId?: string - Filter by course
- * - moduleId?: string - Filter by module
- * - lessonId?: string - Get specific lesson progress
- *
- * POST /api/lms/progress
- * Update lesson progress (mark as started, completed, or update time spent)
- *
- * Request body:
- * {
- *   lessonId: string,
- *   completed?: boolean,
- *   timeSpent?: number (in minutes)
- * }
+ * @swagger
+ * /api/lms/progress:
+ *   get:
+ *     summary: Fetch user's lesson progress
+ *     description: Returns the authenticated user's lesson progress, optionally filtered by courseId, moduleId, or lessonId.
+ *     tags:
+ *       - LMS
+ *     security:
+ *       - SessionCookie: []
+ *     parameters:
+ *       - in: query
+ *         name: courseId
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: moduleId
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: lessonId
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Progress records
+ *   post:
+ *     summary: Update lesson progress
+ *     description: Marks a lesson as started or completed and updates time spent. The course transitions to COMPLETED (and a certificate is issued) only when all lessons are complete AND every course assignment has a GRADED submission from the user. Outstanding assignments are returned in courseProgress.pendingAssignments.
+ *     tags:
+ *       - LMS
+ *     security:
+ *       - SessionCookie: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - lessonId
+ *             properties:
+ *               lessonId:
+ *                 type: string
+ *               completed:
+ *                 type: boolean
+ *               timeSpent:
+ *                 type: number
+ *                 description: Time spent in minutes
+ *     responses:
+ *       200:
+ *         description: Progress updated. courseProgress includes completed/total lesson counts, percentage, isComplete, and pendingAssignments (count and titles) when assignments still need grading.
+ *       201:
+ *         description: Progress tracking started
+ *       400:
+ *         description: Missing lessonId
+ *       403:
+ *         description: Not enrolled in the course
+ *       404:
+ *         description: Lesson not found
  */
 export default requireAuth(async (req: AuthenticatedRequest, res: NextApiResponse) => {
     const userId = req.user?.id;
@@ -234,8 +276,32 @@ export default requireAuth(async (req: AuthenticatedRequest, res: NextApiRespons
         const progressPercentage =
             totalLessons > 0 ? Math.round((completedLessons / totalLessons) * 100) : 0;
 
-        // Check if course is complete
-        const isComplete = progressPercentage === 100;
+        // All lessons done — but completion also requires every course assignment
+        // to have a GRADED submission from this user
+        const lessonsComplete = progressPercentage === 100;
+
+        let pendingAssignments: { id: string; title: string }[] = [];
+
+        if (lessonsComplete) {
+            const assignments = await prisma.assignment.findMany({
+                where: { courseId },
+                select: {
+                    id: true,
+                    title: true,
+                    submissions: {
+                        where: { userId, status: "GRADED" },
+                        select: { id: true },
+                    },
+                },
+            });
+
+            pendingAssignments = assignments
+                .filter((assignment) => assignment.submissions.length === 0)
+                .map((assignment) => ({ id: assignment.id, title: assignment.title }));
+        }
+
+        // Check if course is complete (lessons + graded assignments)
+        const isComplete = lessonsComplete && pendingAssignments.length === 0;
 
         // Update enrollment with progress and completion status
         await prisma.enrollment.updateMany({
@@ -372,6 +438,12 @@ export default requireAuth(async (req: AuthenticatedRequest, res: NextApiRespons
                 total: totalLessons,
                 percentage: progressPercentage,
                 isComplete,
+                ...(pendingAssignments.length > 0 && {
+                    pendingAssignments: {
+                        count: pendingAssignments.length,
+                        titles: pendingAssignments.map((assignment) => assignment.title),
+                    },
+                }),
             },
             ...(certificateGenerated && {
                 certificate: {


### PR DESCRIPTION
## Problem

`POST /api/lms/progress` computed course completion from lesson progress alone (`completedLessons / totalLessons`). At 100% it marked the enrollment `COMPLETED` and auto-generated + emailed a verifiable certificate without ever consulting the `Assignment`/`Submission` models — a learner could earn a certificate without submitting any graded work.

## Solution

- When lesson progress reaches 100%, the route now fetches all assignments for the course along with the user's `GRADED` submissions (one query via a filtered `submissions` relation select). All assignments of a course are treated as required.
- The `COMPLETED` enrollment transition and the certificate generation/email path only run when every assignment has a `GRADED` submission. Courses with zero assignments keep current behavior.
- Lesson `progressPercentage` (the progress bar value) is unchanged; only the completion transition gains the gate.
- Outstanding requirements are surfaced in the response as `courseProgress.pendingAssignments` (`count` + `titles`) so the UI can display what remains.
- Added an `@swagger` block for the route (it previously had only a plain JSDoc comment).

## Verification

- `npx vitest run __tests__/pages/api/lms/progress.test.ts` — 5 new tests pass: ungraded assignment blocks completion/certificate, non-GRADED submission blocks, all-GRADED completes and issues certificate, zero-assignment course keeps current behavior, below-100% lessons never query assignments.
- `npm test` — 42 files / 389 tests pass.
- `npm run typecheck` — 7 pre-existing errors in unrelated `__tests__/pages/api/j0di3/*` files; identical count on clean master, zero introduced by this change.
- `npm run lint` — 20 pre-existing findings, identical count on clean master; both changed files are clean apart from pre-existing `any` annotations in untouched route code.
- `npm run build` — compiles; `/api/lms/progress` builds and the generated swagger spec picks up the new annotation (regenerated `public/swagger-spec.json` not committed, matching existing practice).

## Follow-up

- No existing frontend component consumes the `POST /api/lms/progress` response (`courseProgress` is referenced nowhere outside the route), so no UI wiring was done; `pendingAssignments` is ready for whichever component adopts it.
- Grading an assignment (submissions flow) does not re-trigger this route, so a learner who finishes lessons before grading completes will flip to `COMPLETED` on their next progress update rather than at grading time. Worth a separate issue if certificates should issue immediately upon final grading.

Closes #1149