### PR TITLE
fix(seo): Repair Open Graph share cards and generate them per page

### DIFF
--- a/__tests__/lib/og-card.test.ts
+++ b/__tests__/lib/og-card.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { cardTitle, MAX_TITLE, OG_FALLBACK_TITLE } from "@/lib/og-card";
+
+describe("cardTitle", () => {
+    it("falls back when the title is missing or empty", () => {
+        expect(cardTitle(null)).toBe(OG_FALLBACK_TITLE);
+        expect(cardTitle("   ")).toBe(OG_FALLBACK_TITLE);
+        // A title that is nothing but the site name leaves no headline behind.
+        expect(cardTitle("Vets Who Code")).toBe(OG_FALLBACK_TITLE);
+    });
+
+    it("strips the site name the SEO template appends", () => {
+        expect(cardTitle("Our Programs | Vets Who Code")).toBe("Our Programs");
+        expect(cardTitle("Our Programs - Vets Who Code")).toBe("Our Programs");
+        // Only a trailing occurrence — a mid-title mention is real content.
+        expect(cardTitle("Why Vets Who Code Works")).toBe("Why Vets Who Code Works");
+    });
+
+    it("truncates long titles on a word boundary, never mid-word", () => {
+        const long =
+            "Software Factory Ship Production Code With Veteran Engineers Every Single Cohort Year Round";
+        const result = cardTitle(long);
+        const body = result.slice(0, -1); // drop the ellipsis
+
+        expect(result.length).toBeLessThanOrEqual(MAX_TITLE + 1); // +1 for the ellipsis
+        expect(result.endsWith("…")).toBe(true);
+        expect(long.startsWith(body)).toBe(true);
+        // The cut must land on a word boundary. Asserting `long.includes(body)`
+        // would pass for a mid-word cut too — the next character is what matters.
+        expect(long[body.length]).toBe(" ");
+    });
+
+    it("still bounds a single unbroken word with no space to cut on", () => {
+        const result = cardTitle("A".repeat(200));
+        expect(result.length).toBeLessThanOrEqual(MAX_TITLE + 1);
+        expect(result.endsWith("…")).toBe(true);
+    });
+
+    it("leaves a title that already fits untouched", () => {
+        expect(cardTitle("Apply Now")).toBe("Apply Now");
+    });
+});

