### PR TITLE
fix(auth): Honor callbackUrl on login so deep links survive sign-in

### DIFF
--- a/__tests__/pages/login.test.tsx
+++ b/__tests__/pages/login.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { safeCallbackUrl } from "@/pages/login";
+
+/**
+ * Issue #1199: login must honor callbackUrl so deep links survive login,
+ * without opening a redirect hole.
+ */
+describe("safeCallbackUrl", () => {
+    it("honors a same-origin absolute path", () => {
+        expect(safeCallbackUrl("/learn/js-render-table-rows")).toBe("/learn/js-render-table-rows");
+        expect(safeCallbackUrl("/jobs?role=eng")).toBe("/jobs?role=eng");
+    });
+
+    it("defaults to /profile when absent or empty", () => {
+        expect(safeCallbackUrl(undefined)).toBe("/profile");
+        expect(safeCallbackUrl("")).toBe("/profile");
+    });
+
+    it("rejects open-redirect payloads", () => {
+        expect(safeCallbackUrl("//evil.com")).toBe("/profile");
+        expect(safeCallbackUrl("/\\evil.com")).toBe("/profile");
+        expect(safeCallbackUrl("https://evil.com")).toBe("/profile");
+        expect(safeCallbackUrl("http://evil.com")).toBe("/profile");
+        expect(safeCallbackUrl("javascript:alert(1)")).toBe("/profile");
+    });
+
+    it("uses the first value when the query param is repeated", () => {
+        expect(safeCallbackUrl(["/jobs", "//evil.com"])).toBe("/jobs");
+        expect(safeCallbackUrl(["//evil.com", "/jobs"])).toBe("/profile");
+    });
+});

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -18,6 +18,20 @@ type PageWithLayout = NextPage<LoginProps> & {
     Layout?: typeof Layout;
 };
 
+/**
+ * Resolve the post-login destination from a `callbackUrl` query param, guarding
+ * against open redirects: only a same-origin absolute path is honored, never a
+ * protocol-relative (`//evil.com`) or external URL. Defaults to `/profile`.
+ */
+export function safeCallbackUrl(raw: string | string[] | undefined): string {
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (typeof value !== "string" || value.length === 0) return "/profile";
+    if (!value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
+        return "/profile";
+    }
+    return value;
+}
+
 const Login: PageWithLayout = () => {
     const mounted = useMount();
     const { status, data: session } = useSession();
@@ -28,9 +42,10 @@ const Login: PageWithLayout = () => {
     useEffect(() => {
         if (status === "authenticated" && session && !isRedirecting) {
             setIsRedirecting(true);
-            router.replace("/profile").catch((error) => {
+            const destination = safeCallbackUrl(router.query.callbackUrl);
+            router.replace(destination).catch((error) => {
                 console.error("Redirect error:", error);
-                setErrorMessage("Failed to redirect to profile. Please try refreshing the page.");
+                setErrorMessage("Failed to redirect. Please try refreshing the page.");
                 setIsRedirecting(false);
             });
         }
@@ -114,7 +129,7 @@ const Login: PageWithLayout = () => {
 
     return (
         <div className="tw-fixed tw-top-0 tw-z-50 tw-flex tw-h-screen tw-w-screen tw-flex-col tw-items-center tw-justify-center tw-gap-4 tw-bg-white">
-            <span className="tw-text-secondary">{errorMessage || "Redirecting to profile..."}</span>
+            <span className="tw-text-secondary">{errorMessage || "Redirecting..."}</span>
             <Spinner />
         </div>
     );


### PR DESCRIPTION
## Problem

`login.tsx` always redirected to `/profile` after sign-in, ignoring `callbackUrl`. So a deep link that bounced through login (e.g. `requireAuthSSR` sending `/learn/[slug]` → `/login?callbackUrl=/learn/[slug]`) always landed the user on their profile instead of where they were headed.

## Fix

Redirect to the `callbackUrl` query param after authentication, via a `safeCallbackUrl` sanitizer that guards against open redirects — only same-origin absolute paths are honored (never `//evil.com`, `/\evil.com`, or external/`javascript:` URLs). Defaults to `/profile` when absent or unsafe.

## Verification

New tests (`__tests__/pages/login.test.tsx`, 4 passing) cover: honoring internal paths incl. query strings, defaulting when absent, rejecting every open-redirect payload, and repeated-query-param handling. `npm run typecheck` — pass.

Closes #1199