### PR TITLE
feat(ui): Make the Donate button stand out with a gold treatment

### DIFF
--- a/public/swagger-spec.json
+++ b/public/swagger-spec.json
@@ -237,6 +237,61 @@
           }
         }
       }
+    },
+    "/api/learn/progress": {
+      "get": {
+        "summary": "List the signed-in user's completed interactive lessons",
+        "tags": [
+          "Interactive Lessons"
+        ],
+        "responses": {
+          "200": {
+            "description": "Completed lesson slugs"
+          },
+          "401": {
+            "description": "Not signed in"
+          }
+        }
+      },
+      "post": {
+        "summary": "Mark an interactive lesson complete (or incomplete) for the signed-in user",
+        "tags": [
+          "Interactive Lessons"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "slug"
+                ],
+                "properties": {
+                  "slug": {
+                    "type": "string"
+                  },
+                  "completed": {
+                    "type": "boolean",
+                    "default": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated progress"
+          },
+          "400": {
+            "description": "Unknown or missing lesson slug"
+          },
+          "401": {
+            "description": "Not signed in"
+          }
+        }
+      }
     }
   },
   "tags": []

--- a/src/components/ui/button/index.tsx
+++ b/src/components/ui/button/index.tsx
@@ -6,7 +6,7 @@ interface ButtonProps {
     children: React.ReactNode;
     type?: "button" | "submit" | "reset";
     variant?: "contained" | "outlined" | "texted";
-    color?: "primary" | "light";
+    color?: "primary" | "light" | "gold";
     size?: "xs" | "sm" | "md" | "lg";
     shape?: "tw-rounded" | "square" | "ellipse";
     fullwidth?: boolean;
@@ -106,6 +106,26 @@ const Button = ({
         lightHoverClass,
     ];
 
+    // Gold Button — reserved for Donate. Red carries every other CTA, so the
+    // single most important ask on a nonprofit site gets its own colour rather
+    // than competing with Apply. Navy on gold is 9.1:1, comfortably past AAA.
+    const containedGoldClass =
+        "tw-bg-gold tw-border-gold tw-text-navy tw-shadow-md tw-shadow-gold/30";
+    const containedGoldHoverClass =
+        !disabled &&
+        !active &&
+        hover === "default" &&
+        "hover:tw-bg-gold-rich hover:tw-border-gold-rich hover:tw-text-navy hover:tw-shadow-lg hover:tw-shadow-gold/40 hover:-tw-translate-y-px active:tw-scale-95";
+    const containedGoldActiveClass =
+        !disabled &&
+        active &&
+        "tw-bg-gold-deep tw-border-gold-deep active:tw-bg-gold-deep active:tw-border-gold-deep tw-shadow-xl tw-shadow-gold/40";
+    const containedGoldBtn = color === "gold" && [
+        containedGoldClass,
+        containedGoldHoverClass,
+        containedGoldActiveClass,
+    ];
+
     const outlinedLightClass = "tw-border-white/15 tw-text-white";
     const outlinedLightHoverClass =
         !disabled && !active && hover === "default" && "hover:tw-border-red hover:tw-text-white";
@@ -138,7 +158,7 @@ const Button = ({
     const classnames = clsx(
         variant !== "texted" && baseClass,
         variant !== "texted" && baseNotFullWidthClass,
-        variant === "contained" && [containedPrimaryBtn, containedLightBtn],
+        variant === "contained" && [containedPrimaryBtn, containedLightBtn, containedGoldBtn],
         variant === "outlined" && [outlinedPrimaryBtn, outlinedLightBtn],
         !iconButton && variant !== "texted" && [mdBtn, smBtn, xsBtn],
         sharpEdges,

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -61,11 +61,8 @@ const Header = ({ shadow, fluid }: TProps) => {
                                 </div>
                             </>
                         )}
-                        <Button
-                            size="sm"
-                            path="/donate"
-                            className="tw-shadow-lg tw-shadow-primary/25"
-                        >
+                        <Button size="sm" color="gold" path="/donate" className="tw-gap-2">
+                            <i className="fas fa-heart tw-text-[13px]" aria-hidden="true" />
                             Donate
                         </Button>
                     </div>


### PR DESCRIPTION
## Problem

> "Our current donate button doesn't stand out on our nonprofit website."

It didn't stand out because it looked like everything else. It used `color="primary"` — the same red every other CTA on the site uses — so the single most important ask on a nonprofit homepage competed with Apply and every other button instead of leading them.

## Solution

Adds **gold as a real `Button` color**, rather than overriding styles at the usage site.

That distinction matters: `Button` composes with `clsx`, not `tailwind-merge`. A `className` override would leave *both* `tw-bg-primary` and the override in the class list and let CSS source order pick the winner — which breaks silently whenever the stylesheet is regenerated in a different order.

Gold is already in the brand palette as the highlight color and was unused on CTAs, so Donate now owns it and reads as distinct at a glance.

### Contrast

| Combination | Ratio | Standard |
| --- | --- | --- |
| navy on `gold` FDB330 | **9.10:1** | AAA (needs 7) |
| navy on `gold-rich` DBB42C (hover) | **8.25:1** | AAA |

Both comfortably past AAA for normal text, where AA needs 4.5.

### Brand compliance

Keeps the uppercase, sharp-edged, GothamPro treatment and the literal word **"Donate"** per the brand guide — not softened to "Support us" or "Give". Gains a heart icon so it reads as a donation rather than a generic action.

## Verification

`tw-bg-gold` compiles to `rgb(253 179 48)` in the built CSS, with its hover and shadow variants present.

| Command | Result |
| --- | --- |
| `npm run typecheck` | pass |
| `npm run lint` | 23 errors, identical to master baseline |
| `npm test` | 60 files, 480 tests pass |
| `npm run build` | pass, 300 static pages |

### Reviewer note

`color="gold"` is now available to any `Button`. I've applied it only to the header Donate CTA — the value comes from it staying scarce. Worth agreeing it's reserved for Donate before it spreads.

Closes #538