### PR TITLE
feat(career-guides): Add Marine Corps MOS 6333 Aviation Electronics Tech

### DIFF
--- a/__tests__/lib/career-guides.test.ts
+++ b/__tests__/lib/career-guides.test.ts
@@ -1,0 +1,37 @@
+import { loadCareerGuides } from "@/lib/career-guides";
+
+describe("career-guides", () => {
+    describe("loadCareerGuides", () => {
+        const guides = loadCareerGuides();
+
+        it("yields two distinct 6333 entries, one per branch", () => {
+            const entries = guides.filter((g) => g.code === "6333");
+            expect(entries).toHaveLength(2);
+
+            const navy = entries.find((g) => g.branch === "Navy");
+            expect(navy?.title).toBe("Aviation Maintenance Officer");
+            expect(navy?.slug).toBe("6333");
+            expect(navy?.rank).toBe("Officer");
+
+            const marine = entries.find((g) => g.branch === "Marine Corps");
+            expect(marine?.title).toBe("Aviation Electronics Technician");
+            expect(marine?.slug).toBe("marine_corps:6333");
+            expect(marine?.rank).toBe("Enlisted");
+        });
+
+        it("resolves branch-prefixed pathway data before the bare code", () => {
+            const navy = guides.find((g) => g.code === "6333" && g.branch === "Navy");
+            const marine = guides.find((g) => g.code === "6333" && g.branch === "Marine Corps");
+
+            // Navy officer entry keeps the management-flavored bare "6333" pathways
+            expect(navy?.civilian).toBe("Aircraft Maintenance Manager");
+            // Marine technician entry resolves its own "marine_corps:6333" pathways
+            expect(marine?.civilian).toBe("Avionics Technician");
+        });
+
+        it("gives every guide a unique slug", () => {
+            const slugs = guides.map((g) => g.slug);
+            expect(new Set(slugs).size).toBe(slugs.length);
+        });
+    });
+});

