### PR TITLE
feat(scripts): Draft blog graphic artboards with Gemini

### DIFF
--- a/__tests__/scripts/generate-blog-graphic.test.ts
+++ b/__tests__/scripts/generate-blog-graphic.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { stripFences } from "../../scripts/generate-blog-graphic";
+
+describe("stripFences", () => {
+    it("strips a fenced html block", () => {
+        expect(stripFences('```html\n<div class="artboard"></div>\n```')).toBe(
+            '<div class="artboard"></div>'
+        );
+    });
+
+    it("strips an unlabelled fence", () => {
+        expect(stripFences("```\n<div></div>\n```")).toBe("<div></div>");
+    });
+
+    it("leaves unfenced html alone", () => {
+        expect(stripFences('  <div class="artboard"></div>\n')).toBe(
+            '<div class="artboard"></div>'
+        );
+    });
+
+    it("keeps a fenced code sample inside the markup", () => {
+        const html = '<div class="artboard"><pre>```js</pre></div>';
+        expect(stripFences(html)).toBe(html);
+    });
+});

--- a/scripts/generate-blog-graphic.ts
+++ b/scripts/generate-blog-graphic.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { GoogleGenAI } from "@google/genai";
 import * as fs from "fs";
 import * as path from "path";
 import { chromium } from "playwright";
@@ -19,17 +20,81 @@ async function uploadToCloudinary(file: string, publicId: string): Promise<strin
     return result.secure_url;
 }
 
+export function stripFences(raw: string): string {
+    return raw
+        .replace(/^\s*```(?:html)?\s*\n?/, "")
+        .replace(/\n?```\s*$/, "")
+        .trim();
+}
+
+// The model writes the artboard once; the file it produces is what gets edited
+// and re-rendered from then on. Nothing here touches the render path.
+async function draft(dir: string, name: string, brief: string): Promise<void> {
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+        throw new Error("Missing GEMINI_API_KEY.");
+    }
+
+    const out = path.join(dir, `${name}.html`);
+    if (fs.existsSync(out)) {
+        throw new Error(`${out} already exists. Edit it, or delete it to redraft.`);
+    }
+
+    const brand = fs.readFileSync(path.join(GRAPHICS_DIR, "_brand.css"), "utf-8");
+    const sample = fs.readdirSync(dir).find((f) => f.endsWith(".html"));
+    const example = sample ? fs.readFileSync(path.join(dir, sample), "utf-8") : "";
+
+    const ai = new GoogleGenAI({ apiKey });
+    const response = await ai.models.generateContent({
+        model: "gemini-3.1-pro-preview",
+        contents: `Write one HTML artboard for a Vets Who Code blog graphic.
+
+Brief: ${brief}
+
+These brand tokens are already loaded for you from ../_brand.css:
+
+${brand}
+
+${example ? `An existing artboard in the same set, for house style:\n\n${example}` : ""}
+
+Rules:
+- Output only the HTML. No markdown fences, no commentary, no <html>/<head>/<body>.
+- Start with <link rel="stylesheet" href="../_brand.css" />, then a <style> block, then the markup.
+- The outermost element must be <div class="artboard">. It is 1400x760 and is what gets screenshotted.
+- Colors come from the var(--*) tokens only. Never write a raw hex outside inline SVG strokes.
+- Headings use GothamPro, body copy uses Gilroy. Both are already declared.
+- No images, fonts, or scripts from anywhere else. Inline SVG is fine.
+- Copy must fit at these sizes without clipping or scrolling. Fewer words beats smaller type.`,
+    });
+
+    fs.writeFileSync(out, `${stripFences(response.text ?? "")}\n`);
+    console.log(`drafted ${out}`);
+    console.log(`   review it, then: npm run generate:blog-graphic ${path.basename(dir)} -- --dry`);
+}
+
 async function main() {
     const slug = process.argv[2];
     const dry = process.argv.includes("--dry");
+    const draftAt = process.argv.indexOf("--draft");
 
     if (!slug) {
-        throw new Error("Usage: npm run generate:blog-graphic <slug> [--dry]");
+        throw new Error(
+            "Usage: npm run generate:blog-graphic <slug> [--dry | --draft <name> <brief>]"
+        );
     }
 
     const dir = path.join(GRAPHICS_DIR, slug);
     if (!fs.existsSync(dir)) {
         throw new Error(`No graphics directory: ${dir}`);
+    }
+
+    if (draftAt !== -1) {
+        const [name, brief] = process.argv.slice(draftAt + 1, draftAt + 3);
+        if (!name || !brief) {
+            throw new Error('Usage: --draft <name> "<what the graphic should say>"');
+        }
+        await draft(dir, name, brief);
+        return;
     }
 
     const pages = fs.readdirSync(dir).filter((f) => f.endsWith(".html"));
@@ -69,7 +134,9 @@ async function main() {
     await browser.close();
 }
 
-main().catch((err) => {
-    console.error(err);
-    process.exit(1);
-});
+if (require.main === module) {
+    main().catch((err) => {
+        console.error(err);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

Blog graphics are HTML artboards rendered headless by `generate:blog-graphic`, which made copy edits deterministic — but the first artboard of a set still had to be written by hand. This adds a `--draft` flag that has Gemini write that first file.

The point is that the model's output is a text file, not an image. It stays editable, diffable, and re-renderable, which is the reason these graphics moved off image generation in the first place.

## What changed

- `scripts/generate-blog-graphic.ts` — `--draft <name> "<brief>"` sends Gemini the `_brand.css` tokens plus one existing artboard from the same folder as a house-style sample, and writes the returned HTML to `<slug>/<name>.html`. It stops there; the render and upload path is untouched.
- Refuses to overwrite an existing artboard, so hand edits are never clobbered by a redraft.
- `main()` is now behind `require.main === module`, matching `generate-blog-image.ts`, so the module can be imported by a test.
- `__tests__/scripts/generate-blog-graphic.test.ts` — covers `stripFences`, since the model routinely wraps its output in markdown fences and a fenced code sample inside the markup must survive.

Usage:

```bash
npm run generate:blog-graphic <slug> -- --draft <name> "<what the graphic should say>"
npm run generate:blog-graphic <slug> -- --dry     # review the PNG
npm run generate:blog-graphic <slug>              # render and upload
```

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (22 pre-existing errors on master, none in the touched files)
- [x] `npm test` — 472 passed, including 4 new
- [x] Live end-to-end draft against `10-day-sprint`, rendered with `--dry`: output used only `var(--*)` tokens with no raw hex, GothamPro headings, Gilroy body, correct `.artboard` root, and legible type throughout. Smoke-test artboard deleted afterward.

## Migration / config notes

Uses `GEMINI_API_KEY`, already required by `generate:blog-image` and already documented in `.env.example`. No new environment variables.

## Follow-up

No retry-on-bad-output and no automated validation of the drafted HTML — the `--dry` render is the review step. Worth adding only if drafting ever becomes unattended.