### PR TITLE
perf(donate): Optimize testimonial avatar delivery

### DIFF
--- a/src/containers/donate-form/layout-01/index.tsx
+++ b/src/containers/donate-form/layout-01/index.tsx
@@ -116,8 +116,11 @@ const DonateFormArea = ({ data: { section_title }, space }: TProps) => {
                             </p>
                             <div className="tw-flex tw-items-center">
                                 <img
-                                    src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto,g_auto/v1721082085/josh-morton.jpg"
+                                    src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,dpr_auto,c_thumb,g_face,r_max,w_80,h_80/v1721082085/josh-morton.jpg"
                                     alt="Josh Morton"
+                                    width={40}
+                                    height={40}
+                                    loading="lazy"
                                     className="tw-h-10 tw-w-10 tw-rounded-full tw-object-cover"
                                 />
                                 <div className="tw-ml-3">
@@ -139,8 +142,11 @@ const DonateFormArea = ({ data: { section_title }, space }: TProps) => {
                             </p>
                             <div className="tw-flex tw-items-center">
                                 <img
-                                    src="https://res.cloudinary.com/vetswhocode/image/upload/v1721086509/Image_from_iOS_pdujsr.jpg"
+                                    src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,dpr_auto,c_thumb,g_face,r_max,w_80,h_80/v1721086509/Image_from_iOS_pdujsr.jpg"
                                     alt="Cameron Porter"
+                                    width={40}
+                                    height={40}
+                                    loading="lazy"
                                     className="tw-h-10 tw-w-10 tw-rounded-full tw-object-cover"
                                 />
                                 <div className="tw-ml-3">
@@ -159,8 +165,11 @@ const DonateFormArea = ({ data: { section_title }, space }: TProps) => {
                             </p>
                             <div className="tw-flex tw-items-center">
                                 <img
-                                    src="https://res.cloudinary.com/vetswhocode/image/upload/v1748652090/AB1_6721_towfh2.jpg"
+                                    src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,dpr_auto,c_thumb,g_face,r_max,w_80,h_80/v1748652090/AB1_6721_towfh2.jpg"
                                     alt="Darnell Settles"
+                                    width={40}
+                                    height={40}
+                                    loading="lazy"
                                     className="tw-h-10 tw-w-10 tw-rounded-full tw-object-cover"
                                 />
                                 <div className="tw-ml-3">


### PR DESCRIPTION
## Problem

The three testimonial avatars in `DonateFormArea` were served at full source resolution into a 40px slot.

| Avatar | Bytes served |
| --- | --- |
| `AB1_6721` (Darnell) | 3,843,045 |
| `josh-morton` | 811,330 |
| `Image_from_iOS` (Cameron) | 201,579 |
| **Total** | **4,855,954** |

4.86 MB of image data, on the one page whose job is to load fast enough for someone to finish a donation.

## Solution

Applies the Cloudinary transformation chain specified in the issue:

```
f_auto,q_auto:good,dpr_auto,c_thumb,g_face,r_max,w_80,h_80
```

80px source for a 40px slot keeps it sharp at 2x, `g_face` keeps subjects centred when cropping, and `dpr_auto` serves the right density per device. Also adds explicit `width`/`height` and `loading="lazy"` so the browser reserves the space instead of reflowing when avatars arrive.

| Avatar | Before | After |
| --- | --- | --- |
| `josh-morton` | 811,330 B | 1,829 B |
| `Image_from_iOS` | 201,579 B | 1,875 B |
| `AB1_6721` | 3,843,045 B | 1,566 B |
| **Total** | **4,855,954 B** | **5,270 B** |

**99.9% smaller.** Cards keep `tw-rounded-full` and their existing layout; `r_max` means the crop is already circular, so avatars stay clean even if CSS fails to load.

## Verification

All three transformed URLs return 200 from Cloudinary (sizes above measured from response headers).

| Command | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run lint` | unchanged from master baseline |
| `npm test` | 60 files, 480 tests pass |

Closes #752