### PR TITLE
fix(auth): Require GitHub org membership as the only login gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,14 +21,8 @@ GITHUB_PAT="your-github-personal-access-token"
 GITHUB_TOKEN="your-github-token"
 GITHUB_ORG="Vets-Who-Code"
 
-# Admin allowlist — comma-separated GitHub usernames that bypass org-membership
-# check on sign-in. Keep this list minimal (founders/external admins only).
-ADMIN_GITHUB_LOGINS=""
-
-# Dev-only escape hatch. Set to "true" ONLY when running locally with
-# NODE_ENV=development to allow any GitHub user to sign in. NEVER set in
-# production or preview deployments.
-ALLOW_ANY_GITHUB_USER="false"
+# Sign-in requires GitHub organization membership (GITHUB_ORG above) — there is
+# no allowlist or dev bypass. To grant someone access, add them to the org.
 
 # Google Maps API (for location features)
 NEXT_PUBLIC_GOOGLE_MAPS_KEY="your-google-maps-api-key"

--- a/src/pages/api/auth/options.ts
+++ b/src/pages/api/auth/options.ts
@@ -48,27 +48,9 @@ export const options: NextAuthOptions = {
                     return false;
                 }
 
-                // Dev-only escape hatch. Requires BOTH NODE_ENV=development AND
-                // explicit ALLOW_ANY_GITHUB_USER=true. Never set the flag in
-                // production or on preview deployments.
-                if (
-                    process.env.NODE_ENV === "development" &&
-                    process.env.ALLOW_ANY_GITHUB_USER === "true"
-                ) {
-                    return true;
-                }
-
-                // Configured admin allowlist bypasses org-membership check.
-                // Used for founders/external admins not on the org roster.
-                const adminLogins = (process.env.ADMIN_GITHUB_LOGINS || "")
-                    .split(",")
-                    .map((s) => s.trim().toLowerCase())
-                    .filter(Boolean);
-                if (adminLogins.includes(githubProfile.login.toLowerCase())) {
-                    return true;
-                }
-
-                // For all other users, check organization membership
+                // GitHub organization membership is the sole login gate — there are
+                // no allowlist or dev bypasses. Anyone who must sign in has to be a
+                // member of GITHUB_ORG (admins/founders included).
                 const githubOrg = process.env.GITHUB_ORG;
                 if (!githubOrg) {
                     console.error("[Auth] GITHUB_ORG env var is not set");


### PR DESCRIPTION
## What

Makes **GitHub organization membership the sole login gate.** Removes the two bypasses in the `signIn` callback:

- `ADMIN_GITHUB_LOGINS` — the allowlist that let configured usernames in **without** org membership.
- `ALLOW_ANY_GITHUB_USER` — the dev-only "let any GitHub user sign in" escape hatch.

After this, the only way to sign in is to be a member of `GITHUB_ORG` (`Vets-Who-Code`).

## ⚠️ Action required before merging/deploying

This can **lock people out**. Anyone who currently relies on `ADMIN_GITHUB_LOGINS` — founders, board members, or external admins who are **not** on the GitHub org roster — will lose access the moment this deploys.

**Before merging:** confirm every admin/founder/board member who needs to sign in is a member of the `Vets-Who-Code` GitHub org (add them if not). This is org membership only — they don't need write access to any repo.

Local development is also affected: with `ALLOW_ANY_GITHUB_USER` gone, testing authed flows locally now requires an org-member GitHub account.

## Scope

- `src/pages/api/auth/options.ts` — removed both bypass branches; org-membership check unchanged.
- `.env.example` — removed the two now-unused vars and noted the org-only policy.
- Confirmed neither env var is used anywhere else (no admin-*role* logic depends on them).

## Verification

- `npm run typecheck` — pass
- `__tests__/lib/auth-guards.test.ts` — 7/7 (route guards unaffected)
- No test asserted the removed bypass behavior.
