### PR TITLE
fix(marketing): Drive cohort countdown from config, hide when past

### DIFF
--- a/__tests__/utils/cohort.test.ts
+++ b/__tests__/utils/cohort.test.ts
@@ -1,0 +1,40 @@
+import { getCohortStartDate, isCohortUpcoming } from "@utils/cohort";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Issue #1208: the header countdown must not show a dead 0:0:0:0 timer once the
+ * cohort date has passed, and the date must be configurable.
+ */
+describe("isCohortUpcoming", () => {
+    const now = Date.parse("2026-07-18T00:00:00Z");
+
+    it("is true for a future date", () => {
+        expect(isCohortUpcoming("2026/09/01", now)).toBe(true);
+    });
+
+    it("is false for a past date (the dead-timer case)", () => {
+        expect(isCohortUpcoming("2026/04/07", now)).toBe(false);
+    });
+
+    it("is false for missing or malformed dates", () => {
+        expect(isCohortUpcoming(undefined, now)).toBe(false);
+        expect(isCohortUpcoming(null, now)).toBe(false);
+        expect(isCohortUpcoming("", now)).toBe(false);
+        expect(isCohortUpcoming("not-a-date", now)).toBe(false);
+    });
+});
+
+describe("getCohortStartDate", () => {
+    afterEach(() => {
+        delete process.env.NEXT_PUBLIC_COHORT_START_DATE;
+    });
+
+    it("falls back to the config default", () => {
+        expect(getCohortStartDate("2026/04/07")).toBe("2026/04/07");
+    });
+
+    it("prefers the env override (editable without a code change)", () => {
+        process.env.NEXT_PUBLIC_COHORT_START_DATE = "2027/01/15";
+        expect(getCohortStartDate("2026/04/07")).toBe("2027/01/15");
+    });
+});

--- a/src/data/site-config.ts
+++ b/src/data/site-config.ts
@@ -4,4 +4,8 @@ export default {
     description:
         "Vets Who Code is a non-profit organization that provides free technical training to veterans and their spouses.",
     url: "https://vetswhocode.io", // Add the URL property here
+    // Next cohort start date (YYYY/MM/DD) for the header countdown. When this is in
+    // the past (or unset), the countdown is hidden instead of showing a dead 0:0:0:0.
+    // Override per-environment without a code change via NEXT_PUBLIC_COHORT_START_DATE.
+    cohortStartDate: "2026/04/07",
 };

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -3,10 +3,12 @@ import MainMenu from "@components/menu/main-menu";
 import Social01 from "@components/socials/social-01";
 import UserMenu from "@components/user-menu";
 import menu, { filterMenuByAuth } from "@data/menu";
+import siteConfig from "@data/site-config";
 import { useSticky } from "@hooks";
 import BurgerButton from "@ui/burger-button";
 import Button from "@ui/button";
 import CountdownTimer from "@ui/countdown-timer/layout-03";
+import { getCohortStartDate, isCohortUpcoming } from "@utils/cohort";
 import clsx from "clsx";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/router";
@@ -27,6 +29,8 @@ const Header = ({ shadow, fluid }: TProps) => {
     const [offcanvas, setOffcanvas] = useState(false);
     const { sticky, measuredRef } = useSticky();
     const { status } = useSession();
+    const cohortStartDate = getCohortStartDate(siteConfig.cohortStartDate);
+    const cohortUpcoming = isCohortUpcoming(cohortStartDate);
     const filteredMenu = useMemo(
         () => filterMenuByAuth(menu, status === "authenticated"),
         [status]
@@ -46,13 +50,18 @@ const Header = ({ shadow, fluid }: TProps) => {
                     )}
                 >
                     <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-justify-center">
-                        <p className="tw-mb-3.8 tw-flex-100 tw-text-center md:tw-mb-0 md:tw-mr-7.5 md:tw-flex-1 md:tw-text-left">
-                            New Cohort Starts:
-                        </p>
-                        <div className="tw-flex tw-items-center sm:tw-mr-[45px] md:tw-mr-5 lg:tw-mr-[45px]">
-                            <i className="far fa-clock tw-mr-[5px] tw-text-lg tw-text-secondary" />
-                            <CountdownTimer targetDate="2026/04/07" />
-                        </div>
+                        {/* Hidden once the cohort date passes (no dead 0:0:0:0 timer). */}
+                        {cohortUpcoming && (
+                            <>
+                                <p className="tw-mb-3.8 tw-flex-100 tw-text-center md:tw-mb-0 md:tw-mr-7.5 md:tw-flex-1 md:tw-text-left">
+                                    New Cohort Starts:
+                                </p>
+                                <div className="tw-flex tw-items-center sm:tw-mr-[45px] md:tw-mr-5 lg:tw-mr-[45px]">
+                                    <i className="far fa-clock tw-mr-[5px] tw-text-lg tw-text-secondary" />
+                                    <CountdownTimer targetDate={cohortStartDate || ""} />
+                                </div>
+                            </>
+                        )}
                         <Button
                             size="sm"
                             path="/donate"

--- a/src/utils/cohort.ts
+++ b/src/utils/cohort.ts
@@ -1,0 +1,22 @@
+/**
+ * Whether a cohort start date is still in the future (so a countdown should show).
+ * Returns false for a missing, malformed, or already-passed date — which is what
+ * suppresses the dead "0 : 0 : 0 : 0" timer once a cohort date has elapsed.
+ */
+export function isCohortUpcoming(
+    dateStr: string | undefined | null,
+    now: number = Date.now()
+): boolean {
+    if (!dateStr) return false;
+    const target = new Date(dateStr).getTime();
+    if (Number.isNaN(target)) return false;
+    return target > now;
+}
+
+/**
+ * The active cohort start date: an env override (editable without a code change)
+ * falling back to the value in site-config.
+ */
+export function getCohortStartDate(configDefault: string | undefined): string | undefined {
+    return process.env.NEXT_PUBLIC_COHORT_START_DATE || configDefault;
+}


### PR DESCRIPTION
## Problem

The header hardcoded `targetDate="2026/04/07"` — already in the past — so **every page** showed a dead `0 : 0 : 0 : 0` timer under "New Cohort Starts:".

## Fix

- The countdown date comes from `site-config.ts` (`cohortStartDate`), overridable per environment via `NEXT_PUBLIC_COHORT_START_DATE` — **editable without a code change**.
- The "New Cohort Starts:" label + timer are rendered only when the date is genuinely upcoming (`isCohortUpcoming`); a missing/malformed/past date **hides the block** (the Donate button stays). No dead zeros anywhere.

## Verification

New tests (`__tests__/utils/cohort.test.ts`, 5 passing): `isCohortUpcoming` is true for a future date, false for past/missing/malformed; `getCohortStartDate` falls back to config and prefers the env override. `npm run typecheck` — pass.

Closes #1208