### PR TITLE
fix(commerce): Timing-safe webhook HMAC and email normalization

### DIFF
--- a/__tests__/lib/shopify-webhook.test.ts
+++ b/__tests__/lib/shopify-webhook.test.ts
@@ -1,0 +1,53 @@
+import crypto from "crypto";
+import { describe, expect, it } from "vitest";
+import { normalizeEmail, verifyShopifyHmac } from "@/lib/shopify-webhook";
+
+/**
+ * Issue #1202: timing-safe HMAC verification + email normalization.
+ */
+const SECRET = "shopify-secret";
+
+function sign(body: string, secret = SECRET) {
+    return crypto.createHmac("sha256", secret).update(body, "utf8").digest("base64");
+}
+
+describe("verifyShopifyHmac", () => {
+    it("accepts a valid signature", () => {
+        const body = '{"id":123}';
+        expect(verifyShopifyHmac(body, sign(body), SECRET)).toBe(true);
+    });
+
+    it("rejects a tampered body", () => {
+        const body = '{"id":123}';
+        expect(verifyShopifyHmac('{"id":124}', sign(body), SECRET)).toBe(false);
+    });
+
+    it("rejects a wrong secret", () => {
+        const body = '{"id":123}';
+        expect(verifyShopifyHmac(body, sign(body, "other-secret"), SECRET)).toBe(false);
+    });
+
+    it("rejects a malformed/short header without throwing", () => {
+        expect(verifyShopifyHmac('{"id":1}', "not-base64-of-right-length", SECRET)).toBe(false);
+        expect(verifyShopifyHmac('{"id":1}', "", SECRET)).toBe(false);
+    });
+
+    it("returns false with no secret", () => {
+        expect(verifyShopifyHmac('{"id":1}', sign('{"id":1}'), "")).toBe(false);
+    });
+});
+
+describe("normalizeEmail", () => {
+    it("trims and lowercases", () => {
+        expect(normalizeEmail("  John@Example.COM ")).toBe("john@example.com");
+    });
+
+    it("handles null/undefined", () => {
+        expect(normalizeEmail(null)).toBe("");
+        expect(normalizeEmail(undefined)).toBe("");
+    });
+
+    it("matches mixed-case order and session emails to the same key", () => {
+        expect(normalizeEmail("Vet@VetsWhoCode.io")).toBe(normalizeEmail("vet@vetswhocode.io"));
+    });
+});

--- a/src/lib/shopify-webhook.ts
+++ b/src/lib/shopify-webhook.ts
@@ -1,0 +1,27 @@
+import crypto from "crypto";
+
+/**
+ * Verify a Shopify webhook HMAC using a timing-safe comparison. `hmacHeader` is
+ * the base64 value from `X-Shopify-Hmac-Sha256`. A length mismatch short-circuits
+ * to false (timingSafeEqual throws on unequal-length buffers).
+ */
+export function verifyShopifyHmac(rawBody: string, hmacHeader: string, secret: string): boolean {
+    if (!secret || !hmacHeader) return false;
+
+    const digest = crypto.createHmac("sha256", secret).update(rawBody, "utf8").digest();
+
+    let provided: Buffer;
+    try {
+        provided = Buffer.from(hmacHeader, "base64");
+    } catch {
+        return false;
+    }
+
+    if (digest.length !== provided.length) return false;
+    return crypto.timingSafeEqual(digest, provided);
+}
+
+/** Canonical email form for consistent storage and lookup (trimmed + lowercased). */
+export function normalizeEmail(email: string | null | undefined): string {
+    return typeof email === "string" ? email.trim().toLowerCase() : "";
+}

