### PR TITLE
fix(certificates): Fix certificate-number generation race

### DIFF
--- a/__tests__/lib/certificates.test.ts
+++ b/__tests__/lib/certificates.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1195: certificate-number generation must not collide under concurrency.
+ * generateCertificateNumber is count-based; issueCertificateWithUniqueNumber must
+ * retry on the certificateNumber unique-constraint violation so concurrent
+ * issuance yields unique numbers and never crashes on the constraint.
+ */
+
+const certCount = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+    default: { certificate: { count: (...a: unknown[]) => certCount(...a) } },
+}));
+
+// Freeze the year so generated numbers are deterministic.
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T00:00:00Z"));
+});
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+function p2002(target: string[]) {
+    return Object.assign(new Error("Unique constraint failed"), {
+        code: "P2002",
+        meta: { target },
+    });
+}
+
+describe("issueCertificateWithUniqueNumber", () => {
+    it("retries with a fresh number when certificateNumber collides", async () => {
+        const { issueCertificateWithUniqueNumber } = await import("@/lib/certificates");
+        // count grows as if another issuance landed between attempts
+        certCount.mockResolvedValueOnce(4).mockResolvedValueOnce(5);
+        const numbersTried: string[] = [];
+        let calls = 0;
+
+        const result = await issueCertificateWithUniqueNumber(async (certificateNumber) => {
+            numbersTried.push(certificateNumber);
+            calls += 1;
+            if (calls === 1) throw p2002(["certificateNumber"]);
+            return { certificateNumber };
+        });
+
+        expect(calls).toBe(2);
+        expect(numbersTried).toEqual(["VWC-2026-000005", "VWC-2026-000006"]);
+        expect(result).toEqual({ certificateNumber: "VWC-2026-000006" });
+    });
+
+    it("succeeds on the first attempt with no collision", async () => {
+        const { issueCertificateWithUniqueNumber } = await import("@/lib/certificates");
+        certCount.mockResolvedValue(0);
+        const result = await issueCertificateWithUniqueNumber(async (n) => ({ n }));
+        expect(result).toEqual({ n: "VWC-2026-000001" });
+    });
+
+    it("does not retry on an unrelated unique violation (e.g. userId_courseId)", async () => {
+        const { issueCertificateWithUniqueNumber } = await import("@/lib/certificates");
+        certCount.mockResolvedValue(0);
+        let calls = 0;
+        await expect(
+            issueCertificateWithUniqueNumber(async () => {
+                calls += 1;
+                throw p2002(["userId", "courseId"]);
+            })
+        ).rejects.toMatchObject({ code: "P2002" });
+        expect(calls).toBe(1);
+    });
+
+    it("gives up after maxAttempts of persistent collisions", async () => {
+        const { issueCertificateWithUniqueNumber } = await import("@/lib/certificates");
+        certCount.mockResolvedValue(0);
+        let calls = 0;
+        await expect(
+            issueCertificateWithUniqueNumber(async () => {
+                calls += 1;
+                throw p2002(["certificateNumber"]);
+            }, 3)
+        ).rejects.toMatchObject({ code: "P2002" });
+        expect(calls).toBe(3);
+    });
+});

--- a/src/lib/certificates.ts
+++ b/src/lib/certificates.ts
@@ -26,6 +26,48 @@ export async function generateCertificateNumber(): Promise<string> {
     return `VWC-${year}-${sequence}`;
 }
 
