### PR TITLE
fix(commerce): Fail loud on order webhook write errors with idempotency

### DIFF
--- a/__tests__/pages/api/shopify/order-webhook-failure.test.ts
+++ b/__tests__/pages/api/shopify/order-webhook-failure.test.ts
@@ -1,0 +1,81 @@
+import crypto from "crypto";
+import { Readable } from "stream";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1200: the order webhook must fail loud (5xx) on a DB write failure so
+ * Shopify retries, and be idempotent on shopifyId so a replay yields one row.
+ */
+
+const db = {
+    user: { findUnique: vi.fn() },
+    order: { findUnique: vi.fn(), create: vi.fn() },
+};
+vi.mock("@/lib/prisma", () => ({ default: db }));
+
+const SECRET = "test-webhook-secret";
+process.env.SHOPIFY_WEBHOOK_SECRET = SECRET;
+
+function makeReq(body: string) {
+    const hmac = crypto.createHmac("sha256", SECRET).update(body, "utf8").digest("base64");
+    const req = Readable.from([Buffer.from(body)]) as unknown as Record<string, unknown>;
+    req.method = "POST";
+    req.headers = { "x-shopify-hmac-sha256": hmac };
+    return req as never;
+}
+function makeRes() {
+    const res: Record<string, unknown> = { statusCode: 0, body: undefined };
+    res.status = vi.fn((c: number) => {
+        res.statusCode = c;
+        return res;
+    });
+    res.json = vi.fn((b: unknown) => {
+        res.body = b;
+        return res;
+    });
+    return res as Record<string, unknown> & { statusCode: number };
+}
+
+const ORDER_BODY = JSON.stringify({
+    id: 555,
+    email: "a@b.com",
+    created_at: "2026-01-01",
+    line_items: [],
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    db.user.findUnique.mockResolvedValue(null);
+    db.order.findUnique.mockResolvedValue(null);
+});
+afterAll(() => {
+    delete process.env.SHOPIFY_WEBHOOK_SECRET;
+});
+
+describe("POST /api/shopify/webhooks/orders/create", () => {
+    it("returns 5xx when the DB write fails (so Shopify retries)", async () => {
+        db.order.create.mockRejectedValue(new Error("connection reset"));
+        const { default: handler } = await import("@/pages/api/shopify/webhooks/orders/create");
+        const res = makeRes();
+        await handler(makeReq(ORDER_BODY), res as never);
+        expect(res.statusCode).toBe(500);
+    });
+
+    it("is idempotent on a duplicate shopifyId (P2002 -> 200, no error)", async () => {
+        db.order.create.mockRejectedValue(Object.assign(new Error("dup"), { code: "P2002" }));
+        const { default: handler } = await import("@/pages/api/shopify/webhooks/orders/create");
+        const res = makeRes();
+        await handler(makeReq(ORDER_BODY), res as never);
+        expect(res.statusCode).toBe(200);
+        expect((res.body as { existing?: boolean }).existing).toBe(true);
+    });
+
+    it("returns 200 for an already-stored order (fast path)", async () => {
+        db.order.findUnique.mockResolvedValue({ id: "existing" });
+        const { default: handler } = await import("@/pages/api/shopify/webhooks/orders/create");
+        const res = makeRes();
+        await handler(makeReq(ORDER_BODY), res as never);
+        expect(res.statusCode).toBe(200);
+        expect(db.order.create).not.toHaveBeenCalled();
+    });
+});

--- a/src/pages/api/shopify/webhooks/orders/create.ts
+++ b/src/pages/api/shopify/webhooks/orders/create.ts
@@ -64,9 +64,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         return res.status(405).json({ error: "Method not allowed" });
     }
 
+    let rawBody = "";
     try {
         // Get raw body for signature verification
-        const rawBody = await getRawBody(req);
+        rawBody = await getRawBody(req);
         const hmacHeader = req.headers["x-shopify-hmac-sha256"] as string;
 
         // Verify webhook signature
@@ -153,13 +154,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             orderId: createdOrder.id,
         });
     } catch (error) {
-        console.error("Error processing Shopify webhook:", error);
+        // A duplicate delivery that races past the existing-order check hits the
+        // unique constraint on shopifyId — that's an idempotent success, not a failure.
+        if (error && typeof error === "object" && (error as { code?: string }).code === "P2002") {
+            return res.status(200).json({ received: true, existing: true });
+        }
 
-        // Still return 200 to prevent Shopify from retrying
-        // Log the error for manual investigation
-        return res.status(200).json({
-            received: true,
-            error: "Internal error logged",
+        // Real failure (e.g. the DB write): log with context and return 5xx so Shopify
+        // retries. Previously this returned 200 and the order silently never reached Neon.
+        console.error("[shopify-webhook] order create failed:", {
+            shopifyId: (() => {
+                try {
+                    return JSON.parse(rawBody)?.id;
+                } catch {
+                    return undefined;
+                }
+            })(),
+            error: error instanceof Error ? error.message : String(error),
         });
+        return res.status(500).json({ received: false, error: "Order processing failed" });
     }
 }


### PR DESCRIPTION
## Problem

`/api/shopify/webhooks/orders/create` returned **200 on any error**, explicitly to stop Shopify retrying. So a transient DB write failure silently dropped the order — it never reached Neon and Shopify never retried.

## Fix

- On a real failure the handler now returns **500** so Shopify retries (with its backoff), plus a structured failure log including the `shopifyId`.
- A duplicate delivery that races past the existing-order fast-path check hits the unique constraint on `shopifyId` (P2002) — that's caught and returned as an **idempotent 200**, so a replay yields exactly one `Order` row (no duplicate, no false error).

## Verification

New tests (`__tests__/pages/api/shopify/order-webhook-failure.test.ts`, 3 passing) drive the handler with a valid HMAC over a streamed body: a DB write failure returns 500; a P2002 returns 200 `{ existing: true }`; an already-stored order takes the 200 fast path without calling create. `npm run typecheck` — pass.

Note: touches the same handler as #1255 (HMAC/email); the two are in different regions and should merge cleanly.

Closes #1200