### PR TITLE
feat(header): Add auth-aware user menu with logout

### DIFF
--- a/__tests__/components/user-menu.test.tsx
+++ b/__tests__/components/user-menu.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { signOut, useSession } from "next-auth/react";
+import UserMenu from "@/components/user-menu";
+
+vi.mock("next-auth/react", () => ({
+    useSession: vi.fn(),
+    signOut: vi.fn(),
+}));
+
+vi.mock("next/image", () => ({
+    default: ({
+        alt,
+        src,
+        width,
+        height,
+        className,
+    }: {
+        alt: string;
+        src: string;
+        width: number;
+        height: number;
+        className?: string;
+    }) => <img alt={alt} src={src} width={width} height={height} className={className} />,
+}));
+
+const mockUseSession = vi.mocked(useSession);
+const mockSignOut = vi.mocked(signOut);
+
+const authenticatedSession = {
+    data: {
+        user: {
+            id: "user-123",
+            name: "Jody Vet",
+            email: "jody@example.com",
+            image: "https://avatars.githubusercontent.com/u/1?v=4",
+        },
+        expires: "2099-01-01T00:00:00.000Z",
+    },
+    status: "authenticated",
+    update: vi.fn(),
+} as unknown as ReturnType<typeof useSession>;
+
+describe("UserMenu", () => {
+    beforeEach(() => {
+        mockUseSession.mockReset();
+        mockSignOut.mockReset();
+    });
+
+    it("shows a skeleton while the session is loading, without a sign-in link", () => {
+        mockUseSession.mockReturnValue({
+            data: null,
+            status: "loading",
+            update: vi.fn(),
+        } as unknown as ReturnType<typeof useSession>);
+
+        render(<UserMenu />);
+
+        expect(screen.getByTestId("user-menu-skeleton")).toBeInTheDocument();
+        expect(screen.queryByText("Sign in")).not.toBeInTheDocument();
+    });
+
+    it("shows a sign-in link to /login when unauthenticated", () => {
+        mockUseSession.mockReturnValue({
+            data: null,
+            status: "unauthenticated",
+            update: vi.fn(),
+        } as unknown as ReturnType<typeof useSession>);
+
+        render(<UserMenu />);
+
+        const link = screen.getByRole("link", { name: "Sign in" });
+        expect(link).toHaveAttribute("href", "/login");
+        expect(screen.queryByTestId("user-menu-skeleton")).not.toBeInTheDocument();
+    });
+
+    it("shows the avatar and opens a dropdown with profile link and logout", () => {
+        mockUseSession.mockReturnValue(authenticatedSession);
+
+        render(<UserMenu />);
+
+        expect(screen.getByAltText("Jody Vet avatar")).toBeInTheDocument();
+        expect(screen.queryByText("Logout")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /open user menu/i }));
+
+        expect(screen.getByRole("link", { name: "Profile" })).toHaveAttribute(
+            "href",
+            "/profile/user-123"
+        );
+        expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();
+    });
+
+    it("calls signOut with /login callback when logout is clicked", async () => {
+        mockUseSession.mockReturnValue(authenticatedSession);
+        mockSignOut.mockResolvedValue(undefined as never);
+
+        render(<UserMenu />);
+
+        fireEvent.click(screen.getByRole("button", { name: /open user menu/i }));
+        fireEvent.click(screen.getByRole("button", { name: "Logout" }));
+
+        await waitFor(() => {
+            expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/login" });
+        });
+    });
+
+    it("alerts the user when signOut fails", async () => {
+        mockUseSession.mockReturnValue(authenticatedSession);
+        mockSignOut.mockRejectedValue(new Error("network down"));
+        const alertMock = vi.fn();
+        vi.stubGlobal("alert", alertMock);
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        render(<UserMenu />);
+
+        fireEvent.click(screen.getByRole("button", { name: /open user menu/i }));
+        fireEvent.click(screen.getByRole("button", { name: "Logout" }));
+
+        await waitFor(() => {
+            expect(alertMock).toHaveBeenCalledWith(expect.stringContaining("Logout failed"));
+        });
+
+        vi.unstubAllGlobals();
+        errorSpy.mockRestore();
+    });
+});

