### PR TITLE
feat(team): Rebuild the team page as leadership plus board roster

### DIFF
--- a/__tests__/pages/team.tests.tsx
+++ b/__tests__/pages/team.tests.tsx
@@ -1,0 +1,71 @@
+import boardMembers from "@data/board-members.json";
+import teamMembers from "@data/team-members.json";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { IInstructor } from "@utils/types";
+import Team from "@/pages/team";
+
+vi.mock("@components/seo/page-seo", () => ({
+    default: () => <div data-testid="seo" />,
+}));
+
+vi.mock("@layout/layout-01", () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="layout">{children}</div>
+    ),
+}));
+
+const data = {
+    teamMembers: teamMembers as IInstructor[],
+    boardMembers: boardMembers as IInstructor[],
+};
+
+const renderPage = () => render(<Team data={data} />);
+
+describe("Team page", () => {
+    it("renders every staff and board member", () => {
+        renderPage();
+        for (const member of [...data.teamMembers, ...data.boardMembers]) {
+            expect(screen.getByText(member.name)).toBeInTheDocument();
+        }
+    });
+
+    it("links each person to their profile page", () => {
+        renderPage();
+        for (const member of [...data.teamMembers, ...data.boardMembers]) {
+            const link = screen.getByTitle(`View ${member.name}'s profile`);
+            expect(link).toHaveAttribute("href", `/team/${member.slug}`);
+        }
+    });
+
+    it("shows zero-padded counts derived from the data", () => {
+        renderPage();
+        const pad = (n: number) => String(n).padStart(2, "0");
+        expect(screen.getByText(`${pad(data.teamMembers.length)} Staff`)).toBeInTheDocument();
+        expect(screen.getByText(`${pad(data.boardMembers.length)} Board`)).toBeInTheDocument();
+    });
+
+    it("falls back to the placeholder photo once, without looping", () => {
+        const { container } = renderPage();
+        const photo = container.querySelector("img") as HTMLImageElement;
+
+        fireEvent.error(photo);
+        expect(photo.getAttribute("src")).toBe("/images/profile/placeholder-profile.jpg");
+
+        // A failing placeholder must not re-trigger the swap.
+        photo.setAttribute("src", "/images/profile/placeholder-profile.jpg");
+        fireEvent.error(photo);
+        expect(photo.getAttribute("src")).toBe("/images/profile/placeholder-profile.jpg");
+    });
+
+    it("gives each card a single accessible name", () => {
+        renderPage();
+        const link = screen.getByTitle(`View ${data.teamMembers[0].name}'s profile`);
+        expect(link.querySelector("img")).toHaveAttribute("alt", "");
+    });
+
+    it("shows staff roles but omits the redundant board role line", () => {
+        renderPage();
+        expect(screen.getByText(data.teamMembers[0].designation)).toBeInTheDocument();
+        expect(screen.queryByText("Board Member")).not.toBeInTheDocument();
+    });
+});

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -1,9 +1,9 @@
-import Breadcrumb from "@components/breadcrumb";
+import SectionTitle from "@components/section-title";
 import SEO from "@components/seo/page-seo";
-import TeamCard from "@components/team-card";
 import boardMembers from "@data/board-members.json";
 import teamMembers from "@data/team-members.json";
 import Layout from "@layout/layout-01";
+import Anchor from "@ui/anchor";
 import { IInstructor } from "@utils/types";
 import type { GetStaticProps, NextPage } from "next";
 
@@ -18,100 +18,163 @@ type PageWithLayout = NextPage<TProps> & {
     Layout: typeof Layout;
 };
 