--- a/src/pages/api/orders/index.ts
+++ b/src/pages/api/orders/index.ts
@@ -1,6 +1,7 @@
 import { NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
 import { AuthenticatedRequest, requireAuth } from "@/lib/rbac";
+import { normalizeEmail } from "@/lib/shopify-webhook";
 
 /**
  * GET /api/orders
@@ -31,7 +32,8 @@ export default requireAuth(async (req: AuthenticatedRequest, res: NextApiRespons
 
     try {
         const userId = req.user?.id;
-        const userEmail = req.user?.email;
+        // Orders store customerEmail normalized (see the webhook); match the same way.
+        const userEmail = normalizeEmail(req.user?.email);
 
         // Fetch orders for this user
         // Match by userId OR by email (for orders before user logged in)

--- a/src/pages/api/shopify/webhooks/orders/create.ts
+++ b/src/pages/api/shopify/webhooks/orders/create.ts
@@ -1,6 +1,6 @@
-import crypto from "crypto";
 import { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
+import { normalizeEmail, verifyShopifyHmac } from "@/lib/shopify-webhook";
 
 /**
  * Webhook handler for Shopify order creation
@@ -34,7 +34,7 @@ async function getRawBody(req: NextApiRequest): Promise<string> {
     });
 }
 
-// Verify Shopify HMAC signature
+// Verify Shopify HMAC signature (timing-safe, see @/lib/shopify-webhook)
 function verifyShopifyWebhook(rawBody: string, hmacHeader: string): boolean {
     // Use the Shopify API Secret Key (Client Secret) for webhook verification
     // Try multiple possible env var names for flexibility
@@ -50,12 +50,7 @@ function verifyShopifyWebhook(rawBody: string, hmacHeader: string): boolean {
         return false;
     }
 
-    const hash = crypto
-        .createHmac("sha256", shopifySecret)
-        .update(rawBody, "utf8")
-        .digest("base64");
-
-    return hash === hmacHeader;
+    return verifyShopifyHmac(rawBody, hmacHeader, shopifySecret);
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -85,11 +80,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         // Parse the order data
         const order = JSON.parse(rawBody);
 
-        // Find or link to user by email
+        // Find or link to user by email (normalized for consistent matching)
+        const normalizedEmail = normalizeEmail(order.email);
         let userId: string | null = null;
-        if (order.email) {
+        if (normalizedEmail) {
             const user = await prisma.user.findUnique({
-                where: { email: order.email.toLowerCase() },
+                where: { email: normalizedEmail },
                 select: { id: true },
             });
 
@@ -113,7 +109,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                 shopifyId: order.id.toString(),
                 orderNumber: order.order_number?.toString() || order.name || `#${order.id}`,
                 userId,
-                customerEmail: order.email || "unknown@example.com",
+                customerEmail: normalizedEmail || "unknown@example.com",
                 customerName: order.customer
                     ? `${order.customer.first_name || ""} ${order.customer.last_name || ""}`.trim()
                     : order.billing_address?.name || null,


### PR DESCRIPTION
## Problem

1. The order webhook verified Shopify's HMAC with `hash === hmacHeader` — a non-constant-time comparison (timing side-channel).
2. Email casing was inconsistent: the webhook stored `customerEmail` with Shopify's casing, but `/api/orders` matched it against the session email as-is. A `John@Example.com` order never matched a `john@example.com` session.

## Fix

New `src/lib/shopify-webhook.ts`: `verifyShopifyHmac` (decodes the base64 header, compares with `crypto.timingSafeEqual`, short-circuits on length mismatch) and `normalizeEmail` (trim + lowercase). The webhook verifies via the helper, stores `customerEmail` normalized, and looks up the linked user by normalized email; `/api/orders` normalizes the session email before matching.

New orders match immediately; pre-existing mixed-case rows would need a one-time backfill (out of scope).

## Verification

New tests (`__tests__/lib/shopify-webhook.test.ts`, 8 passing): valid signature accepted; tampered body / wrong secret / malformed header / empty secret rejected without throwing; emails normalized and mixed-case variants collapse to one key. `npm run typecheck` — pass.

Closes #1202