### PR TITLE
feat(auth): Enhance GitHub profile data fetching

### DIFF
--- a/__tests__/lib/github-profile.test.ts
+++ b/__tests__/lib/github-profile.test.ts
@@ -1,0 +1,46 @@
+import {
+    mapGitHubProfileToUser,
+    type GitHubProfileData,
+} from "@/lib/github-profile";
+
+describe("mapGitHubProfileToUser", () => {
+    it("maps GitHub profile fields to Prisma user fields", () => {
+        const profile: GitHubProfileData = {
+            name: "Test Veteran",
+            email: "test@example.com",
+            avatar_url: "https://avatars.githubusercontent.com/u/123",
+            bio: "Software engineer",
+            location: "Atlanta, GA",
+            html_url: "https://github.com/testveteran",
+        };
+
+        expect(mapGitHubProfileToUser(profile)).toEqual({
+            name: "Test Veteran",
+            email: "test@example.com",
+            image: "https://avatars.githubusercontent.com/u/123",
+            bio: "Software engineer",
+            location: "Atlanta, GA",
+            githubUrl: "https://github.com/testveteran",
+        });
+    });
+
+    it("preserves nullable GitHub profile fields", () => {
+        const profile: GitHubProfileData = {
+            name: null,
+            email: null,
+            avatar_url: null,
+            bio: null,
+            location: null,
+            html_url: "https://github.com/testveteran",
+        };
+
+        expect(mapGitHubProfileToUser(profile)).toEqual({
+            name: null,
+            email: null,
+            image: null,
+            bio: null,
+            location: null,
+            githubUrl: "https://github.com/testveteran",
+        });
+    });
+});

