### PR TITLE
fix(j0di3): Validate troopId format before proxying

### DIFF
--- a/__tests__/lib/j0di3/j0di3-proxy.test.ts
+++ b/__tests__/lib/j0di3/j0di3-proxy.test.ts
@@ -20,7 +20,7 @@ import j0di3 from "@/lib/j0di3-client";
 import { j0di3Proxy } from "@/lib/j0di3-proxy";
 
 const mockJ0di3 = j0di3 as unknown as Mock;
-const mockIsAxiosError = axios.isAxiosError as Mock;
+const mockIsAxiosError = axios.isAxiosError as unknown as Mock;
 
 function createMockReqRes(overrides: Partial<NextApiRequest> = {}): {
     req: NextApiRequest;
@@ -35,7 +35,7 @@ function createMockReqRes(overrides: Partial<NextApiRequest> = {}): {
             name: "Test",
             email: "test@test.com",
             role: "STUDENT",
-            troopId: "troop-uuid-123",
+            troopId: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
             troopToken: "troop-token-abc",
         },
         ...overrides,
@@ -62,7 +62,7 @@ describe("j0di3Proxy", () => {
         expect(mockJ0di3).toHaveBeenCalledWith({
             method: "POST",
             url: "/api/v1/learning/explain",
-            data: { question: "What is React?", troop_id: "troop-uuid-123" },
+            data: { question: "What is React?", troop_id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301" },
             params: undefined,
             headers: { "X-Troop-Token": "troop-token-abc" },
         });
@@ -81,7 +81,7 @@ describe("j0di3Proxy", () => {
             method: "GET",
             url: "/api/v1/challenges/recommended",
             data: undefined,
-            params: expect.objectContaining({ troop_id: "troop-uuid-123" }),
+            params: expect.objectContaining({ troop_id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301" }),
             headers: { "X-Troop-Token": "troop-token-abc" },
         });
     });
@@ -151,6 +151,38 @@ describe("j0di3Proxy", () => {
         expect(res.json).toHaveBeenCalledWith(
             expect.objectContaining({ error: expect.stringContaining("No J0dI3 troop profile") })
         );
+    });
+
+    it("returns 400 without calling upstream when troopId is malformed", async () => {
+        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const handler = j0di3Proxy("POST", "/api/v1/learning/explain");
+        const { req, res } = createMockReqRes();
+        (req as any).user.troopId = "not-a-uuid";
+
+        await handler(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.json).toHaveBeenCalledWith({
+            error: "Invalid troop profile. Please sign out and sign back in.",
+        });
+        expect(mockJ0di3).not.toHaveBeenCalled();
+        consoleSpy.mockRestore();
+    });
+
+    it("logs the rejected troopId redacted, never the full value", async () => {
+        const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        const handler = j0di3Proxy("POST", "/api/v1/learning/explain");
+        const { req, res } = createMockReqRes();
+        (req as any).user.troopId = "bogus-troop-id-value";
+
+        await handler(req, res);
+
+        expect(consoleSpy).toHaveBeenCalledTimes(1);
+        const logged = String(consoleSpy.mock.calls[0][0]);
+        expect(logged).toContain("bogu");
+        expect(logged).toContain("length 20");
+        expect(logged).not.toContain("bogus-troop-id-value");
+        consoleSpy.mockRestore();
     });
 
     it("returns 400 when user has troopId but no troopToken", async () => {

--- a/__tests__/pages/api/j0di3/challenges.test.ts
+++ b/__tests__/pages/api/j0di3/challenges.test.ts
@@ -1,18 +1,18 @@
 vi.mock("@/lib/j0di3-proxy", () => ({
-    j0di3Proxy: vi.fn((_method: string, _path: string | Function) => vi.fn()),
+    j0di3Proxy: vi.fn((_method: string, _path: string | ((req: unknown) => string)) => vi.fn()),
 }));
 
 vi.mock("@/lib/rbac", () => ({
     requireAuth: vi.fn((handler) => handler),
 }));
 
-import { j0di3Proxy } from "@/lib/j0di3-proxy";
-
 describe("J0dI3 Challenges API routes", () => {
     beforeEach(() => {
         vi.resetModules();
         vi.mock("@/lib/j0di3-proxy", () => ({
-            j0di3Proxy: vi.fn((_method: string, _path: string | Function) => vi.fn()),
+            j0di3Proxy: vi.fn((_method: string, _path: string | ((req: unknown) => string)) =>
+                vi.fn()
+            ),
         }));
     });
 

--- a/__tests__/pages/api/j0di3/coding.test.ts
+++ b/__tests__/pages/api/j0di3/coding.test.ts
@@ -1,8 +1,6 @@
 vi.mock("@/lib/j0di3-proxy", () => ({
-    j0di3Proxy: vi.fn((_method: string, _path: string | Function) => vi.fn()),
+    j0di3Proxy: vi.fn((_method: string, _path: string | ((req: unknown) => string)) => vi.fn()),
 }));
-
-import { j0di3Proxy } from "@/lib/j0di3-proxy";
 
 describe("J0dI3 Coding API routes", () => {
     const routes = [
@@ -10,7 +8,10 @@ describe("J0dI3 Coding API routes", () => {
         { module: "@/pages/api/j0di3/coding/refactor", endpoint: "/api/v1/coding/refactor" },
         { module: "@/pages/api/j0di3/coding/explain", endpoint: "/api/v1/coding/explain" },
         { module: "@/pages/api/j0di3/coding/generate", endpoint: "/api/v1/coding/generate" },
-        { module: "@/pages/api/j0di3/coding/architecture", endpoint: "/api/v1/coding/architecture" },
+        {
+            module: "@/pages/api/j0di3/coding/architecture",
+            endpoint: "/api/v1/coding/architecture",
+        },
     ];
 
     for (const { module, endpoint } of routes) {

--- a/__tests__/pages/api/j0di3/jobs.test.ts
+++ b/__tests__/pages/api/j0di3/jobs.test.ts
@@ -2,7 +2,9 @@ describe("J0dI3 Jobs API routes", () => {
     beforeEach(() => {
         vi.resetModules();
         vi.mock("@/lib/j0di3-proxy", () => ({
-            j0di3Proxy: vi.fn((_method: string, _path: string | Function) => vi.fn()),
+            j0di3Proxy: vi.fn((_method: string, _path: string | ((req: unknown) => string)) =>
+                vi.fn()
+            ),
         }));
     });
 
@@ -11,8 +13,14 @@ describe("J0dI3 Jobs API routes", () => {
         { module: "@/pages/api/j0di3/jobs/resume/tailor", endpoint: "/api/v1/jobs/resume/tailor" },
         { module: "@/pages/api/j0di3/jobs/match", endpoint: "/api/v1/jobs/match" },
         { module: "@/pages/api/j0di3/jobs/apply-coach", endpoint: "/api/v1/jobs/apply-coach" },
-        { module: "@/pages/api/j0di3/jobs/interview/start", endpoint: "/api/v1/jobs/interview/start" },
-        { module: "@/pages/api/j0di3/jobs/offer/evaluate", endpoint: "/api/v1/jobs/offer/evaluate" },
+        {
+            module: "@/pages/api/j0di3/jobs/interview/start",
+            endpoint: "/api/v1/jobs/interview/start",
+        },
+        {
+            module: "@/pages/api/j0di3/jobs/offer/evaluate",
+            endpoint: "/api/v1/jobs/offer/evaluate",
+        },
     ];
 
     for (const { module, endpoint } of postRoutes) {

--- a/__tests__/pages/api/j0di3/learning.test.ts
+++ b/__tests__/pages/api/j0di3/learning.test.ts
@@ -1,11 +1,6 @@
-import type { Mock } from "vitest";
-
 vi.mock("@/lib/j0di3-proxy", () => ({
-    j0di3Proxy: vi.fn((_method: string, _path: string | Function) => {
-        const handler = vi.fn();
-        handler._method = _method;
-        handler._path = _path;
-        return handler;
+    j0di3Proxy: vi.fn((_method: string, _path: string | ((req: unknown) => string)) => {
+        return Object.assign(vi.fn(), { _method, _path });
     }),
 }));
 

--- a/__tests__/pages/api/j0di3/troops.test.ts
+++ b/__tests__/pages/api/j0di3/troops.test.ts
@@ -18,8 +18,6 @@ vi.mock("axios", () => ({
     },
 }));
 
-import j0di3 from "@/lib/j0di3-client";
-
 function createRes() {
     return {
         status: vi.fn().mockReturnThis(),
@@ -108,7 +106,9 @@ describe("troops/dashboard API route", () => {
     it("wires to GET with dynamic troop path", async () => {
         vi.resetModules();
         vi.mock("@/lib/j0di3-proxy", () => ({
-            j0di3Proxy: vi.fn((_method: string, _path: string | Function) => vi.fn()),
+            j0di3Proxy: vi.fn((_method: string, _path: string | ((req: unknown) => string)) =>
+                vi.fn()
+            ),
         }));
         vi.mock("@/lib/rbac", () => ({
             requireAuth: vi.fn((h) => h),

--- a/src/lib/j0di3-proxy.ts
+++ b/src/lib/j0di3-proxy.ts
@@ -5,6 +5,10 @@ import { type AuthenticatedRequest, requireAuth, requireRole } from "@/lib/rbac"
 
 type Method = "GET" | "POST" | "PATCH" | "DELETE";
 
+// J0dI3 troop IDs are UUIDs (see prisma/schema.prisma User.troopId). Accept any
+// UUID version rather than over-restricting to v4.
+const TROOP_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 interface ProxyOptions {
     injectTroopId?: boolean;
 }
@@ -23,6 +27,16 @@ async function dispatch(
         return res
             .status(400)
             .json({ error: "No J0dI3 troop profile linked. Please sign out and back in." });
+    }
+
+    if (injectTroopId && troopId && !TROOP_ID_PATTERN.test(troopId)) {
+        // Log redacted so the origin of the bad value can be investigated.
+        console.warn(
+            `[j0di3-proxy] Rejected malformed troopId: ${troopId.slice(0, 4)}… (length ${troopId.length})`
+        );
+        return res
+            .status(400)
+            .json({ error: "Invalid troop profile. Please sign out and sign back in." });
     }
 
     if (injectTroopId && !troopToken) {


### PR DESCRIPTION
## Problem

`src/lib/j0di3-proxy.ts` only checked `if (!troopId)` before injecting the troop ID into upstream J0dI3 requests. A malformed `troopId` (stale session, botched migration) reached the external J0dI3 API and surfaced to users as an unhelpful 4xx/5xx.

## Solution

- Established the real format from evidence: `ensure-troop.ts` stores `data.id` from the J0dI3 registration response, and `prisma/schema.prisma` annotates `User.troopId` as "J0dI3 troop UUID". No evidence pins the version to v4, so the proxy validates against a generic UUID pattern (8-4-4-4-12 hex, any version) rather than over-restricting.
- On invalid format, `dispatch` returns `400 {"error": "Invalid troop profile. Please sign out and sign back in."}` before any upstream call.
- The rejected value is logged redacted via `console.warn` (first 4 chars + length, never the full value) so the origin can be investigated.
- Tests: valid UUID passes through to the upstream client (existing pass-through tests now use a real UUID fixture); malformed ID returns 400 without calling the upstream client; the log line contains the redacted prefix and length but never the full value.

The second commit fixes pre-existing typecheck and Biome errors in the j0di3 route tests (unused imports, property assignment onto a `Mock`, banned `Function` type in mock signatures) that failed verification on the master baseline. No test behavior changes.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — j0di3 area clean; 19 pre-existing errors remain in unrelated files (components, containers, scripts, pages) that also fail on master and are out of scope here
- `npm test` — 41 files, 386 tests passed
- `npm run build` — pass

Closes #1066