### PR TITLE
refactor(ai-provider): Replace any with explicit model types (#879)

### DIFF
--- a/src/lib/ai-provider.ts
+++ b/src/lib/ai-provider.ts
@@ -1,13 +1,14 @@
 import { createAzure } from "@ai-sdk/azure";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
 
 export type AIProvider = "gemini" | "azure" | "openai" | "phi3";
 
 interface ProviderConfig {
     name: AIProvider;
     model: string;
-    instance: any;
+    instance: LanguageModel;
 }
 
 /**
@@ -131,7 +132,7 @@ export function getPrimaryProvider(): ProviderConfig | null {
  * Attempts to use primary provider, falls back to others if unavailable
  */
 export async function getAIModelWithFallback(): Promise<{
-    model: any;
+    model: LanguageModel;
     provider: AIProvider;
     modelName: string;
 } | null> {
@@ -161,7 +162,7 @@ export async function getAIModelWithFallback(): Promise<{
  * If primary provider fails, tries next available provider
  */
 export async function tryProvidersWithFallback<T>(
-    operation: (model: any) => Promise<T>
+    operation: (model: LanguageModel) => Promise<T>
 ): Promise<{ result: T; provider: AIProvider } | null> {
     const providers = getAvailableProviders();
 


### PR DESCRIPTION
### Replace `any` with `LanguageModel` in the AI provider utility

Closes #879.

**What & why.** `src/lib/ai-provider.ts` used `any` in three places that all describe the same thing — the AI SDK model instance returned by `openai()` / `google()` / `azure()`. This PR types them with `LanguageModel` from the `ai` package (AI SDK v5), restoring compile-time safety and editor autocomplete with no runtime change.

**Changes.**
- `+ import type { LanguageModel } from "ai";`
- `ProviderConfig.instance: any` → `LanguageModel`
- `getAIModelWithFallback()` return `model: any` → `LanguageModel`
- `tryProvidersWithFallback()` `operation: (model: any) => …` → `(model: LanguageModel) => …`

**Note on the type.** The issue suggested `LanguageModel` from `@ai-sdk/provider`, but in the installed v5 that package exports `LanguageModelV2` and is only a transitive dependency. `ai` (a direct dependency) exports `LanguageModel = string | LanguageModelV2`, which the concrete model instances satisfy and which is the type the SDK's own APIs (e.g. `generateText`) consume — so I imported from `ai`.

**Testing.** Type-only change (annotation erased at compile time). `npm run typecheck` passes with no errors; `biome lint` is clean on the file.