### PR TITLE
fix(alumni): Reword the alumni strip eyebrow to Where Our Alumni Code

### DIFF
--- a/src/components/ui/alumni-strip/index.tsx
+++ b/src/components/ui/alumni-strip/index.tsx
@@ -36,7 +36,7 @@ const palette: Record<Theme, { eyebrow: string; name: string; divider: string }>
 };
 
 const AlumniStrip = ({
-    eyebrow = "Where Our Alumni Engineer",
+    eyebrow = "Where Our Alumni Code",
     companies = DEFAULT_COMPANIES,
     className,
     align = "left",

--- a/src/containers/about/alumni.tsx
+++ b/src/containers/about/alumni.tsx
@@ -45,7 +45,7 @@ const Alumni = () => {
                                 aria-hidden="true"
                                 className="tw-inline-block tw-h-[2px] tw-w-4 tw-bg-red"
                             />
-                            Where Our Alumni Engineer
+                            Where Our Alumni Code
                         </span>
                         <h2
                             id="about-alumni-headline"


### PR DESCRIPTION
## Summary

The alumni strip eyebrow read "Where Our Alumni Engineer", which uses "engineer" as a verb in a phrase that scans as a noun. Reworded to "Where Our Alumni Code".

Before: `WHERE OUR ALUMNI ENGINEER`
After: `WHERE OUR ALUMNI CODE`

Kept "Our Alumni" as the explicit subject rather than shortening to "Where They Code" — on `/` and `/apply` the eyebrow sits directly above a bare company row, with no preceding sentence for a pronoun to refer back to.

## What changed

- `src/components/ui/alumni-strip/index.tsx` — the default `eyebrow` prop. It's never overridden, so this covers `/` and `/apply`.
- `src/containers/about/alumni.tsx` — the same string, hardcoded, on `/about`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` — no new findings on the changed files
- [x] `npm test` — 480 passing
- [x] Confirmed both call sites; `AlumniStrip` renders on `/` and `/apply` and never overrides the eyebrow

No build run — copy-only, nothing routing, API, Prisma, or config related. No screenshot attached; the change is the three words quoted above.