### PR TITLE
fix(api): Lock down user profile field exposure and ownership

### DIFF
--- a/__tests__/pages/api/user/profile.test.ts
+++ b/__tests__/pages/api/user/profile.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1170: profile GET must not leak troopAccessToken/email for arbitrary
+ * userIds. Cross-user requests get public fields only; self/admin get more.
+ */
+
+const findUnique = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+    default: {
+        user: {
+            findUnique: (...a: unknown[]) => findUnique(...a),
+            update: vi.fn(),
+        },
+    },
+}));
+
+let sessionUser: { id: string; role?: string } | null = { id: "self", role: "STUDENT" };
+vi.mock("next-auth/next", () => ({
+    getServerSession: vi.fn(async () => (sessionUser ? { user: sessionUser } : null)),
+}));
+vi.mock("@/pages/api/auth/options", () => ({ options: {} }));
+
+function makeRes() {
+    const res: Record<string, unknown> = { statusCode: 200, body: undefined };
+    res.status = vi.fn((c: number) => {
+        res.statusCode = c;
+        return res;
+    });
+    res.json = vi.fn((b: unknown) => {
+        res.body = b;
+        return res;
+    });
+    res.setHeader = vi.fn();
+    return res as Record<string, unknown> & { status: ReturnType<typeof vi.fn> };
+}
+
+describe("GET /api/user/profile field exposure", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        sessionUser = { id: "self", role: "STUDENT" };
+        findUnique.mockResolvedValue({ id: "target", name: "T", skills: null, deployments: null });
+    });
+
+    it("never selects troopAccessToken or troopId", async () => {
+        const { default: handler } = await import("@/pages/api/user/profile");
+        await handler({ method: "GET", query: { userId: "target" } } as never, makeRes() as never);
+
+        const select = findUnique.mock.calls[0][0].select;
+        expect(select.troopAccessToken).toBeUndefined();
+        expect(select.troopId).toBeUndefined();
+    });
+
+    it("cross-user requests get the public select (no email)", async () => {
+        const { default: handler } = await import("@/pages/api/user/profile");
+        await handler({ method: "GET", query: { userId: "other" } } as never, makeRes() as never);
+
+        const select = findUnique.mock.calls[0][0].select;
+        expect(select.email).toBeUndefined();
+        expect(select.name).toBe(true);
+    });
+
+    it("self requests get the private select (email included)", async () => {
+        const { default: handler } = await import("@/pages/api/user/profile");
+        await handler({ method: "GET", query: { userId: "self" } } as never, makeRes() as never);
+
+        expect(findUnique.mock.calls[0][0].select.email).toBe(true);
+    });
+
+    it("admins get the private select for any user", async () => {
+        sessionUser = { id: "admin", role: "ADMIN" };
+        const { default: handler } = await import("@/pages/api/user/profile");
+        await handler({ method: "GET", query: { userId: "other" } } as never, makeRes() as never);
+
+        expect(findUnique.mock.calls[0][0].select.email).toBe(true);
+    });
+
+    it("rejects unauthenticated requests", async () => {
+        sessionUser = null;
+        const { default: handler } = await import("@/pages/api/user/profile");
+        const res = makeRes();
+        await handler({ method: "GET", query: {} } as never, res as never);
+        expect(res.status).toHaveBeenCalledWith(401);
+        expect(findUnique).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/api/user/profile.ts
+++ b/src/pages/api/user/profile.ts
@@ -19,24 +19,63 @@ interface UpdateProfileBody {
     deployments?: string[];
 }
 
-async function handleGetProfile(userId: string, res: NextApiResponse) {
+// Field allowlists. troopAccessToken and troopId (J0dI3 bearer credentials) are
+// NEVER selected, so they can never appear in a response.
+const PUBLIC_PROFILE_SELECT = {
+    id: true,
+    name: true,
+    image: true,
+    bio: true,
+    title: true,
+    location: true,
+    githubUrl: true,
+    linkedinUrl: true,
+    websiteUrl: true,
+    skills: true,
+    branch: true,
+    rank: true,
+    yearsServed: true,
+    mos: true,
+    deployments: true,
+    role: true,
+    skillLevel: true,
+    cohortId: true,
+    graduationDate: true,
+    createdAt: true,
+} as const;
+
+// Self/admin additionally see private-but-not-secret fields.
+const PRIVATE_PROFILE_SELECT = {
+    ...PUBLIC_PROFILE_SELECT,
+    email: true,
+    isActive: true,
+    assessmentScore: true,
+    assessmentDate: true,
+    updatedAt: true,
+} as const;
+
+type ProfileRow = { skills?: string | null; deployments?: string | null } & Record<string, unknown>;
+
+function parseJsonFields(user: ProfileRow) {
+    return {
+        ...user,
+        skills: user.skills ? JSON.parse(user.skills) : [],
+        deployments: user.deployments ? JSON.parse(user.deployments) : [],
+    };
+}
+
+async function handleGetProfile(userId: string, privileged: boolean, res: NextApiResponse) {
     try {
         const user = await prisma.user.findUnique({
             where: { id: userId },
+            select: privileged ? PRIVATE_PROFILE_SELECT : PUBLIC_PROFILE_SELECT,
         });
 
         if (!user) {
             return res.status(404).json({ error: "User not found" });
         }
 
-        // Parse JSON strings back to arrays
-        const userData = {
-            ...user,
-            skills: user.skills ? JSON.parse(user.skills) : [],
-            deployments: user.deployments ? JSON.parse(user.deployments) : [],
-        };
-
-        return res.status(200).json(userData);
+        return res.status(200).json(parseJsonFields(user as ProfileRow));
     } catch (_error) {
         return res.status(500).json({ error: "Internal server error" });
     }
@@ -77,16 +116,11 @@ async function handleUpdateProfile(userId: string, body: UpdateProfileBody, res:
                 mos,
                 deployments: deployments ? JSON.stringify(deployments) : null,
             },
+            // The owner is updating their own profile — return the private set, never the token.
+            select: PRIVATE_PROFILE_SELECT,
         });
 
-        // Parse JSON strings back to arrays
-        const userData = {
-            ...updatedUser,
-            skills: updatedUser.skills ? JSON.parse(updatedUser.skills) : [],
-            deployments: updatedUser.deployments ? JSON.parse(updatedUser.deployments) : [],
-        };
-
-        return res.status(200).json(userData);
+        return res.status(200).json(parseJsonFields(updatedUser as ProfileRow));
     } catch (_error) {
         return res.status(500).json({ error: "Internal server error" });
     }
@@ -99,17 +133,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(401).json({ error: "Unauthorized" });
     }
 
