### PR TITLE
fix(certificates): Redact email from public verify + add rate limiting

### DIFF
--- a/__tests__/pages/api/certificates/verify-privacy.test.ts
+++ b/__tests__/pages/api/certificates/verify-privacy.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1193: public certificate verification must not leak the student email
+ * and must be rate-limited (no enumeration).
+ */
+
+const findUnique = vi.fn();
+vi.mock("@/lib/prisma", () => ({
+    default: { certificate: { findUnique: (...a: unknown[]) => findUnique(...a) } },
+}));
+
+function makeReq(ip: string, query: Record<string, string>) {
+    return { method: "GET", headers: { "x-forwarded-for": ip }, query, socket: {} } as never;
+}
+function makeRes() {
+    const res: Record<string, unknown> = { statusCode: 200, body: undefined };
+    res.status = vi.fn((c: number) => {
+        res.statusCode = c;
+        return res;
+    });
+    res.json = vi.fn((b: unknown) => {
+        res.body = b;
+        return res;
+    });
+    res.setHeader = vi.fn();
+    return res as Record<string, unknown> & {
+        statusCode: number;
+        status: ReturnType<typeof vi.fn>;
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    findUnique.mockResolvedValue({
+        id: "VWC-2026-000001",
+        issuedAt: new Date("2026-01-01"),
+        certificateUrl: "https://example/cert.pdf",
+        user: { id: "u1", name: "Jane Vet" },
+        course: {
+            id: "c1",
+            title: "Web Dev",
+            description: "",
+            difficulty: "BEGINNER",
+            estimatedHours: 100,
+            category: "Web",
+        },
+    });
+});
+
+describe("GET /api/certificates/verify", () => {
+    it("returns no student email and never selects it", async () => {
+        const { default: handler } = await import("@/pages/api/certificates/verify");
+        const res = makeRes();
+        await handler(makeReq("10.0.0.1", { number: "VWC-2026-000001" }), res as never);
+
+        expect(findUnique.mock.calls[0][0].include.user.select.email).toBeUndefined();
+        const serialized = JSON.stringify(res.body);
+        expect(serialized).not.toContain("email");
+        expect(serialized).toContain("Jane Vet");
+    });
+
+    it("rate-limits after the window budget (429)", async () => {
+        const { default: handler } = await import("@/pages/api/certificates/verify");
+        let last = makeRes();
+        for (let i = 0; i < 31; i++) {
+            last = makeRes();
+            // same IP -> same bucket
+            // eslint-disable-next-line no-await-in-loop
+            await handler(makeReq("10.9.9.9", { number: "x" }), last as never);
+        }
+        expect(last.statusCode).toBe(429);
+    });
+});
+
+describe("GET /api/certificates/[certificateId]", () => {
+    it("returns no student email and never selects it", async () => {
+        const { default: handler } = await import("@/pages/api/certificates/[certificateId]");
+        const res = makeRes();
+        await handler(makeReq("10.0.0.2", { certificateId: "VWC-2026-000001" }), res as never);
+
+        expect(findUnique.mock.calls[0][0].include.user.select.email).toBeUndefined();
+        expect(JSON.stringify(res.body)).not.toContain("email");
+    });
+});

--- a/src/pages/api/certificates/[certificateId].ts
+++ b/src/pages/api/certificates/[certificateId].ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
+import { enforceRateLimit } from "@/lib/rate-limit";
 
 /**
  * GET /api/certificates/[certificateId]
@@ -14,10 +15,10 @@ async function handleGet(_req: NextApiRequest, res: NextApiResponse, certificate
             where: { id: certificateId },
             include: {
                 user: {
+                    // Public endpoint — expose name only, never the student's email.
                     select: {
                         id: true,
                         name: true,
-                        email: true,
                     },
                 },
                 course: {
@@ -43,7 +44,6 @@ async function handleGet(_req: NextApiRequest, res: NextApiResponse, certificate
             certificateNumber: certificate.id, // Using ID as certificate number
             student: {
                 name: certificate.user.name || "Unknown",
-                email: certificate.user.email,
             },
             course: {
                 title: certificate.course.title,
@@ -68,6 +68,11 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     if (!certificateId || typeof certificateId !== "string") {
         return res.status(400).json({ error: "Invalid certificate ID" });
+    }
+
+    // Public + unauthenticated: throttle per IP so certificates can't be enumerated.
+    if (!enforceRateLimit(req, res, { name: "cert-verify", maxRequests: 30, windowMs: 60_000 })) {
+        return undefined;
     }
 
     switch (req.method) {

--- a/src/pages/api/certificates/verify.ts
+++ b/src/pages/api/certificates/verify.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import prisma from "@/lib/prisma";
+import { enforceRateLimit } from "@/lib/rate-limit";
 
 /**
  * GET /api/certificates/verify?number=CERT_NUMBER
@@ -30,10 +31,10 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
             where: { id: number },
             include: {
                 user: {
+                    // Public endpoint — expose name only, never the student's email.
                     select: {
                         id: true,
                         name: true,
-                        email: true,
                     },
                 },
                 course: {
@@ -64,7 +65,6 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
                 certificateNumber: certificate.id,
                 student: {
                     name: certificate.user.name || "Unknown",
-                    email: certificate.user.email,
                 },
                 course: {
                     title: certificate.course.title,
@@ -85,6 +85,11 @@ async function handleGet(req: NextApiRequest, res: NextApiResponse) {
 export default async (req: NextApiRequest, res: NextApiResponse) => {
     if (req.method !== "GET") {
         return res.status(405).json({ error: "Method not allowed" });
+    }
+
+    // Public + unauthenticated: throttle per IP so the endpoint can't be enumerated.
+    if (!enforceRateLimit(req, res, { name: "cert-verify", maxRequests: 30, windowMs: 60_000 })) {
+        return undefined;
     }
 
     return handleGet(req, res);


### PR DESCRIPTION
## Problem

The two **public, unauthenticated** certificate-verification endpoints — `GET /api/certificates/verify?number=` and `GET /api/certificates/[certificateId]` — returned the student's **email** and had **no rate limiting**. So anyone could verify a certificate *and* harvest student PII, and enumerate certificate numbers unthrottled.

## Fix

- **No email**: both endpoints now `select` only `{ id, name }` for the user and return `student.name` only — the email is never fetched or serialized.
- **Rate limiting**: both are throttled to 30 requests/min per IP via the shared `enforceRateLimit` helper (429 + `Retry-After` on abuse).

Verification still confirms validity (name / course / issue date) — just without the PII.

## Verification

New tests (`__tests__/pages/api/certificates/verify-privacy.test.ts`, 3 passing): the Prisma `select` omits `email` and no `email` appears in either response; the endpoint returns 429 after the per-IP budget is exhausted. `npm run typecheck` — pass.

Closes #1193