### PR TITLE
fix(donate): Add fallback link when Donorbox embed is blocked

### DIFF
--- a/src/components/forms/donate-form.tsx
+++ b/src/components/forms/donate-form.tsx
@@ -73,8 +73,24 @@ const DonateForm = forwardRef<HTMLDivElement, TProps>(({ className }, ref) => {
                             src="https://donorbox.org/embed/vetswhocode-donation?show_content=true&default_interval=o&amount=25&hide_donation_meter=true&compact=true"
                             name="vwc-donorbox"
                             seamless={true}
-                            className="tw-h-[950px] tw-w-full tw-border-none"
+                            className="tw-h-[720px] tw-w-full tw-border-none sm:tw-h-[860px] lg:tw-h-[950px]"
                         />
+                        {/* Content blockers on mobile Safari and Brave block the Donorbox
+                            iframe outright, leaving no way to give. A blocked iframe cannot
+                            be detected reliably across browsers, so this route out is always
+                            rendered rather than shown on a failure we cannot observe. */}
+                        <p className="tw-border-t tw-border-gray-200 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-text-navy/70">
+                            Form not loading?{" "}
+                            <a
+                                href="https://donorbox.org/vetswhocode-donation"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="tw-font-medium tw-text-primary tw-underline"
+                            >
+                                Donate on Donorbox directly
+                            </a>
+                            .
+                        </p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Problem

Reported on iOS Safari and Brave: `/donate` shows no donation form at all. There is no way to give from a phone.

## Root cause

**Not our CSP.** `frame-src` already allows `donorbox.org`:

```
frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://donorbox.org
```

It's content and tracker blocking — on by default in Brave, and common in Safari via content blockers. Those block the `donorbox.org` iframe before it ever loads. Nothing we render *inside* the iframe can fix that.

A blocked iframe also can't be detected reliably across browsers: `onload` and `onerror` both stay silent depending on how the blocker intervenes, so feature-detecting the failure and swapping in a fallback isn't dependable.

## Solution

Stop trying to detect the failure, and always render a way out — a direct link to the hosted Donorbox page beneath the embed. Users whose iframe loads see a quiet one-line fallback; users whose iframe is blocked still have a working path to donate.

Also drops the fixed `tw-h-[950px]` iframe height, which overflowed small viewports, to a responsive `720 / 860 / 950` across `sm` and `lg`.

## Verification

Both URLs return 200:

- `https://donorbox.org/vetswhocode-donation` (fallback target)
- `https://donorbox.org/embed/vetswhocode-donation` (embed)

| Command | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run lint` | 23 errors, identical to master baseline |
| `npm test` | 60 files, 480 tests pass |

### Reviewer note

The fallback is deliberately always visible rather than conditional. If you'd prefer it hidden until failure, that needs a detection method that works under Brave shields and Safari content blockers — I couldn't find one that's reliable.

Closes #842