+/** True when `error` is a Prisma unique-constraint violation (P2002) on `field`. */
+export function isUniqueViolation(error: unknown, field: string): boolean {
+    if (typeof error !== "object" || error === null) return false;
+    const e = error as { code?: string; meta?: { target?: unknown }; message?: string };
+    if (e.code !== "P2002") return false;
+    const target = e.meta?.target;
+    if (Array.isArray(target)) return target.includes(field);
+    if (typeof target === "string") return target.includes(field);
+    return typeof e.message === "string" && e.message.includes(field);
+}
+
+/**
+ * Allocate a unique certificate number and persist the row, retrying on a
+ * concurrent collision. `generateCertificateNumber` is count-based and therefore
+ * racy — two simultaneous issuances can compute the same number and one hits the
+ * `certificateNumber` unique constraint. Here we recompute and retry so the number
+ * (and the PDF built with it) always matches the stored row.
+ *
+ * `create` receives the freshly generated number, does any work bound to it
+ * (PDF, upload), and performs the DB insert — so a collision cleanly redoes that
+ * attempt rather than leaving an orphaned row.
+ */
+export async function issueCertificateWithUniqueNumber<T>(
+    create: (certificateNumber: string) => Promise<T>,
+    maxAttempts = 5
+): Promise<T> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const certificateNumber = await generateCertificateNumber();
+        try {
+            return await create(certificateNumber);
+        } catch (error) {
+            lastError = error;
+            if (isUniqueViolation(error, "certificateNumber") && attempt < maxAttempts) {
+                continue;
+            }
+            throw error;
+        }
+    }
+    throw lastError ?? new Error("Failed to allocate a unique certificate number");
+}
+
 /**
  * Check if a user has completed a course
  * Completion criteria:

--- a/src/pages/api/lms/certificates/generate.ts
+++ b/src/pages/api/lms/certificates/generate.ts
@@ -1,6 +1,6 @@
 import { v2 as cloudinary } from "cloudinary";
 import { NextApiResponse } from "next";
-import { checkCertificateEligibility, generateCertificateNumber } from "@/lib/certificates";
+import { checkCertificateEligibility, issueCertificateWithUniqueNumber } from "@/lib/certificates";
 import { generateCertificateFilename, generateCertificatePDF } from "@/lib/pdf-certificate";
 import prisma from "@/lib/prisma";
 import { AuthenticatedRequest, requireAuth } from "@/lib/rbac";
@@ -96,73 +96,60 @@ export default requireAuth(async (req: AuthenticatedRequest, res: NextApiRespons
             return res.status(404).json({ error: "User, course, or enrollment not found" });
         }
 
-        // Generate certificate number
-        const certificateNumber = await generateCertificateNumber();
-
-        // Generate PDF
-        const pdfBytes = await generateCertificatePDF({
-            studentName: user.name || user.email,
-            courseName: course.title,
-            completionDate: enrollment.completedAt || new Date(),
-            certificateNumber,
-            estimatedHours: course.estimatedHours || undefined,
-        });
-
-        // Generate filename
-        const filename = generateCertificateFilename(
-            user.name || user.email,
-            course.title,
-            certificateNumber
-        );
-
-        // Upload to Cloudinary
-        const uploadResult = await new Promise<{ secure_url: string; public_id: string }>(
-            (resolve, reject) => {
-                const uploadStream = cloudinary.uploader.upload_stream(
-                    {
-                        folder: "certificates",
-                        public_id: filename.replace(".pdf", ""),
-                        resource_type: "raw",
-                        format: "pdf",
-                    },
-                    (error, result) => {
-                        if (error) {
-                            reject(error);
-                        } else {
-                            resolve(result as { secure_url: string; public_id: string });
-                        }
-                    }
-                );
-
-                uploadStream.end(Buffer.from(pdfBytes));
-            }
-        );
-
-        // Create certificate record in database
-        const certificate = await prisma.certificate.create({
-            data: {
-                userId,
-                courseId,
-                certificateUrl: uploadResult.secure_url,
+        // Allocate a unique certificate number, build the PDF with it, upload, and
+        // persist — retrying atomically if a concurrent issuance grabs the number.
+        // The DB insert is the last step so a collision never leaves an orphan row.
+        const certificate = await issueCertificateWithUniqueNumber(async (certificateNumber) => {
+            const pdfBytes = await generateCertificatePDF({
+                studentName: user.name || user.email,
+                courseName: course.title,
+                completionDate: enrollment.completedAt || new Date(),
                 certificateNumber,
-            },
-            include: {
-                user: {
-                    select: {
-                        id: true,
-                        name: true,
-                        email: true,
+                estimatedHours: course.estimatedHours || undefined,
+            });
+
+            const filename = generateCertificateFilename(
+                user.name || user.email,
+                course.title,
+                certificateNumber
+            );
+
+            const uploadResult = await new Promise<{ secure_url: string; public_id: string }>(
+                (resolve, reject) => {
+                    const uploadStream = cloudinary.uploader.upload_stream(
+                        {
+                            folder: "certificates",
+                            public_id: filename.replace(".pdf", ""),
+                            resource_type: "raw",
+                            format: "pdf",
+                        },
+                        (error, result) => {
+                            if (error) {
+                                reject(error);
+                            } else {
+                                resolve(result as { secure_url: string; public_id: string });
+                            }
+                        }
+                    );
+
+                    uploadStream.end(Buffer.from(pdfBytes));
+                }
+            );
+
+            return prisma.certificate.create({
+                data: {
+                    userId,
+                    courseId,
+                    certificateUrl: uploadResult.secure_url,
+                    certificateNumber,
+                },
+                include: {
+                    user: { select: { id: true, name: true, email: true } },
+                    course: {
+                        select: { id: true, title: true, difficulty: true, estimatedHours: true },
                     },
                 },
-                course: {
-                    select: {
-                        id: true,
-                        title: true,
-                        difficulty: true,
-                        estimatedHours: true,
-                    },
-                },
-            },
+            });
         });
 
         // Send certificate email to user
@@ -170,8 +157,8 @@ export default requireAuth(async (req: AuthenticatedRequest, res: NextApiRespons
             to: certificate.user.email || user.email,
             studentName: certificate.user.name || certificate.user.email || "Student",
             courseName: certificate.course.title,
-            certificateUrl: certificate.certificateUrl || uploadResult.secure_url,
-            certificateNumber: certificate.certificateNumber || certificateNumber,
+            certificateUrl: certificate.certificateUrl || "",
+            certificateNumber: certificate.certificateNumber || "",
             completionDate: enrollment.completedAt || new Date(),
         });
 


### PR DESCRIPTION
## Problem

`generateCertificateNumber()` counts existing certificates for the year and returns `count + 1` as `VWC-YYYY-NNNNNN`. Two concurrent issuances read the same count, produce the same number, and one crashes on the `certificateNumber` unique constraint (after already generating a PDF and uploading it).

## Fix

New `issueCertificateWithUniqueNumber(create, maxAttempts)` in `src/lib/certificates.ts`: it generates a number, runs the caller's `create` (PDF → upload → DB insert), and on a `certificateNumber` unique-constraint violation (P2002) **recomputes the number and retries**. Key properties:

- The **DB insert is the last step inside the retry**, so a collision cleanly redoes the attempt instead of leaving an orphaned/number-less row (the failure mode #1179 is about).
- The PDF is rebuilt with the retried number, so the printed number always matches the stored row.
- Only `certificateNumber` collisions retry — an unrelated unique violation (e.g. `userId_courseId`) propagates immediately.

`generate.ts` now wraps its number → PDF → upload → insert pipeline in this helper.

## Verification

New tests (`__tests__/lib/certificates.test.ts`, 4 passing): retries with a fresh number on collision and yields a unique value; succeeds first-try without collision; does **not** retry on an unrelated unique violation; gives up after `maxAttempts`. `npm run typecheck` — pass.

Closes #1195