### PR TITLE
feat(lessons): Mount AI teaching assistant on lesson pages

### DIFF
--- a/__tests__/pages/lessons/lesson.test.tsx
+++ b/__tests__/pages/lessons/lesson.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+// Mock next/router
+vi.mock("next/router", () => ({
+    useRouter: () => ({ push: vi.fn(), query: { id: "lesson-1" } }),
+}));
+
+// Mock next-auth
+vi.mock("next-auth/next", () => ({
+    getServerSession: vi.fn(),
+}));
+
+// Mock auth options
+vi.mock("@/pages/api/auth/options", () => ({
+    options: {},
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// We test the component behavior, not getServerSideProps
+import LessonPage from "@/pages/lessons/lesson/[id]";
+
+function mockLessonFetch(explain?: (opts?: any) => Promise<any>) {
+    mockFetch.mockImplementation((url: string, opts?: any) => {
+        if (url === "/api/j0di3/lessons/lesson-1") {
+            return Promise.resolve({
+                ok: true,
+                json: () =>
+                    Promise.resolve({
+                        id: "lesson-1",
+                        title: "React Hooks",
+                        module: 3,
+                        content: "Hooks let you use state in function components.",
+                    }),
+            });
+        }
+        if (url === "/api/j0di3/learning/explain" && explain) {
+            return explain(opts);
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+}
+
+describe("LessonPage AI teaching assistant", () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+    });
+
+    it("renders the floating assistant button", async () => {
+        mockLessonFetch();
+
+        render(<LessonPage />);
+
+        await screen.findByText("Mark complete");
+        expect(screen.getByLabelText("Open AI teaching assistant")).toBeInTheDocument();
+        expect(screen.queryByText("J0d!e - AI Teaching Assistant")).not.toBeInTheDocument();
+    });
+
+    it("opens the assistant with lesson context when the button is clicked", async () => {
+        mockLessonFetch();
+
+        render(<LessonPage />);
+
+        await screen.findByText("Mark complete");
+        fireEvent.click(screen.getByLabelText("Open AI teaching assistant"));
+
+        expect(screen.getByText("J0d!e - AI Teaching Assistant")).toBeInTheDocument();
+        expect(screen.getByText(/Vets Who Code \/ Module 3 \/ React Hooks/)).toBeInTheDocument();
+    });
+
+    it("sends a question and renders the assistant response", async () => {
+        mockLessonFetch(() =>
+            Promise.resolve({
+                ok: true,
+                json: () => Promise.resolve({ response: "useState stores component state." }),
+            })
+        );
+
+        render(<LessonPage />);
+
+        await screen.findByText("Mark complete");
+        fireEvent.click(screen.getByLabelText("Open AI teaching assistant"));
+
+        const input = screen.getByPlaceholderText("Ask me anything...");
+        fireEvent.change(input, { target: { value: "What is useState?" } });
+        fireEvent.submit(input.closest("form")!);
+
+        await waitFor(() => {
+            expect(screen.getByText("useState stores component state.")).toBeInTheDocument();
+        });
+
+        const explainCall = mockFetch.mock.calls.find(
+            ([url]) => url === "/api/j0di3/learning/explain"
+        );
+        expect(explainCall).toBeDefined();
+        const body = JSON.parse(explainCall![1].body);
+        expect(body.concept).toBe("React Hooks");
+        expect(body.question).toBe("What is useState?");
+    });
+
+    it("renders an error when the assistant request fails", async () => {
+        mockLessonFetch(() =>
+            Promise.resolve({
+                ok: false,
+                json: () => Promise.resolve({ error: "Service unavailable" }),
+            })
+        );
+
+        render(<LessonPage />);
+
+        await screen.findByText("Mark complete");
+        fireEvent.click(screen.getByLabelText("Open AI teaching assistant"));
+
+        const input = screen.getByPlaceholderText("Ask me anything...");
+        fireEvent.change(input, { target: { value: "Help" } });
+        fireEvent.submit(input.closest("form")!);
+
+        await waitFor(() => {
+            expect(screen.getByText(/Service unavailable/)).toBeInTheDocument();
+        });
+    });
+});

--- a/src/pages/lessons/lesson/[id].tsx
+++ b/src/pages/lessons/lesson/[id].tsx
@@ -1,3 +1,4 @@
+import { AITeachingAssistant } from "@components/ai-assistant";
 import Breadcrumb from "@components/breadcrumb";
 import SEO from "@components/seo/page-seo";
 import Layout01 from "@layout/layout-01";
@@ -33,6 +34,7 @@ const LessonPage: PageWithLayout = () => {
     const [isLoading, setIsLoading] = useState(true);
     const [isCompleting, setIsCompleting] = useState(false);
     const [completed, setCompleted] = useState(false);
+    const [isAssistantOpen, setIsAssistantOpen] = useState(false);
 
     useEffect(() => {
         if (!id) return;
@@ -122,6 +124,32 @@ const LessonPage: PageWithLayout = () => {
                     </>
                 )}
             </div>
+
+            <button
+                type="button"
+                onClick={() => setIsAssistantOpen(true)}
+                className="tw-fixed tw-bottom-6 tw-right-6 tw-z-40 tw-rounded-full tw-bg-navy tw-px-5 tw-py-3 tw-font-medium tw-text-white tw-shadow-lg tw-transition-colors hover:tw-bg-navy-royal focus-visible:tw-ring-2 focus-visible:tw-ring-gold"
+                aria-label="Open AI teaching assistant"
+            >
+                Ask J0d!e
+            </button>
+
+            <AITeachingAssistant
+                isOpen={isAssistantOpen}
+                onClose={() => setIsAssistantOpen(false)}
+                lessonContext={
+                    lesson && id
+                        ? {
+                              lessonId: id,
+                              lessonTitle: lesson.title ?? "Lesson",
+                              moduleTitle:
+                                  lesson.module != null ? `Module ${lesson.module}` : "Curriculum",
+                              courseTitle: "Vets Who Code",
+                              content: body || undefined,
+                          }
+                        : undefined
+                }
+            />
         </>
     );
 };


### PR DESCRIPTION
## Problem

`src/components/ai-assistant/AITeachingAssistant.tsx` is a complete chat modal (message history, lesson-context awareness, feedback via `/api/j0di3/learning/feedback`, ESC-to-close) exported from `src/components/ai-assistant/index.ts`, but it had zero imports anywhere — students had no way to reach it. The backend `/api/j0di3/learning/explain` proxy is live and already used elsewhere.

## Solution

- Mounted `AITeachingAssistant` on the lesson page (`src/pages/lessons/lesson/[id].tsx`) with a floating "Ask J0d!e" button (fixed bottom-right, navy/gold brand tokens, `tw-` prefixed classes).
- The assistant receives the current lesson as context (`lessonId`, `lessonTitle`, `Module N`, course title, lesson body) once the lesson loads; it still opens without context while loading.
- Verified the endpoints the component calls exist: `src/pages/api/j0di3/learning/explain.ts` and `src/pages/api/j0di3/learning/feedback.ts` (both `j0di3Proxy` routes).
- Added a smoke test (`__tests__/pages/lessons/lesson.test.tsx`, mocked fetch/router/next-auth): floating button renders, opens the assistant with lesson context, sending a question renders a mocked response with the lesson title as `concept`, and the error state renders on API failure.

### Follow-ups (intentionally out of scope)

- Challenge page (`src/pages/challenges/[id].tsx`): not mounted — it already has a dedicated coach UI (`/api/j0di3/challenges/{id}/coach`) that sends the student's code as context; adding the generic assistant alongside would duplicate the chat UX without code awareness. Worth a separate design pass.
- Global Cmd+K / "A" shortcut affordance to open the assistant from anywhere.

## Verification

- `npm run typecheck` — 7 pre-existing errors in unrelated `__tests__/{lib,pages/api}/j0di3/*` files (present on master from #1026); no new errors from this change.
- `npm run lint` — 25 pre-existing errors, identical count on master; changed files lint clean (`npx biome lint` exits 0 on both).
- `npm test` — 42 files, 388 tests, all pass (includes the 4 new lesson-page tests).
- `npm run build` — succeeds; `/lessons/lesson/[id]` compiles.

Closes #1152