--- a/src/containers/career-guides/grid-view.tsx
+++ b/src/containers/career-guides/grid-view.tsx
@@ -14,7 +14,7 @@ const GuideCard = ({ g }: { g: GuideEntry }) => {
 
     return (
         <Link
-            href={`/career-guides/${g.code.toLowerCase()}`}
+            href={`/career-guides/${g.slug}`}
             className={clsx(
                 "tw-group tw-relative tw-flex tw-flex-col tw-gap-5 tw-border-t tw-border-l tw-border-cream/10 tw-bg-secondary tw-p-6 tw-transition-colors tw-duration-150",
                 "hover:tw-border-accent hover:tw-bg-[#003559]"

--- a/src/containers/career-guides/types.ts
+++ b/src/containers/career-guides/types.ts
@@ -21,6 +21,8 @@ export type Family =
 
 export interface GuideEntry {
     code: string;
+    /** Full training-pipeline key (lowercased); unique even when codes collide across branches */
+    slug: string;
     title: string;
     branch: Branch;
     rank: Rank;

--- a/src/data/training-pipeline.json
+++ b/src/data/training-pipeline.json
@@ -12424,6 +12424,29 @@
         "civilian_certs": [],
         "ace_credits": "Up to 3 semester hours in management"
     },
+    "marine_corps:6333": {
+        "branch": "Marine Corps",
+        "title": "Aviation Electronics Technician",
+        "program": "Aviation Electronics Technician Course, Center for Naval Aviation Technical Training (CNATT), NAS Pensacola, FL",
+        "hours": 960,
+        "weeks": 24,
+        "topics": [
+            "Basic Electricity and Electronics Theory",
+            "Aircraft Electrical Systems",
+            "Avionics Troubleshooting and Fault Isolation",
+            "Wiring Schematics and MIL-SPEC Standards",
+            "Electronic Test Equipment Operation (Multimeters, Oscilloscopes, Avionics Test Sets)",
+            "Aircraft Communication and Navigation Systems Maintenance",
+            "Technical Documentation and Procedures",
+            "Safety Procedures for Avionics Maintenance"
+        ],
+        "civilian_certs": [
+            "FCC General Radiotelephone Operator License (partial)",
+            "CompTIA A+ (partial)",
+            "ETA-I Certified Electronics Technician (CET) Associate (partial)"
+        ],
+        "ace_credits": "Up to 15 semester hours recommended in avionics technology or electronics engineering technology."
+    },
     "6335": {
         "branch": "Navy",
         "title": "Aviation Maintenance Management Officer",

--- a/src/lib/career-guides.ts
+++ b/src/lib/career-guides.ts
@@ -131,8 +131,8 @@ export const loadCareerGuides = (): GuideEntry[] => {
         const family = detectFamily(entry.title);
         const certs = entry.civilian_certs ?? [];
 
-        // Pathway lookup: try raw code first, then full key
-        const matches = pathways[code] ?? pathways[stripBranchPrefix(key)] ?? [];
+        // Pathway lookup: exact full key first (branch-prefixed entries), then bare code
+        const matches = pathways[key] ?? pathways[code] ?? pathways[stripBranchPrefix(key)] ?? [];
         const top = matches[0];
         const civilian = top?.role ?? entry.title;
         const salaries = matches.map((m) => m.avgSalary).filter((s) => typeof s === "number");
@@ -142,6 +142,7 @@ export const loadCareerGuides = (): GuideEntry[] => {
 
         guides.push({
             code,
+            slug: key.toLowerCase(),
             title: entry.title,
             branch,
             rank,

--- a/src/pages/career-guides/[mos].tsx
+++ b/src/pages/career-guides/[mos].tsx
@@ -146,6 +146,11 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     const training = trainingMap[mosCode];
     if (!training) return { notFound: true };
 
+    // Branch-prefixed keys (e.g. "marine_corps:6333") disambiguate code collisions
+    // across branches; display only the bare code.
+    const colonIdx = mosCode.indexOf(":");
+    const displayCode = colonIdx === -1 ? mosCode : mosCode.slice(colonIdx + 1);
+
     const techBundle = techPathwaysMap[mosCode];
     const techPathway: TechPathway | null = techBundle
         ? {
@@ -171,7 +176,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         : null;
 
     const detail = buildDetail({
-        code: mosCode,
+        code: displayCode,
         training,
         certs: certsMap[mosCode] || {
             direct_qualifies: [],


### PR DESCRIPTION
## Problem

Marine Corps MOS 6333 (Aviation Electronics Technician) was missing from the Career Guide. The `training-pipeline.json` key `"6333"` is occupied by the Navy officer designator 6333 (Aviation Maintenance Officer), so the Marine MOS could not be added under its bare code. The resume-translator data (`job-codes-index.json`, `job-codes-descriptions.json`) already covers both branches; the gap was Career Guide data only. Closes #1124.

## Solution

- **`src/data/training-pipeline.json`** — added `"marine_corps:6333"` (Marine Corps, Aviation Electronics Technician, CNATT NAS Pensacola program, avionics/electrical topics incl. fault isolation, wiring schematics, MIL-SPEC standards, test equipment), modeled on the existing Marine avionics entry `"6316"`. `loadCareerGuides()` already strips branch prefixes from keys, so this yields a second 6333 guide entry with the correct branch.
- **`src/data/career-pathways-map.json`** — the existing bare `"6333"` pathways entry is officer/management flavored (Aircraft Maintenance Manager, QA Specialist, Logistics Manager), so a shared entry would misrepresent the technician MOS. Added `"marine_corps:6333"` with technician-flavored roles: Avionics Technician plus the software-adjacent targets named in the issue (Junior Software Engineer, Software Developer in Test, Systems Software Developer, DevOps Engineer).
- **`src/lib/career-guides.ts`** — pathway lookup now prefers the exact full key before the bare code (`pathways[key] ?? pathways[code] ?? ...`), so each 6333 entry resolves its own pathway data. Each guide also gets a `slug` (full training key, lowercased) since `code` is no longer unique.
- **`src/containers/career-guides/{types.ts,grid-view.tsx}`** — `GuideEntry.slug` added; guide cards link by slug, so the two 6333 cards lead to distinct detail pages.
- **`src/pages/career-guides/[mos].tsx`** — the detail route already resolves branch-prefixed keys via its existing key-matching fallback (`/career-guides/marine_corps:6333` → Marine guide; `/career-guides/6333` deterministically remains the Navy entry, the only bare-key match). Added a strip of the branch prefix for the displayed code so the page shows `6333`, not `MARINE_CORPS:6333`.
- **`__tests__/lib/career-guides.test.ts`** — new tests: two 6333 entries with correct branch/title/rank/slug, each resolving its own pathway data (Navy → Aircraft Maintenance Manager, Marine → Avionics Technician), and slug uniqueness across all guides.

Both edited JSON files were inserted textually next to their sibling entries and re-validated with `node` (`JSON.parse` via `require`).

## Limitations

- The Marine detail page lives at `/career-guides/marine_corps:6333`. Its JSON-LD `url` field is derived from the bare display code and therefore points at `/career-guides/6333`; threading the slug into the page component for structured data was left out to keep the change minimal.
- `cert-equivalencies.json`, `military-systems-map.json`, `cognitive-skills-map.json`, and `tech-pathways-map.json` have no `marine_corps:6333` entries, so those detail-page sections fall back to their existing empty defaults. They can be backfilled by the `generate:*` scripts later.

## Verification

- `npm run typecheck` — 7 pre-existing errors in `__tests__/{lib,pages/api}/j0di3/*` (verified identical count on clean master via stash); no new errors.
- `npm run lint` — 25 errors / 491 warnings, all pre-existing in untouched files; `npx biome check` on the changed files reports 0 errors (1 pre-existing complexity warning on `detectRank`, untouched by this PR).
- `npm test` — 42 files, 387 tests, all pass (includes 3 new tests).
- `npm run build` — succeeds (swagger spec, Next build, sitemap).