-    const userId = session.user.id;
+    const requesterId = session.user.id;
+    const isAdmin = session.user.role === "ADMIN";
 
     if (req.method === "GET") {
-        // Allow viewing another member's profile via ?userId=
-        const targetUserId = (req.query.userId as string) || userId;
-        return handleGetProfile(targetUserId, res);
+        // Viewing another member via ?userId= yields public fields only; self/admin see more.
+        const targetUserId = (req.query.userId as string) || requesterId;
+        const privileged = targetUserId === requesterId || isAdmin;
+        return handleGetProfile(targetUserId, privileged, res);
     }
 
     if (req.method === "PUT") {
-        // Only the owner can update their own profile
-        return handleUpdateProfile(userId, req.body, res);
+        // Only the owner can update their own profile.
+        return handleUpdateProfile(requesterId, req.body, res);
     }
 
     res.setHeader("Allow", ["GET", "PUT"]);


### PR DESCRIPTION
## Problem

`GET /api/user/profile` did `prisma.user.findUnique({ where: { id } })` with **no select** and returned the whole row for any `?userId=`. So any authenticated user could read any other user's full record — including `troopAccessToken` (a J0dI3 bearer credential), `email`, and other private fields.

## Fix

- **Field allowlists**: `PUBLIC_PROFILE_SELECT` (profile-display fields) for viewing other users; `PRIVATE_PROFILE_SELECT` (adds `email`, `isActive`, assessment fields) for **self or admin**.
- **`troopAccessToken` and `troopId` are never in either select**, so they can't appear in any response.
- Ownership/role check on the `?userId=` param decides which select applies (`isSelf || isAdmin`).
- The `PUT` (self-update) response is sanitized to the private select too (previously returned the full row with the token).

## Verification

New tests (`__tests__/pages/api/user/profile.test.ts`, 5 passing): the select never includes `troopAccessToken`/`troopId`; cross-user gets public (no `email`); self and admin get the private set (with `email`); unauthenticated is 401. `npm run typecheck` — pass.

Closes #1170