+// The design system exposes the mono stack as a CSS var, not a Tailwind token —
+// same approach SectionTitle uses for its eyebrow.
+const mono = { fontFamily: "var(--font-mono)", letterSpacing: "0.1em" } as const;
+
+// The context-bar counts are zero-padded array lengths, so they self-correct
+// whenever the JSON gains or loses a person.
+const pad = (n: number) => String(n).padStart(2, "0");
+
+const fallbackPhoto = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const target = e.currentTarget;
+    // React attaches the error listener itself, so nulling onerror would not disarm
+    // it — flag the element so a failing placeholder can't spin in a request loop.
+    if (target.dataset.fallback) return;
+    target.dataset.fallback = "1";
+    target.src = "/images/profile/placeholder-profile.jpg";
+};
+
 const Team: PageWithLayout = ({ data }) => {
     return (
         <>
             <SEO title="Team | Vets Who Code" />
-            <h1 className="tw-sr-only">Our Team</h1>
 
-            {/* Custom Hero Area with original size */}
-            <div className="tw-relative tw-z-1 tw-overflow-hidden tw-bg-cream">
-                <div className="tw-relative tw-z-1 tw-flex tw-h-[450px] tw-w-full tw-items-end md:tw-h-[500px] lg:tw-h-[600px] xl:tw-h-[700px]">
-                    <div className="tw-absolute tw-inset-0 tw-object-cover">
-                        <img
-                            src="https://res.cloudinary.com/vetswhocode/image/upload/v1746583132/14_ogbakk.png"
-                            alt="Vets Who Code Team"
-                            className="tw-h-full tw-w-full tw-object-cover"
+            {/* Hero — navy gradient, no photo */}
+            <section className="tw-relative tw-bg-secondary">
+                <div className="tw-absolute tw-inset-0 tw-bg-[linear-gradient(135deg,rgba(9,31,64,0.92)_0%,rgba(6,26,64,0.88)_100%)]" />
+                <div className="tw-container tw-relative tw-px-[clamp(20px,4vw,32px)] tw-pb-[clamp(56px,8vw,110px)] tw-pt-[clamp(72px,11vw,150px)]">
+                    <span
+                        style={mono}
+                        className="tw-inline-flex tw-items-center tw-gap-3 tw-text-[12px] tw-font-medium tw-uppercase tw-text-[rgba(185,214,242,0.7)]"
+                    >
+                        <span className="tw-inline-block tw-h-0.5 tw-w-4 tw-shrink-0 tw-bg-primary" />
+                        About / Our Team
+                    </span>
+                    <h1 className="tw-mt-5 tw-font-heading tw-text-[clamp(44px,8vw,92px)] tw-font-black tw-uppercase tw-leading-[0.98] tw-tracking-[-0.02em] tw-text-white">
+                        Our Team
+                    </h1>
+                    <p className="tw-mt-5 tw-max-w-[560px] tw-text-[clamp(17px,2vw,21px)] tw-leading-[1.6] tw-text-gray-50">
+                        Meet the people behind #VetsWhoCode
+                    </p>
+                </div>
+            </section>
+
+            {/* Context bar — breadcrumb + team scale */}
+            <div className="tw-border-b tw-border-gray-100 tw-bg-gray-50">
+                <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-4 tw-px-[clamp(20px,4vw,32px)] tw-py-4">
+                    <nav
+                        aria-label="Breadcrumb"
+                        style={mono}
+                        className="tw-flex tw-shrink-0 tw-items-center tw-gap-2.5 tw-whitespace-nowrap tw-text-[11px] tw-uppercase tw-text-gray-200"
+                    >
+                        <Anchor path="/" className="tw-text-secondary">
+                            Home
+                        </Anchor>
+                        <span aria-hidden="true" className="tw-text-gray-100">
+                            /
+                        </span>
+                        <span aria-current="page">Our Team</span>
+                    </nav>
+                    <div
+                        style={mono}
+                        className="tw-flex tw-shrink-0 tw-items-center tw-gap-3.5 tw-whitespace-nowrap tw-text-[11px] tw-uppercase tw-text-gray-200"
+                    >
+                        <span>{pad(data.teamMembers.length)} Staff</span>
+                        <span
+                            aria-hidden="true"
+                            className="tw-inline-block tw-h-px tw-w-4 tw-shrink-0 tw-bg-primary"
                         />
-                        <div className="tw-absolute tw-inset-0 tw-bg-[rgba(9,31,64,0.3)]" />
-                    </div>
-
-                    {/* Text Overlay */}
-                    <div className="tw-container tw-relative tw-z-1 tw-flex tw-h-full tw-items-center tw-justify-center tw-pt-16">
-                        <div className="tw-text-center">
-                            <h2 className="tw-text-5xl tw-font-bold tw-uppercase tw-tracking-wider tw-text-white tw-drop-shadow-lg md:tw-text-6xl lg:tw-text-7xl">
-                                Our Team
-                            </h2>
-                            <p className="tw-mt-4 tw-text-lg tw-font-light tw-tracking-wide tw-text-white tw-drop-shadow-md md:tw-text-xl lg:tw-text-2xl">
-                                Meet the people behind #VetsWhoCode
-                            </p>
-                        </div>
+                        <span>{pad(data.boardMembers.length)} Board</span>
                     </div>
                 </div>
             </div>
 
-            <Breadcrumb pages={[{ path: "/", label: "Home" }]} currentPage="Our Team" />
-            <div className="tw-container tw-py-15 md:tw-py-20 lg:tw-py-[100px]">
-                <div className="tw-text-center">
-                    <h2 className="tw-text-3xl tw-font-bold">Team Members</h2>
-                </div>
-                <div className="tw-mx-auto tw-mt-10 tw-grid tw-max-w-4xl tw-grid-cols-1 tw-gap-7.5 md:tw-grid-cols-2 lg:tw-grid-cols-2">
-                    {data.teamMembers.map((member) => {
-                        const memberWithSafeSocials = {
-                            ...member,
-                            socials: Array.isArray(member.socials) ? member.socials : [],
-                        };
-
-                        return (
-                            <div key={member.slug} className="tw-group">
-                                <a
-                                    href={`/team/${member.slug}`}
-                                    aria-label={`View ${member.name}'s profile`}
-                                    title={`View ${member.name}'s profile`}
-                                    className="tw-block"
-                                >
-                                    <TeamCard
-                                        name={member.name}
-                                        designation={member.designation}
-                                        image={member.image}
-                                        socials={memberWithSafeSocials.socials}
+            {/* Team Members — two feature cards */}
+            <section className="tw-bg-cream tw-py-[clamp(64px,9vw,120px)]">
+                <div className="tw-container tw-px-[clamp(20px,4vw,32px)]">
+                    <SectionTitle
+                        align="left"
+                        subtitle="01 / Leadership"
+                        title="Team Members"
+                        description="The staff running the accelerator day to day."
+                    />
+                    <div className="tw-mt-[clamp(32px,4vw,56px)] tw-grid tw-grid-cols-[repeat(auto-fit,minmax(min(100%,320px),1fr))] tw-gap-[30px]">
+                        {data.teamMembers.map((member) => (
+                            <Anchor
+                                key={member.slug}
+                                path={`/team/${member.slug}`}
+                                title={`View ${member.name}'s profile`}
+                                className="tw-group tw-block tw-border tw-border-t-2 tw-border-gray-100 tw-bg-white tw-transition-[transform,box-shadow,border-color] tw-duration-300 tw-ease-[cubic-bezier(0.3,0.2,0.3,0.3)] hover:tw--translate-y-0.5 hover:tw-border-t-primary hover:tw-shadow-[0_10px_30px_rgba(0,0,0,0.18)]"
+                            >
+                                <div className="tw-aspect-[35/34] tw-overflow-hidden tw-bg-secondary">
+                                    <img
+                                        src={member.image?.src}
+                                        alt=""
+                                        loading="lazy"
+                                        onError={fallbackPhoto}
+                                        className="tw-h-full tw-w-full tw-object-cover tw-object-top tw-grayscale tw-transition-[filter,transform] tw-duration-1000 tw-ease-out group-hover:tw-scale-105 group-hover:tw-grayscale-0"
                                     />
-                                </a>
-                            </div>
-                        );
-                    })}
+                                </div>
+                                <div className="tw-flex tw-flex-col tw-gap-2 tw-px-[30px] tw-pb-[30px] tw-pt-[26px]">
+                                    <h3 className="tw-m-0 tw-font-heading tw-text-[clamp(20px,2.4vw,26px)] tw-font-bold tw-uppercase tw-leading-[1.15] tw-tracking-[-0.02em] tw-text-secondary">
+                                        {member.name}
+                                    </h3>
+                                    <p
+                                        style={mono}
+                                        className="tw-m-0 tw-text-[12px] tw-font-medium tw-uppercase tw-text-primary"
+                                    >
+                                        {member.designation}
+                                    </p>
+                                </div>
+                            </Anchor>
+                        ))}
+                    </div>
                 </div>
-                <div className="tw-mt-20 tw-text-center">
-                    <h2 className="tw-text-3xl tw-font-bold">Board Members</h2>
-                </div>
-                <div className="tw-mx-auto tw-mt-10 tw-grid tw-max-w-4xl tw-grid-cols-1 tw-gap-7.5 md:tw-grid-cols-2 lg:tw-grid-cols-2">
-                    {data.boardMembers.map((member) => {
-                        // Ensure member.socials is defined and is an array
-                        const memberWithSafeSocials = {
-                            ...member,
-                            socials: Array.isArray(member.socials) ? member.socials : [],
-                        };
+            </section>
 
-                        return (
-                            <div key={member.slug} className="tw-group">
-                                <a
-                                    href={`/team/${member.slug}`}
-                                    aria-label={`View ${member.name}'s profile`}
-                                    title={`View ${member.name}'s profile`}
-                                    className="tw-block"
-                                >
-                                    <TeamCard
-                                        name={member.name}
-                                        designation={member.designation}
-                                        image={member.image}
-                                        socials={memberWithSafeSocials.socials}
+            {/* Board Members — compact roster */}
+            <section className="tw-bg-white tw-py-[clamp(64px,9vw,120px)]">
+                <div className="tw-container tw-px-[clamp(20px,4vw,32px)]">
+                    <SectionTitle
+                        align="left"
+                        subtitle="02 / Governance"
+                        title="Board Members"
+                        description="Engineering, security, media, and veteran-service leaders who govern the organization."
+                    />
+
+                    {/* Section divider with the red signature segment at its left edge */}
+                    <div className="tw-relative tw-my-[clamp(32px,4vw,48px)] tw-h-px tw-bg-gray-100">
+                        <span className="tw-absolute tw-left-0 tw-top-0 tw-h-px tw-w-12 tw-bg-primary" />
+                    </div>
+
+                    <div className="tw-grid tw-grid-cols-[repeat(auto-fill,minmax(min(100%,200px),1fr))] tw-gap-6">
+                        {data.boardMembers.map((member) => (
+                            <Anchor
+                                key={member.slug}
+                                path={`/team/${member.slug}`}
+                                title={`View ${member.name}'s profile`}
+                                className="tw-group tw-block tw-border-t-2 tw-border-transparent tw-pt-[14px] tw-transition-[transform,border-color] tw-duration-300 tw-ease-[cubic-bezier(0.3,0.2,0.3,0.3)] hover:tw--translate-y-0.5 hover:tw-border-t-primary"
+                            >
+                                <div className="tw-aspect-square tw-overflow-hidden tw-bg-secondary">
+                                    <img
+                                        src={member.image?.src}
+                                        alt=""
+                                        loading="lazy"
+                                        onError={fallbackPhoto}
+                                        className="tw-h-full tw-w-full tw-object-cover tw-object-top tw-grayscale tw-transition-[filter,transform] tw-duration-1000 tw-ease-out group-hover:tw-scale-105 group-hover:tw-grayscale-0"
                                     />
-                                </a>
-                            </div>
-                        );
-                    })}
+                                </div>
+                                {/* Role omitted: every board entry is "Board Member", which the
+                                    section heading already says. Restore it if titles differentiate. */}
+                                <h3 className="tw-mt-4 tw-font-heading tw-text-[17px] tw-font-bold tw-normal-case tw-leading-[1.25] tw-tracking-[-0.01em] tw-text-secondary">
+                                    {member.name}
+                                </h3>
+                            </Anchor>
+                        ))}
+                    </div>
                 </div>
-            </div>
+            </section>
         </>
     );
 };