--- a/src/components/seo/deafult-seo.tsx
+++ b/src/components/seo/deafult-seo.tsx
@@ -15,9 +15,10 @@ const DefaultSEO = () => {
                 site_name: siteConfig.name,
                 // One entry only: the second was the same asset declared 1230 wide,
                 // which is a lie about a 1200px image and gave scrapers a coin flip.
+                // The generated card replaces a 2020 VS Code screenshot.
                 images: [
                     {
-                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
+                        url: `${siteConfig.url}/api/og`,
                         width: 1200,
                         height: 630,
                         alt: `${siteConfig.name} — free software engineering training for veterans and military spouses`,

--- a/src/components/seo/deafult-seo.tsx
+++ b/src/components/seo/deafult-seo.tsx
@@ -13,28 +13,21 @@ const DefaultSEO = () => {
                 type: "website",
                 locale: "en_IE",
                 site_name: siteConfig.name,
+                // One entry only: the second was the same asset declared 1230 wide,
+                // which is a lie about a 1200px image and gave scrapers a coin flip.
                 images: [
                     {
                         url: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
                         width: 1200,
                         height: 630,
-                        alt: "Og Image Alt",
-                    },
-                    {
-                        url: "https://res.cloudinary.com/vetswhocode/image/upload/v1609084190/hashflag-white-vscode_n5k5db.jpg",
-                        width: 1230,
-                        height: 630,
-                        alt: "Og Image Alt Second",
+                        alt: `${siteConfig.name} — free software engineering training for veterans and military spouses`,
                     },
                 ],
             }}
+            // handle/site omitted until the real X account is confirmed — "@site"
+            // and "@handle" were attributing every share to accounts we don't own.
             twitter={{
-                handle: "@handle",
-                site: "@site",
                 cardType: "summary_large_image",
-            }}
-            facebook={{
-                appId: "1234567890",
             }}
             additionalMetaTags={[
                 {

--- a/src/components/seo/page-seo.tsx
+++ b/src/components/seo/page-seo.tsx
@@ -1,6 +1,6 @@
 import siteConfig from "@data/site-config";
+import { useRouter } from "next/router";
 import { ArticleJsonLd, CourseJsonLd, NextSeo, NextSeoProps } from "next-seo";
-import { useEffect, useState } from "react";
 
 interface SeoProps extends NextSeoProps {
     template?: string;
@@ -28,29 +28,28 @@ const PageSeo = ({
     image,
     instructor,
 }: SeoProps) => {
-    const [href, setHref] = useState("");
-    useEffect(() => {
-        setHref(window.location.href);
-    }, []);
+    // Built from the router, not window.location in an effect — scrapers don't
+    // run JS, so the effect version left og:url empty and every share fell back
+    // to the site-wide canonical (the homepage).
+    const { asPath } = useRouter();
+    // asPath can be absent when the router is mocked or not yet mounted; fall
+    // back to the bare site URL rather than rendering "undefined" into og:url.
+    const path = asPath?.split(/[?#]/)[0] ?? "";
+    const href = `${siteConfig.url}${path === "/" ? "" : path}`;
 
-    const articleMeta = jsonLdType === "article" && {
-        type: "article",
-        ...article,
-        images: [
-            {
-                url: image as string,
-                width: 1230,
-                height: 630,
-                alt: title,
-            },
-            {
-                url: image as string,
-                width: 1230,
-                height: 630,
-                alt: title,
-            },
-        ],
-    };
+    const articleMeta = jsonLdType === "article" &&
+        image && {
+            type: "article",
+            ...article,
+            images: [
+                {
+                    url: image,
+                    width: 1200,
+                    height: 630,
+                    alt: title,
+                },
+            ],
+        };
 
     return (
         <>
@@ -60,6 +59,7 @@ const PageSeo = ({
                     template ? `${title ?? ""} - ${template}` : `%s - ${siteConfig.titleTemplate}`
                 }
                 description={description}
+                canonical={href}
                 openGraph={{
                     url: href,
                     title,

--- a/src/components/seo/page-seo.tsx
+++ b/src/components/seo/page-seo.tsx
@@ -37,18 +37,40 @@ const PageSeo = ({
     const path = asPath?.split(/[?#]/)[0] ?? "";
     const href = `${siteConfig.url}${path === "/" ? "" : path}`;
 
+    // The homepage's title is literally "Home", which would print HOME as the
+    // headline on the most-shared URL on the site. Fall through to the card's
+    // own brand headline instead.
+    const cardTitle = path === "/" ? "" : (title ?? "");
+    const generatedCard = `${siteConfig.url}/api/og${
+        cardTitle ? `?title=${encodeURIComponent(cardTitle)}` : ""
+    }`;
+
+    // Page artwork when it has some (blog posts, products); otherwise a branded
+    // card generated from the title. Previously `image` was only read inside the
+    // article branch, so a product page's own image was dropped and the share
+    // fell through to the site-wide default.
+    const ogImage = image || generatedCard;
+
+    const imageMeta = {
+        images: [
+            {
+                url: ogImage,
+                alt: title,
+                // Only declare dimensions for the card we render ourselves. A
+                // caller-supplied image (Shopify product, blog artwork) is not
+                // necessarily 1200x630, and a wrong declaration makes scrapers
+                // crop or skip it. Extensionless endpoint needs an explicit type.
+                ...(image ? {} : { width: 1200, height: 630, type: "image/png" }),
+            },
+        ],
+    };
+
+    // next-seo only emits article:* tags from a nested `article` key — spreading
+    // these flat meant blog posts never had article metadata at all.
     const articleMeta = jsonLdType === "article" &&
-        image && {
+        article && {
             type: "article",
-            ...article,
-            images: [
-                {
-                    url: image,
-                    width: 1200,
-                    height: 630,
-                    alt: title,
-                },
-            ],
+            article,
         };
 
     return (
@@ -64,8 +86,10 @@ const PageSeo = ({
                     url: href,
                     title,
                     description,
-                    ...openGraph,
+                    ...imageMeta,
                     ...articleMeta,
+                    // Caller-supplied openGraph wins over everything above.
+                    ...openGraph,
                 }}
             />
             {jsonLdType === "article" && article && (
@@ -73,7 +97,7 @@ const PageSeo = ({
                     type="Blog"
                     url={href}
                     title={title as string}
-                    images={[image as string]}
+                    images={[ogImage]}
                     datePublished={article.publishedTime}
                     dateModified={article.modifiedTime}
                     authorName={article.authors[0]}

--- a/src/components/seo/page-seo.tsx
+++ b/src/components/seo/page-seo.tsx
@@ -8,7 +8,8 @@ interface SeoProps extends NextSeoProps {
     article?: {
         publishedTime: string;
         modifiedTime: string;
-        authors: string[];
+        /** Optional: bylines aren't tracked, so this is usually absent. */
+        authors?: string[];
         tags: string[];
     };
     image?: string;
@@ -100,7 +101,14 @@ const PageSeo = ({
                     images={[ogImage]}
                     datePublished={article.publishedTime}
                     dateModified={article.modifiedTime}
-                    authorName={article.authors[0]}
+                    // Vets Who Code publishes these; per-author bylines aren't
+                    // tracked, and an undefined authorName is invalid JSON-LD.
+                    // Organization, not Person — the org is the author.
+                    authorName={
+                        article.authors?.[0]
+                            ? { name: article.authors[0], type: "Person" }
+                            : { name: siteConfig.name, type: "Organization", url: siteConfig.url }
+                    }
                     description={description as string}
                 />
             )}

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -134,9 +134,19 @@ export function getPostBySlug(slug: string, fields: Array<keyof IBlog> | "all" =
         );
     }
 
+    // formatDate throws away the timestamp, but article:published_time and
+    // JSON-LD both need the ISO 8601 original. Normalise it: front-matter dates
+    // are strings when quoted and Date objects when not, and getStaticProps can
+    // serialize neither a Date nor undefined.
+    const rawPostedAt: unknown = blogData.postedAt;
+    let postedAtISO: string | undefined;
+    if (rawPostedAt instanceof Date) postedAtISO = rawPostedAt.toISOString();
+    else if (typeof rawPostedAt === "string" && rawPostedAt) postedAtISO = rawPostedAt;
+
     return {
         ...blog,
         postedAt: formatDate(blogData.postedAt),
+        ...(postedAtISO ? { postedAtISO } : {}),
         path: `/blogs/${realSlug}`,
     };
 }

--- a/src/lib/og-card.ts
+++ b/src/lib/og-card.ts
@@ -1,0 +1,35 @@
+/** Title handling for the generated Open Graph card (see src/pages/api/og.tsx). */
+
+// Satori lays out one line at a time, so an unbounded title silently overflows
+// the card rather than wrapping into oblivion. 90 chars is ~3 lines at 68px.
+export const MAX_TITLE = 90;
+
+export const OG_FALLBACK_TITLE = "Learn Software Engineering";
+
+/**
+ * Page titles arrive with the site name already appended by the SEO template
+ * ("Our Programs | Vets Who Code"). The card carries the wordmark, so repeating
+ * it just steals headline room.
+ */
+export const stripSiteName = (value: string) =>
+    value.replace(/\s*[|\-–]\s*Vets Who Code\s*$/i, "").trim();
+
+/** Cut on a word boundary — mid-word truncation ("YEAR ROU") reads as a bug. */
+export const truncate = (value: string) => {
+    if (value.length <= MAX_TITLE) return value;
+    const clipped = value.slice(0, MAX_TITLE);
+    const lastSpace = clipped.lastIndexOf(" ");
+    // Only honour the boundary if it isn't so early that we'd drop half the title.
+    const cut = lastSpace > MAX_TITLE * 0.6 ? clipped.slice(0, lastSpace) : clipped;
+    return `${cut.trimEnd()}…`;
+};
+
+/** Full pipeline: raw query param → the string drawn on the card. */
+export const cardTitle = (raw?: string | null) => {
+    // Clamp before the regex, not after: stripSiteName backtracks over runs of
+    // whitespace, so an unbounded query param would pay for it.
+    const cleaned = raw ? stripSiteName(raw.slice(0, MAX_TITLE * 3).trim()) : "";
+    // A title that is only the site name would print the wordmark twice.
+    if (!cleaned || cleaned.toLowerCase() === "vets who code") return OG_FALLBACK_TITLE;
+    return truncate(cleaned);
+};

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -1,0 +1,143 @@
+import { ImageResponse } from "next/og";
+import { cardTitle } from "@/lib/og-card";
+
+/**
+ * Branded Open Graph card, rendered on demand.
+ *
+ * /api/og?title=Learn+Software+Engineering
+ *
+ * Pages without their own artwork (everything but blog posts) point og:image
+ * here, so a share shows the page title on brand instead of one stale asset.
+ * Deliberately not documented with @swagger — it returns an image, not JSON,
+ * and has no place in the API reference.
+ */
+export const config = { runtime: "edge" };
+
+const NAVY = "#091f40";
+const RED = "#c5203e";
+const CREAM = "#EEEDE9";
+const GOLD = "#FDB330";
+
+const FONT_DIR = "/fonts/gotham";
+const SITE_URL = "https://vetswhocode.io";
+// Fixed label. Deliberately not a query param: nothing sets one, and every
+// attacker-controlled string drawn on first-party branding is a liability.
+const EYEBROW = "vetswhocode.io";
+
+/**
+ * Fonts are fetched over HTTP because the edge runtime has no filesystem. Only
+ * trust the request's own origin for hosts we recognise — otherwise a spoofed
+ * Host header would choose where this server sends its requests.
+ */
+const fontOrigin = (requestOrigin: string) => {
+    try {
+        const { hostname } = new URL(requestOrigin);
+        const trusted =
+            hostname === "localhost" ||
+            hostname === "127.0.0.1" ||
+            hostname === "vetswhocode.io" ||
+            hostname.endsWith(".vetswhocode.io") ||
+            hostname.endsWith(".vercel.app");
+        return trusted ? requestOrigin : SITE_URL;
+    } catch {
+        return SITE_URL;
+    }
+};
+
+const loadFont = async (origin: string, file: string) => {
+    const res = await fetch(`${origin}${FONT_DIR}/${file}`);
+    // arrayBuffer() happily returns an HTML 404 body. Satori then fails *after*
+    // ImageResponse has already handed back a 200, so the CDN caches a broken
+    // PNG. Fail loudly here instead, while the status code is still ours.
+    if (!res.ok) throw new Error(`OG card: font ${file} responded ${res.status}`);
+    return res.arrayBuffer();
+};
+
+const handler = async (req: Request) => {
+    const { searchParams, origin } = new URL(req.url);
+
+    const title = cardTitle(searchParams.get("title"));
+    const assetOrigin = fontOrigin(origin);
+
+    const [black, medium] = await Promise.all([
+        loadFont(assetOrigin, "GothamPro-Black.ttf"),
+        loadFont(assetOrigin, "GothamPro-Medium.ttf"),
+    ]);
+
+    return new ImageResponse(
+        <div
+            style={{
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "space-between",
+                backgroundColor: NAVY,
+                padding: "64px 72px",
+            }}
+        >
+            {/* Wordmark with the red bar that fronts the brand's headings */}
+            <div style={{ display: "flex", alignItems: "center" }}>
+                <div style={{ width: 10, height: 44, backgroundColor: RED }} />
+                <div
+                    style={{
+                        marginLeft: 20,
+                        fontFamily: "Gotham",
+                        fontWeight: 900,
+                        fontSize: 30,
+                        letterSpacing: "0.06em",
+                        color: CREAM,
+                    }}
+                >
+                    VETS WHO CODE
+                </div>
+            </div>
+
+            <div
+                style={{
+                    display: "flex",
+                    fontFamily: "Gotham",
+                    fontWeight: 900,
+                    fontSize: title.length > 48 ? 68 : 84,
+                    lineHeight: 1.08,
+                    letterSpacing: "-0.02em",
+                    color: CREAM,
+                    textTransform: "uppercase",
+                }}
+            >
+                {title}
+            </div>
+
+            <div style={{ display: "flex", flexDirection: "column" }}>
+                <div style={{ width: 96, height: 4, backgroundColor: GOLD }} />
+                <div
+                    style={{
+                        marginTop: 20,
+                        fontFamily: "Gotham",
+                        fontWeight: 500,
+                        fontSize: 24,
+                        letterSpacing: "0.1em",
+                        color: "rgba(238, 237, 233, 0.65)",
+                        textTransform: "uppercase",
+                    }}
+                >
+                    {EYEBROW}
+                </div>
+            </div>
+        </div>,
+        {
+            width: 1200,
+            height: 630,
+            fonts: [
+                { name: "Gotham", data: black, weight: 900, style: "normal" },
+                { name: "Gotham", data: medium, weight: 500, style: "normal" },
+            ],
+            headers: {
+                "Cache-Control":
+                    "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+            },
+        }
+    );
+};
+
+export default handler;

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -18,11 +18,22 @@ const RED = "#c5203e";
 const CREAM = "#EEEDE9";
 const GOLD = "#FDB330";
 
+const NAVY_LIFT = "#0f2d5c"; // radial highlight so the field isn't flat
+
 const FONT_DIR = "/fonts/gotham";
 const SITE_URL = "https://vetswhocode.io";
-// Fixed label. Deliberately not a query param: nothing sets one, and every
+// Fixed labels. Deliberately not query params: nothing sets one, and every
 // attacker-controlled string drawn on first-party branding is a liability.
-const EYEBROW = "vetswhocode.io";
+const EYEBROW = "Software Engineering Accelerator";
+const DOMAIN = "vetswhocode.io";
+
+// The wordmark ships as navy type on transparency, which disappears on a navy
+// field. e_colorize repaints it cream; f_png because satori decodes PNG/JPEG,
+// and f_auto would hand it a webp.
+const LOGO_URL =
+    "https://res.cloudinary.com/vetswhocode/image/upload/e_colorize:100,co_rgb:EEEDE9,f_png/v1627489505/VWC_Logo_Horizontal_gsxn3h.png";
+const LOGO_W = 300;
+const LOGO_H = 75; // 426x107 native, kept to ratio
 
 /**
  * Fonts are fetched over HTTP because the edge runtime has no filesystem. Only
@@ -44,6 +55,24 @@ const fontOrigin = (requestOrigin: string) => {
     }
 };
 
+/**
+ * Inline the wordmark as a data URI. Satori would happily fetch the URL itself,
+ * but then a Cloudinary hiccup takes the whole card down; resolving it here lets
+ * the card fall back to a type-only lockup instead of 500ing.
+ */
+const loadLogo = async (): Promise<string | null> => {
+    try {
+        const res = await fetch(LOGO_URL);
+        if (!res.ok) return null;
+        const bytes = new Uint8Array(await res.arrayBuffer());
+        let binary = "";
+        for (const byte of bytes) binary += String.fromCharCode(byte);
+        return `data:image/png;base64,${btoa(binary)}`;
+    } catch {
+        return null;
+    }
+};
+
 const loadFont = async (origin: string, file: string) => {
     const res = await fetch(`${origin}${FONT_DIR}/${file}`);
     // arrayBuffer() happily returns an HTML 404 body. Satori then fails *after*
@@ -59,9 +88,10 @@ const handler = async (req: Request) => {
     const title = cardTitle(searchParams.get("title"));
     const assetOrigin = fontOrigin(origin);
 
-    const [black, medium] = await Promise.all([
+    const [black, medium, logo] = await Promise.all([
         loadFont(assetOrigin, "GothamPro-Black.ttf"),
         loadFont(assetOrigin, "GothamPro-Medium.ttf"),
+        loadLogo(),
     ]);
 
     return new ImageResponse(
@@ -71,57 +101,100 @@ const handler = async (req: Request) => {
                 height: "100%",
                 display: "flex",
                 flexDirection: "column",
-                justifyContent: "space-between",
                 backgroundColor: NAVY,
-                padding: "64px 72px",
+                backgroundImage: `radial-gradient(circle at 78% 18%, ${NAVY_LIFT} 0%, ${NAVY} 58%)`,
             }}
         >
-            {/* Wordmark with the red bar that fronts the brand's headings */}
-            <div style={{ display: "flex", alignItems: "center" }}>
-                <div style={{ width: 10, height: 44, backgroundColor: RED }} />
-                <div
-                    style={{
-                        marginLeft: 20,
-                        fontFamily: "Gotham",
-                        fontWeight: 900,
-                        fontSize: 30,
-                        letterSpacing: "0.06em",
-                        color: CREAM,
-                    }}
-                >
-                    VETS WHO CODE
-                </div>
-            </div>
+            {/* Full-bleed accent rule: red into gold, the two brand accents */}
+            <div
+                style={{
+                    display: "flex",
+                    height: 10,
+                    width: "100%",
+                    backgroundImage: `linear-gradient(90deg, ${RED} 0%, #d9542f 45%, ${GOLD} 100%)`,
+                }}
+            />
 
             <div
                 style={{
                     display: "flex",
-                    fontFamily: "Gotham",
-                    fontWeight: 900,
-                    fontSize: title.length > 48 ? 68 : 84,
-                    lineHeight: 1.08,
-                    letterSpacing: "-0.02em",
-                    color: CREAM,
-                    textTransform: "uppercase",
+                    flexDirection: "column",
+                    justifyContent: "space-between",
+                    flex: 1,
+                    padding: "58px 72px 62px 72px",
                 }}
             >
-                {title}
-            </div>
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    {logo ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={logo} width={LOGO_W} height={LOGO_H} alt="Vets Who Code" />
+                    ) : (
+                        <div
+                            style={{
+                                display: "flex",
+                                fontFamily: "Gotham",
+                                fontWeight: 900,
+                                fontSize: 40,
+                                letterSpacing: "-0.01em",
+                                color: CREAM,
+                            }}
+                        >
+                            VetsWhoCode
+                        </div>
+                    )}
+                    <div
+                        style={{
+                            marginTop: 22,
+                            fontFamily: "Gotham",
+                            fontWeight: 500,
+                            fontSize: 21,
+                            letterSpacing: "0.16em",
+                            color: GOLD,
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        {EYEBROW}
+                    </div>
+                </div>
 
-            <div style={{ display: "flex", flexDirection: "column" }}>
-                <div style={{ width: 96, height: 4, backgroundColor: GOLD }} />
+                <div style={{ display: "flex", flexDirection: "column" }}>
+                    <div
+                        style={{
+                            display: "flex",
+                            fontFamily: "Gotham",
+                            fontWeight: 900,
+                            fontSize: title.length > 48 ? 66 : 82,
+                            lineHeight: 1.06,
+                            letterSpacing: "-0.02em",
+                            color: CREAM,
+                            textTransform: "uppercase",
+                        }}
+                    >
+                        {title}
+                    </div>
+                    <div
+                        style={{
+                            display: "flex",
+                            marginTop: 26,
+                            width: 110,
+                            height: 6,
+                            backgroundColor: RED,
+                        }}
+                    />
+                </div>
+
                 <div
                     style={{
-                        marginTop: 20,
+                        display: "flex",
                         fontFamily: "Gotham",
                         fontWeight: 500,
-                        fontSize: 24,
+                        fontSize: 23,
                         letterSpacing: "0.1em",
-                        color: "rgba(238, 237, 233, 0.65)",
+                        color: GOLD,
                         textTransform: "uppercase",
                     }}
                 >
-                    {EYEBROW}
+                    {DOMAIN}
                 </div>
             </div>
         </div>,

--- a/src/pages/blogs/[slug].tsx
+++ b/src/pages/blogs/[slug].tsx
@@ -39,10 +39,13 @@ const BlogDetails: PageProps = ({ data: { blog, prevAndNextPost, recentPosts, ta
                 description={blog.description as string}
                 jsonLdType="article"
                 article={{
-                    publishedTime: blog.postedAt,
-                    modifiedTime: blog.postedAt,
-                    authors: [blog.author.name],
-                    tags: tags.map((tag) => tag.title),
+                    // ISO 8601, not the display string — Open Graph requires it.
+                    publishedTime: blog.postedAtISO ?? blog.postedAt,
+                    modifiedTime: blog.postedAtISO ?? blog.postedAt,
+                    authors: blog.author?.name ? [blog.author.name] : [],
+                    // This post's tags. `tags` is the sidebar's sitewide tag
+                    // cloud — using it emitted every tag on the site per post.
+                    tags: blog.tags.map((tag) => tag.title),
                 }}
                 image={ogImageUrl}
             />

--- a/src/pages/blogs/[slug].tsx
+++ b/src/pages/blogs/[slug].tsx
@@ -42,7 +42,8 @@ const BlogDetails: PageProps = ({ data: { blog, prevAndNextPost, recentPosts, ta
                     // ISO 8601, not the display string — Open Graph requires it.
                     publishedTime: blog.postedAtISO ?? blog.postedAt,
                     modifiedTime: blog.postedAtISO ?? blog.postedAt,
-                    authors: blog.author?.name ? [blog.author.name] : [],
+                    // No authors: bylines aren't tracked, so JSON-LD credits the
+                    // organisation and article:author is simply not emitted.
                     // This post's tags. `tags` is the sidebar's sitewide tag
                     // cloud — using it emitted every tag on the site per post.
                     tags: blog.tags.map((tag) => tag.title),

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -239,6 +239,8 @@ export interface IBlog {
     slug: string;
     path: string;
     postedAt: string;
+    /** Raw ISO 8601 timestamp from front-matter; `postedAt` is display-formatted. */
+    postedAtISO?: string;
     image: ImageType;
     category: BlogMetaType;
     tags: BlogMetaType[];


### PR DESCRIPTION
## Summary

Every link shared from this site resolved to the homepage, attributed itself to Twitter accounts we don't own, and showed a VS Code screenshot uploaded in December 2020. This fixes the metadata and adds a generated, on-brand card for every page.

Verified against production HTML before starting, and against server-rendered HTML (`curl`, no JS — what a scraper actually sees) after each change. **LinkedIn is the priority channel**, and it reads `og:*` and does not execute JS, so the `og:url` fix below is what unblocks it.

## What was broken

| Problem | Evidence on the live site |
|---|---|
| `og:url` was the homepage on every page | A blog post emitted `og:url = https://vetswhocode.io` |
| Twitter attribution was placeholder | `twitter:site = @site`, `twitter:creator = @handle` |
| `fb:app_id` was fake | `1234567890` |
| Alt text was placeholder | `"Og Image Alt"`, `"Og Image Alt Second"` |
| Duplicate `og:image`, one lying about its size | Same URL twice, declared 1200 and 1230 wide |
| No `article:*` tags on any blog post | next-seo needs them nested under `openGraph.article`; they were spread flat |
| Page-supplied images were discarded | `image` was only read inside the article branch, so Shopify product images never reached `og:image` |
| Default image was a 2020 VS Code screenshot | `hashflag-white-vscode`, `v1609084190` |

The `og:url` bug was the worst: `PageSeo` built it from `window.location.href` inside a `useEffect`, so the tag was empty in server-rendered HTML and scrapers — which don't run JS — fell back to the sitewide canonical.

## What changed

- **`src/pages/api/og.tsx`** (new) — edge route rendering a 1200x630 navy/red/gold card with the page title in GothamPro. Uses `next/og`, which ships with Next 15, so **no new dependency**. 1200x630 satisfies LinkedIn's minimum of 1200x627.
- **`src/lib/og-card.ts`** (new) — title handling: strips the appended site name, truncates on a word boundary, falls back to a brand headline. Unit-tested.
- **`src/components/seo/page-seo.tsx`** — server-rendered `og:url` + per-page canonical; article fields nested so `article:*` finally emit; `image` honoured for every page type; dimensions declared only for the card we render.
- **`src/components/seo/deafult-seo.tsx`** — placeholders removed, default image now the generated card.
- **`src/lib/blog.ts` / `[slug].tsx`** — real article metadata (see below).

## Social channels

No X/Twitter account exists, so `twitter:site` and `twitter:creator` are removed rather than filled in — a placeholder handle attributes every share to an account we don't control. `twitter:card = summary_large_image` is kept because Slack, Discord and other unfurlers read it; it costs one tag and needs no account.

Bylines aren't tracked either. `article:author` is omitted rather than emitted blank, and JSON-LD credits **Vets Who Code as an `Organization`** — previously `authorName` was `undefined` for nearly every post, which is invalid structured data.

## Reviewed adversarially

A multi-agent review raised 19 findings; each was independently checked against the source before I acted. Fixes that came out of it:

- **Unchecked font fetch** — `arrayBuffer()` returns a 404's HTML body happily, and satori then fails *after* `ImageResponse` has already handed back a 200, so the CDN would cache a broken PNG for 24h. Now rejects non-200 while the status is still ours.
- **Font origin from the request URL** — a spoofed `Host` header would choose where the server sends its own requests. Now only trusts known hosts.
- **Quadratic regex** on an uncapped query param — input clamped before the regex.
- **`eyebrow` param dropped** — no caller set it, and attacker-controlled text on first-party branding is a liability.
- **Homepage card read "HOME"** — `index.tsx` passes `title="Home"`; the most-shared URL now uses the brand headline.
- **A test of mine that could never fail** — `expect(long).toContain(result)` passes for a mid-word cut too. Replaced with an assertion on the character at the cut.

Enabling `article:*` then exposed three latent data bugs, all fixed here: tags came from `getTags()` (the sitewide tag cloud — ~150 tags per post, now 10), `published_time` carried the display string `"Jan 29, 2026"` instead of ISO 8601, and `article:author` rendered empty.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 446 passing (5 new)
- [x] `npm run build` — required; it caught two serialization defects (`Date` and `undefined` from `getStaticProps`) that typecheck could not
- [x] `curl` on homepage, `/programs`, a blog post, verifying `og:url`, canonical, `og:image`, `og:image:type`, `article:*`, and JSON-LD
- [x] Card rendered and inspected: long title, short title, no title, site-name-suffixed title
- [ ] Post-deploy: validate a real URL with the **LinkedIn Post Inspector** (it caches aggressively — the inspector is also how you force a re-scrape)

## Follow-up

- `og:image` hardcodes the production origin, so cards can't be previewed from a preview deployment.