### PR TITLE
fix(lms): Stop echoing the user object with troop token in responses

### DIFF
--- a/__tests__/pages/api/lms/no-user-echo.test.ts
+++ b/__tests__/pages/api/lms/no-user-echo.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Regression tests for issue #1196: LMS endpoints must not echo req.user —
+ * it carries the caller's troopToken (J0dI3 access credential).
+ */
+
+const AUTH_USER = {
+    id: "user-1",
+    name: "Test User",
+    email: "test@vetswhocode.io",
+    role: "ADMIN",
+    troopId: "troop-uuid",
+    troopToken: "SECRET-TROOP-TOKEN",
+};
+
+vi.mock("@/lib/rbac", () => ({
+    requireAuth:
+        (handler: (req: unknown, res: unknown) => Promise<void>) =>
+        (req: { user?: unknown }, res: unknown) => {
+            req.user = { ...AUTH_USER };
+            return handler(req, res);
+        },
+    requireRole:
+        () =>
+        (handler: (req: unknown, res: unknown) => Promise<void>) =>
+        (req: { user?: unknown }, res: unknown) => {
+            req.user = { ...AUTH_USER };
+            return handler(req, res);
+        },
+}));
+
+vi.mock("@/lib/prisma", () => ({
+    default: {
+        user: {
+            count: vi.fn().mockResolvedValue(1),
+            findUnique: vi
+                .fn()
+                .mockResolvedValue({
+                    id: "user-1",
+                    email: "t@t.io",
+                    name: "T",
+                    role: "ADMIN",
+                    cohort: null,
+                }),
+        },
+        course: { count: vi.fn().mockResolvedValue(0), findMany: vi.fn().mockResolvedValue([]) },
+        cohort: { count: vi.fn().mockResolvedValue(0) },
+    },
+}));
+
+function makeRes() {
+    const res: Record<string, unknown> = { body: undefined };
+    res.status = vi.fn(() => res);
+    res.json = vi.fn((payload: unknown) => {
+        res.body = payload;
+        return res;
+    });
+    res.setHeader = vi.fn();
+    return res as {
+        body: unknown;
+        status: ReturnType<typeof vi.fn>;
+        json: ReturnType<typeof vi.fn>;
+    };
+}
+
+const ROUTES = [
+    ["GET /api/lms/courses", "@/pages/api/lms/courses/index"],
+    ["GET /api/lms/test", "@/pages/api/lms/test"],
+    ["GET /api/lms/admin-only", "@/pages/api/lms/admin-only"],
+] as const;
+
+describe("LMS endpoints do not leak the troop token", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it.each(ROUTES)("%s response contains no troopToken", async (_label, modulePath) => {
+        const { default: handler } = await import(modulePath);
+        const res = makeRes();
+
+        await handler({ method: "GET", query: {}, headers: {} } as never, res as never);
+
+        expect(res.json).toHaveBeenCalled();
+        const serialized = JSON.stringify(res.body);
+        expect(serialized).not.toContain("SECRET-TROOP-TOKEN");
+        expect(serialized).not.toContain("troopToken");
+    });
+});

--- a/src/pages/api/lms/admin-only.ts
+++ b/src/pages/api/lms/admin-only.ts
@@ -14,7 +14,8 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
 
     res.status(200).json({
         message: "Success! You have admin access.",
-        user: req.user,
+        // Sanitized identity only — req.user carries the troop access token.
+        user: { id: req.user?.id, role: req.user?.role },
         timestamp: new Date().toISOString(),
     });
 }

--- a/src/pages/api/lms/courses/index.ts
+++ b/src/pages/api/lms/courses/index.ts
@@ -67,8 +67,8 @@ export default requireAuth(async (req: AuthenticatedRequest, res: NextApiRespons
             },
         }));
 
+        // Do not echo req.user — it carries the caller's troop access token.
         res.status(200).json({
-            user: req.user,
             courses: coursesWithStats,
             message: "Courses retrieved successfully",
         });

--- a/src/pages/api/lms/test.ts
+++ b/src/pages/api/lms/test.ts
@@ -44,7 +44,8 @@ async function handler(req: AuthenticatedRequest, res: NextApiResponse) {
             message: "LMS API test successful!",
             auth: {
                 authenticated: true,
-                user: req.user,
+                // Sanitized identity only — req.user carries the troop access token.
+                user: { id: req.user?.id, email: req.user?.email, role: req.user?.role },
                 fullUserDetails: currentUser,
             },
             database: {


### PR DESCRIPTION
## Problem

Three LMS endpoints — including the production `GET /api/lms/courses` — returned `req.user` in the response body. That object includes `troopToken`, the caller's J0dI3 access credential, so every course listing shipped a bearer credential to the browser.

## Fix

- `GET /api/lms/courses`: response echo removed entirely — the endpoint returns courses, not identity.
- `GET /api/lms/test` and `GET /api/lms/admin-only` (diagnostics whose point is proving auth/RBAC): return a sanitized `{ id, email, role }` / `{ id, role }` subset — never the token.

## Verification

- New regression tests (`__tests__/pages/api/lms/no-user-echo.test.ts`, 3 passing) drive each handler with an authenticated user carrying a sentinel token and assert the serialized response contains neither the token value nor a `troopToken` key.
- `npm run typecheck` — pass.

Closes #1196