### PR TITLE
fix(platform): Stop leaking operational data from LMS health endpoint

### DIFF
--- a/__tests__/pages/api/lms/health.test.ts
+++ b/__tests__/pages/api/lms/health.test.ts
@@ -31,12 +31,17 @@ describe("GET /api/lms/health", () => {
         await handler({ method: "GET" } as never, res as never);
 
         expect(res.statusCode).toBe(200);
+        expect(Object.keys(res.body as Record<string, unknown>).sort()).toEqual(["database", "status", "timestamp"]);
+        expect(res.body).toMatchObject({ status: "healthy", database: "connected" });
+
         const serialized = JSON.stringify(res.body);
-        // Must NOT leak any counts/sample/schema fields.
+        // Defense-in-depth: ensure common operational fields don't appear anywhere in the payload.
         for (const leak of [
             "users",
             "courses",
             "cohorts",
+            "modules",
+            "lessons",
             "stats",
             "sampleData",
             "features",
@@ -44,8 +49,6 @@ describe("GET /api/lms/health", () => {
         ]) {
             expect(serialized).not.toContain(leak);
         }
-        expect((res.body as { database?: string }).database).toBe("connected");
-    });
 
     it("returns 503 with no error details when the DB is down", async () => {
         queryRaw.mockRejectedValue(new Error("connect ECONNREFUSED 10.0.0.1:5432"));

--- a/__tests__/pages/api/lms/health.test.ts
+++ b/__tests__/pages/api/lms/health.test.ts
@@ -54,6 +54,7 @@ describe("GET /api/lms/health", () => {
         await handler({ method: "GET" } as never, res as never);
 
         expect(res.statusCode).toBe(503);
+        expect(Object.keys(res.body as Record<string, unknown>).sort()).toEqual(["database", "status", "timestamp"]);
+        expect(res.body).toMatchObject({ status: "unhealthy", database: "disconnected" });
         expect(JSON.stringify(res.body)).not.toContain("ECONNREFUSED");
-    });
 });

--- a/__tests__/pages/api/lms/health.test.ts
+++ b/__tests__/pages/api/lms/health.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #1226: the public LMS health endpoint must not disclose operational data
+ * (counts, sample records, schema) — only reachability.
+ */
+
+const queryRaw = vi.fn();
+vi.mock("@/lib/prisma", () => ({ default: { $queryRaw: (...a: unknown[]) => queryRaw(...a) } }));
+
+function makeRes() {
+    const res: Record<string, unknown> = { statusCode: 0, body: undefined };
+    res.status = vi.fn((c: number) => {
+        res.statusCode = c;
+        return res;
+    });
+    res.json = vi.fn((b: unknown) => {
+        res.body = b;
+        return res;
+    });
+    return res as Record<string, unknown> & { statusCode: number; body: unknown };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/lms/health", () => {
+    it("reports healthy with no operational data", async () => {
+        queryRaw.mockResolvedValue([{ "?column?": 1 }]);
+        const { default: handler } = await import("@/pages/api/lms/health");
+        const res = makeRes();
+        await handler({ method: "GET" } as never, res as never);
+
+        expect(res.statusCode).toBe(200);
+        const serialized = JSON.stringify(res.body);
+        // Must NOT leak any counts/sample/schema fields.
+        for (const leak of [
+            "users",
+            "courses",
+            "cohorts",
+            "stats",
+            "sampleData",
+            "features",
+            "models",
+        ]) {
+            expect(serialized).not.toContain(leak);
+        }
+        expect((res.body as { database?: string }).database).toBe("connected");
+    });
+
+    it("returns 503 with no error details when the DB is down", async () => {
+        queryRaw.mockRejectedValue(new Error("connect ECONNREFUSED 10.0.0.1:5432"));
+        const { default: handler } = await import("@/pages/api/lms/health");
+        const res = makeRes();
+        await handler({ method: "GET" } as never, res as never);
+
+        expect(res.statusCode).toBe(503);
+        expect(JSON.stringify(res.body)).not.toContain("ECONNREFUSED");
+    });
+});

--- a/src/pages/api/lms/health.ts
+++ b/src/pages/api/lms/health.ts
@@ -4,8 +4,9 @@ import prisma from "@/lib/prisma";
 /**
  * GET /api/lms/health
  *
- * Public health check endpoint to verify LMS infrastructure.
- * Does NOT require authentication.
+ * Public liveness check for the LMS database connection. Deliberately returns
+ * NO operational data (user/course counts, sample records, schema/feature lists)
+ * — a public endpoint must not disclose that. It only reports reachability.
  */
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method !== "GET") {
@@ -13,81 +14,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
 
     try {
-        // Test database connectivity
-        const [userCount, courseCount, cohortCount, moduleCount, lessonCount] = await Promise.all([
-            prisma.user.count(),
-            prisma.course.count(),
-            prisma.cohort.count(),
-            prisma.module.count(),
-            prisma.lesson.count(),
-        ]);
-
-        // Get sample course data
-        const sampleCourse = await prisma.course.findFirst({
-            where: { isPublished: true },
-            include: {
-                modules: {
-                    take: 1,
-                    include: {
-                        lessons: {
-                            take: 1,
-                        },
-                    },
-                },
-            },
-        });
-
-        res.status(200).json({
+        // Lightweight connectivity probe — no counts, no row data.
+        await prisma.$queryRaw`SELECT 1`;
+        return res.status(200).json({
             status: "healthy",
-            message: "✅ Phase 1 LMS Foundation is operational!",
-            database: {
-                connected: true,
-                provider: "PostgreSQL (Neon)",
-            },
-            stats: {
-                users: userCount,
-                courses: courseCount,
-                cohorts: cohortCount,
-                modules: moduleCount,
-                lessons: lessonCount,
-            },
-            sampleData: sampleCourse
-                ? {
-                      courseTitle: sampleCourse.title,
-                      difficulty: sampleCourse.difficulty,
-                      moduleCount: sampleCourse.modules.length,
-                      hasLessons: sampleCourse.modules[0]?.lessons.length > 0,
-                  }
-                : null,
-            features: {
-                authentication: "NextAuth with GitHub OAuth",
-                rbac: "Role-based access control (ADMIN, INSTRUCTOR, MENTOR, STUDENT)",
-                models: [
-                    "User",
-                    "Course",
-                    "Module",
-                    "Lesson",
-                    "Enrollment",
-                    "Progress",
-                    "Assignment",
-                    "Submission",
-                    "Certificate",
-                    "Cohort",
-                    "Bookmark",
-                    "Note",
-                ],
-            },
+            database: "connected",
             timestamp: new Date().toISOString(),
         });
     } catch (error) {
-        // Log error for debugging
         if (process.env.NODE_ENV === "development") {
-            console.error("Health check failed:", error);
+            console.error("LMS health check failed:", error);
         }
-        res.status(500).json({
+        // No error details in the response body.
+        return res.status(503).json({
             status: "unhealthy",
-            error: "Database connection or query failed",
-            details: error instanceof Error ? error.message : "Unknown error",
+            database: "disconnected",
+            timestamp: new Date().toISOString(),
         });
     }
 }


### PR DESCRIPTION
## Problem

The public, unauthenticated `GET /api/lms/health` returned operational data: user / course / cohort / module / lesson **counts**, a **sample published course** (title, difficulty, module/lesson info), and the full list of models + features. That discloses platform internals to anyone.

## Fix

`/api/lms/health` now does a lightweight `SELECT 1` connectivity probe and reports **reachability only** — `{ status, database, timestamp }` — with no counts, no sample records, and no error details in the body (200 healthy / 503 unhealthy).

## Notes

- **Platform health independent of J0dI3** (the other AC) is already true: `/api/health` checks the DB + required env vars and never touches J0dI3. The *optional* non-blocking J0dI3 substatus is left out of scope here.

## Verification

New tests (`__tests__/pages/api/lms/health.test.ts`, 2 passing): the healthy response contains none of `users/courses/cohorts/stats/sampleData/features/models` and reports `database: connected`; a DB failure returns 503 without leaking the underlying error. `npm run typecheck` — pass.

Closes #1226