### PR DESCRIPTION
## Summary

The team page ran a photo hero over two identical 2-up card grids, so the 13 board members competed with the 2 staff for visual weight. This rebuilds it per the design handoff: a navy gradient hero, a mono context bar, two feature cards for staff, and a compact board roster. Information architecture is unchanged — staff and board, name and role only, each person still links to their existing `/team/[slug]` profile.

## What changed

- `src/pages/team.tsx` — full rewrite. Navy gradient hero (photo hero removed), mono context bar carrying the breadcrumb and zero-padded counts, staff feature cards on cream, 5-up board roster on white with the red section-divider signature.
- Board tiles drop the role line. Every board entry reads "Board Member", which the section heading already says. Restore it if titles ever differentiate (Chair, Treasurer).
- Cards are built in the page rather than in `TeamCard`. `containers/team/layout-02` still uses that component unchanged, and this design needs neither its social overlay nor its fixed 350x430 frame.
- Photos are `alt=""` — decorative, since the name sits in the adjacent `h3`. Prevents each card's accessible name from doubling the person's name.
- The counts sit outside the `<nav aria-label="Breadcrumb">` landmark so they aren't announced as part of the breadcrumb trail.
- Photo fallback guards with a `data-` flag rather than `onerror = null`, which does not disarm React's own error listener.
- `__tests__/pages/team.tests.tsx` — new. Covers roster completeness, profile links, derived counts, the hidden board role line, the single-shot photo fallback, and empty alt text.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` — 0 new errors. Adds 2 `noNoninteractiveElementInteractions` warnings, matching the pattern `src/components/team-card/index.tsx` already has.
- [x] `npm test` — 486 passing
- [x] `npm run build` — `/team` and all 15 `/team/[slug]` pages generate
- [x] Browser check on the golden path: hero, context bar, staff cards, board roster, hover states
- [x] Accessibility verified in the live DOM: one `h1`, breadcrumb landmark contains only the trail, each card resolves to a single accessible name, all 15 photo alts empty
- [x] Palette and radius audited — brand tokens only, zero radius throughout

## Screenshots / recordings

Screenshots attached below.

## Follow-up

- Mobile rendering was not visually verified — the browser resize did not take effect on the rendering viewport. Both grids use `minmax(min(100%, X), 1fr)`, which is the standard no-overflow guarantee, and no horizontal overflow was observed at desktop.
- The handoff notes the live page shows 14 board members while `board-members.json` has 13. The counts derive from array length, so they self-correct; the missing person still needs reconciling.
- The handoff claims the page needs its own `prefers-reduced-motion` and focus-ring styles. Both already exist globally in `src/assets/css/globals.css` (lines 519 and 535), so no page-level CSS was added.