### PR TITLE
fix(header): Keep the nav menu on one line when signed in

### DIFF
--- a/src/components/menu/main-menu/index.tsx
+++ b/src/components/menu/main-menu/index.tsx
@@ -34,14 +34,16 @@ const MainMenu = ({ className, hoverStyle, menu, color, align }: TProps) => {
                 className
             )}
         >
-            <ul aria-label="Main Menu">
+            {/* nowrap keeps the nav on a single row — with a long (logged-in) menu it
+                would otherwise wrap; the header frees space by hiding secondary items. */}
+            <ul aria-label="Main Menu" className="tw-whitespace-nowrap">
                 {menu.map(({ id, label, path, submenu, megamenu }) => {
                     const hasSubmenu = !!submenu || !!megamenu;
                     return (
                         <li
                             key={id}
                             className={clsx(
-                                "tw-group tw-inline-block tw-px-2.5 tw-py-[29px] 2xl:tw-px-[15px]",
+                                "tw-group tw-inline-block tw-px-2 tw-py-[29px] 2xl:tw-px-[15px]",
                                 submenu && "tw-relative"
                             )}
                             role="none"

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -27,10 +27,8 @@ const Header = ({ shadow, fluid }: TProps) => {
     const [offcanvas, setOffcanvas] = useState(false);
     const { sticky, measuredRef } = useSticky();
     const { status } = useSession();
-    const filteredMenu = useMemo(
-        () => filterMenuByAuth(menu, status === "authenticated"),
-        [status]
-    );
+    const isAuthed = status === "authenticated";
+    const filteredMenu = useMemo(() => filterMenuByAuth(menu, isAuthed), [isAuthed]);
 
     useEffect(() => {
         setOffcanvas(false);
@@ -90,7 +88,15 @@ const Header = ({ shadow, fluid }: TProps) => {
                                 hoverStyle="B"
                             />
                             <div className="tw-flex tw-items-center tw-justify-end tw-gap-4 tw-shrink-0">
-                                <div className="tw-hidden lg:tw-flex tw-items-center tw-gap-2">
+                                <div
+                                    className={clsx(
+                                        "tw-hidden lg:tw-flex tw-items-center tw-gap-2",
+                                        // When signed in, the menu gains items and needs the room —
+                                        // drop this secondary indicator on desktop (the countdown in
+                                        // the top bar already conveys the active cohort).
+                                        isAuthed && "xl:tw-hidden"
+                                    )}
+                                >
                                     <span className="tw-relative tw-flex tw-h-[5px] tw-w-[5px]">
                                         <span
                                             className="tw-absolute tw-inline-flex tw-h-full tw-w-full tw-rounded-full tw-bg-red tw-opacity-75"
@@ -112,7 +118,14 @@ const Header = ({ shadow, fluid }: TProps) => {
                                         2026 Cohort Active
                                     </span>
                                 </div>
-                                <Social01 className="tw-hidden md:tw-flex md:tw-items-center" />
+                                <Social01
+                                    className={clsx(
+                                        "tw-hidden md:tw-flex md:tw-items-center",
+                                        // Signed-in desktop hides social here to fit the longer menu on
+                                        // one line; the footer still carries the social links.
+                                        isAuthed && "xl:tw-hidden"
+                                    )}
+                                />
                                 <UserMenu />
                                 <BurgerButton
                                     className="tw-pl-2 xl:tw-hidden"


### PR DESCRIPTION
## Problem

When signed in, the top nav wraps onto two rows. Signing in adds menu items (**My Cohort**, **Train**) and the user menu (avatar + name), which together widen the header past what fits — the menu needed ~300px more than the capped container allows, so its 9 items wrapped.

## Fix

- **Never wrap** the nav (`white-space: nowrap`) and slightly tighten item spacing.
- **On desktop, when signed in**, hide the two *secondary* right-side items — the "2026 Cohort Active" pill and the social icons — to free the room the longer menu needs.

Both hidden items still appear elsewhere: the cohort countdown is already in the top bar, and the social links are in the footer. **Logged-out and mobile/tablet headers are unchanged** (the hide is gated on `isAuthed` and the `xl` breakpoint).

## Verification

- Prototyped the exact change on the signed-in preview: 9 items collapse to a single row with ~135px to spare.
- Verified the logged-out header locally: 7 items on one line, social + cohort still shown, nothing broken.
- `npm run typecheck` — pass.

## Note

This touches the shared header (`main-menu`, `header`), so it affects every page. If you'd rather keep the social icons + cohort pill visible on desktop, the alternative is widening the header to full-width at large screens (trade-off: header no longer aligns with the centered page content) — say the word and I'll switch approaches.