--- a/__tests__/pages/api/auth/options.test.ts
+++ b/__tests__/pages/api/auth/options.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Profile } from "next-auth";
+
+const accountFindUnique = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+    default: {
+        account: {
+            findUnique: (...args: unknown[]) => accountFindUnique(...args),
+        },
+        user: {
+            findUnique: vi.fn(),
+        },
+    },
+}));
+
+vi.mock("@/lib/ensure-troop", () => ({
+    ensureTroop: vi.fn(),
+}));
+
+const originalFetch = global.fetch;
+
+describe("GitHub signIn callback", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env.GITHUB_ORG = "Vets-Who-Code";
+        global.fetch = vi.fn();
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+    });
+
+    it("does not fetch GitHub profile data for an existing account", async () => {
+        accountFindUnique.mockResolvedValue({
+            userId: "user-1",
+            provider: "github",
+            providerAccountId: "123",
+        });
+
+        vi.mocked(global.fetch).mockResolvedValueOnce(
+            new Response(null, { status: 204 })
+        );
+
+        const { options } = await import("@/pages/api/auth/options");
+
+        const signIn = options.callbacks?.signIn;
+
+        const user = {
+            id: "user-1",
+            name: "Existing User",
+            email: "existing@example.com",
+            image: null,
+        };
+
+        const result = await signIn?.({
+            user,
+            account: {
+                provider: "github",
+                type: "oauth",
+                providerAccountId: "123",
+                access_token: "token",
+            },
+            profile: {
+                login: "existing-user",
+            } as unknown as Profile,
+            email: undefined,
+            credentials: undefined,
+        });
+
+        expect(result).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches and maps GitHub profile data on first sign-in", async () => {
+        accountFindUnique.mockResolvedValue(null);
+
+        vi.mocked(global.fetch)
+            .mockResolvedValueOnce(new Response(null, { status: 204 }))
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        name: "New Veteran",
+                        email: "new@example.com",
+                        avatar_url: "https://avatars.githubusercontent.com/u/123",
+                        bio: "Software engineer",
+                        location: "Atlanta, GA",
+                        html_url: "https://github.com/new-veteran",
+                    }),
+                    {
+                        status: 200,
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                    }
+                )
+            );
+
+        const { options } = await import("@/pages/api/auth/options");
+
+        const signIn = options.callbacks?.signIn;
+
+        const user = {
+            id: "user-2",
+            name: null,
+            email: "fallback@example.com",
+            image: null,
+        };
+
+        const result = await signIn?.({
+            user,
+            account: {
+                provider: "github",
+                type: "oauth",
+                providerAccountId: "456",
+                access_token: "token",
+            },
+            profile: {
+                login: "new-veteran",
+            } as unknown as Profile,
+            email: undefined,
+            credentials: undefined,
+        });
+
+        expect(result).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+
+        expect(user).toEqual(
+            expect.objectContaining({
+                name: "New Veteran",
+                email: "new@example.com",
+                image: "https://avatars.githubusercontent.com/u/123",
+                bio: "Software engineer",
+                location: "Atlanta, GA",
+                githubUrl: "https://github.com/new-veteran",
+            })
+        );
+    });
+
+    it("preserves the existing email when GitHub email is null", async () => {
+        accountFindUnique.mockResolvedValue(null);
+
+        vi.mocked(global.fetch)
+            .mockResolvedValueOnce(new Response(null, { status: 204 }))
+            .mockResolvedValueOnce(
+                new Response(
+                    JSON.stringify({
+                        name: "Private Email User",
+                        email: null,
+                        avatar_url: null,
+                        bio: null,
+                        location: null,
+                        html_url: "https://github.com/private-user",
+                    }),
+                    {
+                        status: 200,
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                    }
+                )
+            );
+
+        const { options } = await import("@/pages/api/auth/options");
+
+        const signIn = options.callbacks?.signIn;
+
+        const user = {
+            id: "user-3",
+            name: null,
+            email: "resolved@example.com",
+            image: null,
+        };
+
+        const result = await signIn?.({
+            user,
+            account: {
+                provider: "github",
+                type: "oauth",
+                providerAccountId: "789",
+                access_token: "token",
+            },
+            profile: {
+                login: "private-user",
+            } as unknown as Profile,
+            email: undefined,
+            credentials: undefined,
+        });
+
+        expect(result).toBe(true);
+        expect(user.email).toBe("resolved@example.com");
+    });
+
+    it("allows sign-in when GitHub profile API returns an error", async () => {
+        accountFindUnique.mockResolvedValue(null);
+
+        vi.mocked(global.fetch)
+            .mockResolvedValueOnce(new Response(null, { status: 204 }))
+            .mockResolvedValueOnce(new Response(null, { status: 429 }));
+
+        const { options } = await import("@/pages/api/auth/options");
+
+        const result = await options.callbacks?.signIn?.({
+            user: {
+                id: "user-4",
+                name: null,
+                email: "user@example.com",
+                image: null,
+            },
+            account: {
+                provider: "github",
+                type: "oauth",
+                providerAccountId: "111",
+                access_token: "token",
+            },
+            profile: {
+                login: "rate-limited-user",
+            } as unknown as Profile,
+            email: undefined,
+            credentials: undefined,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it("allows sign-in when GitHub profile request throws", async () => {
+        accountFindUnique.mockResolvedValue(null);
+
+        vi.mocked(global.fetch)
+            .mockResolvedValueOnce(new Response(null, { status: 204 }))
+            .mockRejectedValueOnce(new Error("GitHub unavailable"));
+
+        const { options } = await import("@/pages/api/auth/options");
+
+        const result = await options.callbacks?.signIn?.({
+            user: {
+                id: "user-5",
+                name: null,
+                email: "user@example.com",
+                image: null,
+            },
+            account: {
+                provider: "github",
+                type: "oauth",
+                providerAccountId: "222",
+                access_token: "token",
+            },
+            profile: {
+                login: "network-error-user",
+            } as unknown as Profile,
+            email: undefined,
+            credentials: undefined,
+        });
+
+        expect(result).toBe(true);
+    });
+
+    it("denies sign-in and skips profile lookup when user is not an organization member", async () => {
+        vi.mocked(global.fetch).mockResolvedValueOnce(
+            new Response(null, { status: 404 })
+        );
+    
+        const { options } = await import("@/pages/api/auth/options");
+    
+        const result = await options.callbacks?.signIn?.({
+            user: {
+                id: "user-6",
+                name: null,
+                email: "outsider@example.com",
+                image: null,
+            },
+            account: {
+                provider: "github",
+                type: "oauth",
+                providerAccountId: "333",
+                access_token: "token",
+            },
+            profile: {
+                login: "not-a-member",
+            } as unknown as Profile,
+            email: undefined,
+            credentials: undefined,
+        });
+    
+        expect(result).toBe(false);
+        expect(accountFindUnique).not.toHaveBeenCalled();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/lib/github-profile.ts
+++ b/src/lib/github-profile.ts
@@ -1,0 +1,17 @@
+export type GitHubProfileData = {
+    name: string | null;
+    email: string | null;
+    avatar_url: string | null;
+    bio: string | null;
+    location: string | null;
+    html_url: string;
+};
+
+export const mapGitHubProfileToUser = (profile: GitHubProfileData) => ({
+    name: profile.name,
+    email: profile.email,
+    image: profile.avatar_url,
+    bio: profile.bio,
+    location: profile.location,
+    githubUrl: profile.html_url,
+});

--- a/src/pages/api/auth/options.ts
+++ b/src/pages/api/auth/options.ts
@@ -3,6 +3,10 @@ import { NextAuthOptions } from "next-auth";
 import GithubProvider, { GithubProfile } from "next-auth/providers/github";
 import { ensureTroop } from "@/lib/ensure-troop";
 import prisma from "@/lib/prisma";
+import {
+    mapGitHubProfileToUser,
+    type GitHubProfileData,
+} from "@/lib/github-profile";
 
 const fetchWithTimeout = async (
     url: string,
@@ -39,7 +43,7 @@ export const options: NextAuthOptions = {
     ],
     adapter: PrismaAdapter(prisma),
     callbacks: {
-        async signIn({ account, profile }) {
+        async signIn({ user, account, profile }) {
             if (account?.provider === "github") {
                 const githubProfile = profile as GithubProfile;
 
@@ -77,6 +81,51 @@ export const options: NextAuthOptions = {
 
                     // 204 = member, 302 = requester not in org, 404 = not a member
                     if (res.status === 204) {
+                        const existingAccount = await prisma.account.findUnique({
+                            where: {
+                                provider_providerAccountId: {
+                                    provider: "github",
+                                    providerAccountId: account.providerAccountId,
+                                },
+                            },
+                        });
+
+                        if (existingAccount) {
+                            return true;
+                        }
+
+                        try {
+                            const profileResponse = await fetchWithTimeout(
+                                "https://api.github.com/user",
+                                {
+                                    headers: {
+                                        Accept: "application/vnd.github.v3+json",
+                                        Authorization: `Bearer ${account.access_token}`,
+                                        "User-Agent": "NextAuth.js",
+                                    },
+                                },
+                                5000
+                            );
+
+                            if (!profileResponse.ok) {
+                                console.error(
+                                    `[Auth] GitHub profile fetch failed for ${githubProfile.login}: status ${profileResponse.status}`
+                                );
+                                return true;
+                            }
+
+                            const githubUser = (await profileResponse.json()) as GitHubProfileData;
+                            const mappedProfile = mapGitHubProfileToUser(githubUser);
+
+                            Object.assign(user, {
+                                ...mappedProfile,
+                                email: mappedProfile.email ?? user.email,
+                            });
+                        } catch (error) {
+                            console.error("[Auth] GitHub profile fetch error:", error);
+                            return true;
+                        }
+
                         return true;
                     }
 


### PR DESCRIPTION
## Description

Enhances the GitHub authentication flow to automatically populate profile information for first-time users after successful Vets Who Code organization membership verification.

Existing linked GitHub accounts are not overwritten on subsequent logins, and GitHub profile API failures are handled gracefully without blocking verified organization members.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Build/CI update

## Related Issues

Closes #861

## Changes Made

- Added GitHub profile data fetching after successful organization membership verification
- Added first-sign-in detection using the linked GitHub account
- Added mapping for name, email, avatar, bio, location, and GitHub URL
- Preserved existing email when GitHub returns a null email
- Prevented existing profile data from being overwritten on subsequent logins
- Added graceful handling for GitHub API errors, rate limits, and request failures
- Added unit tests for GitHub-to-Prisma profile mapping
- Added authentication behavior tests for first-time users, returning users, API failures, email fallback, and failed organization membership

## Screenshots/Videos

Not applicable — authentication/backend changes only.

### Before

GitHub authentication verified organization membership but did not populate the additional GitHub profile fields required by #861.

### After

First-time verified organization members have supported GitHub profile data mapped into their user profile while returning users retain their existing profile information.