--- a/src/components/user-menu/index.tsx
+++ b/src/components/user-menu/index.tsx
@@ -1,0 +1,113 @@
+import Anchor from "@ui/anchor";
+import Image from "next/image";
+import { signOut, useSession } from "next-auth/react";
+import { useEffect, useRef, useState } from "react";
+
+const UserMenu = () => {
+    const { data: session, status } = useSession();
+    const [open, setOpen] = useState(false);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!open) return undefined;
+        const handleMouseDown = (e: MouseEvent) => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+            }
+        };
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setOpen(false);
+        };
+        document.addEventListener("mousedown", handleMouseDown);
+        document.addEventListener("keydown", handleKeyDown);
+        return () => {
+            document.removeEventListener("mousedown", handleMouseDown);
+            document.removeEventListener("keydown", handleKeyDown);
+        };
+    }, [open]);
+
+    const handleLogout = async () => {
+        try {
+            await signOut({ callbackUrl: "/login" });
+        } catch (error) {
+            console.error("[UserMenu] signOut failed:", error);
+            window.alert(
+                "Logout failed. Please try again, or clear your browser cookies for this site."
+            );
+        }
+    };
+
+    if (status === "loading") {
+        return (
+            <span
+                data-testid="user-menu-skeleton"
+                aria-hidden="true"
+                className="tw-block tw-h-9 tw-w-9 tw-animate-pulse tw-rounded-full tw-bg-gray-200"
+            />
+        );
+    }
+
+    if (!session?.user) {
+        return (
+            <Anchor
+                path="/login"
+                className="tw-whitespace-nowrap tw-text-sm tw-font-medium tw-text-secondary hover:tw-text-primary"
+            >
+                Sign in
+            </Anchor>
+        );
+    }
+
+    const { user } = session;
+    const displayName = user.name || user.email || "Account";
+
+    return (
+        <div ref={containerRef} className="tw-relative">
+            <button
+                type="button"
+                aria-haspopup="true"
+                aria-expanded={open}
+                aria-label="Open user menu"
+                onClick={() => setOpen((prev) => !prev)}
+                className="tw-flex tw-items-center tw-gap-2"
+            >
+                {user.image ? (
+                    <Image
+                        src={user.image}
+                        alt={`${displayName} avatar`}
+                        width={36}
+                        height={36}
+                        className="tw-rounded-full tw-border tw-border-gray-200"
+                    />
+                ) : (
+                    <span className="tw-flex tw-h-9 tw-w-9 tw-items-center tw-justify-center tw-rounded-full tw-bg-navy tw-text-sm tw-font-semibold tw-text-white">
+                        {displayName.charAt(0).toUpperCase()}
+                    </span>
+                )}
+                <span className="tw-hidden tw-max-w-[120px] tw-truncate tw-text-sm tw-font-medium tw-text-secondary lg:tw-block">
+                    {displayName}
+                </span>
+            </button>
+            {open && (
+                <div className="tw-absolute tw-right-0 tw-top-full tw-z-[60] tw-mt-2 tw-w-44 tw-rounded-md tw-border tw-border-gray-200 tw-bg-white tw-py-1 tw-shadow-lg">
+                    <Anchor
+                        path={`/profile/${user.id}`}
+                        className="tw-block tw-px-4 tw-py-2 tw-text-sm tw-text-secondary hover:tw-bg-gray-50"
+                        onClick={() => setOpen(false)}
+                    >
+                        Profile
+                    </Anchor>
+                    <button
+                        type="button"
+                        onClick={handleLogout}
+                        className="tw-block tw-w-full tw-px-4 tw-py-2 tw-text-left tw-text-sm tw-text-red hover:tw-bg-gray-50"
+                    >
+                        Logout
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default UserMenu;

--- a/src/layouts/headers/header-02.tsx
+++ b/src/layouts/headers/header-02.tsx
@@ -1,5 +1,6 @@
 import Logo from "@components/logo";
 import MainMenu from "@components/menu/main-menu";
+import UserMenu from "@components/user-menu";
 import menu, { filterMenuByAuth } from "@data/menu";
 import { useSticky } from "@hooks";
 import BurgerButton from "@ui/burger-button";
@@ -57,7 +58,8 @@ const Header = ({ shadow, fluid }: TProps) => {
                             className="tw-hidden xl:tw-block"
                         />
                         <Logo variant="dark" className="tw-max-w-[120px] sm:tw-max-w-[158px]" />
-                        <div className="tw-flex tw-items-center tw-justify-end">
+                        <div className="tw-flex tw-items-center tw-justify-end tw-gap-4">
+                            <UserMenu />
                             <BurgerButton
                                 className="tw-pl-5 xl:tw-hidden"
                                 color="dark"

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -1,6 +1,7 @@
 import Logo from "@components/logo";
 import MainMenu from "@components/menu/main-menu";
 import Social01 from "@components/socials/social-01";
+import UserMenu from "@components/user-menu";
 import menu, { filterMenuByAuth } from "@data/menu";
 import { useSticky } from "@hooks";
 import BurgerButton from "@ui/burger-button";
@@ -112,6 +113,7 @@ const Header = ({ shadow, fluid }: TProps) => {
                                     </span>
                                 </div>
                                 <Social01 className="tw-hidden md:tw-flex md:tw-items-center" />
+                                <UserMenu />
                                 <BurgerButton
                                     className="tw-pl-2 xl:tw-hidden"
                                     color="dark"


### PR DESCRIPTION
## Problem

Logout only exists on the profile page (`src/pages/profile/[id].tsx`). There is no global, auth-aware entry point in the header: no way to sign out from anywhere on the site, no visible session state, and no quick path to your profile.

## Solution

- New `src/components/user-menu/index.tsx` driven by `useSession()`:
  - **Loading** — small pulsing skeleton, so no "Sign in" link flashes before the avatar resolves.
  - **Authenticated** — avatar (GitHub image with initial-letter fallback) + name button that toggles a dropdown containing a Profile link (`/profile/<session.user.id>`, matching how the profile page resolves ownership) and a Logout button. Dropdown closes on outside click and Escape; trigger has `aria-expanded`/`aria-haspopup` and an explicit `type="button"`.
  - **Unauthenticated** — "Sign in" link to `/login`.
- Logout calls `signOut({ callbackUrl: "/login" })` in try/catch; on failure it logs and alerts the user (same pattern as the profile page) rather than failing silently.
- Mounted in both header variants used by production layouts: `src/layouts/headers/header.tsx` (layout-01, layout-03) and `src/layouts/headers/header-02.tsx` (layout-02). `header-01.tsx` is unreferenced and was left untouched. The menu sits in the always-visible header action area at every breakpoint, so mobile is covered without editing the offcanvas menu.
- Tests in `__tests__/components/user-menu.test.tsx` mock `next-auth/react`: skeleton (and no sign-in flash) while loading, sign-in link when unauthenticated, avatar + dropdown + `signOut` call with `/login` callback when authenticated, and alert on `signOut` rejection.

## Verification

- `npm run typecheck` — no errors in changed files; the 7 reported errors are pre-existing in `__tests__/{pages/api,lib}/j0di3/*` (verified identical count on clean master).
- `npm run lint` — changed files have 0 errors, 1 `noAlert` warning (matches existing profile-page logout pattern); the 25 repo errors are pre-existing in untouched files.
- `npm test` — 42 files, 389 tests passed (includes 5 new user-menu tests).
- `npm run build` — succeeds; only pre-existing page-data-size warnings.

Closes #1054