### PR TITLE
fix(csp): Allow the donate logo hosts in connect-src

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -80,7 +80,12 @@ const nextConfig = {
                             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://pro.fontawesome.com",
                             "img-src 'self' data: blob: https://res.cloudinary.com https://avatars.githubusercontent.com https://github.githubassets.com https://www.paypalobjects.com https://cdn.shopify.com https://*.myshopify.com https://cdn.jsdelivr.net https://widgets.guidestar.org https://maps.googleapis.com https://maps.gstatic.com https://*.googleapis.com https://images.huffingtonpost.com https://images.ctfassets.net https://www.hackerrank.com https://*.businessinsider.com https://i.insider.com https://cdn.sstatic.net https://i.stack.imgur.com https://stackoverflow.blog https://cdn.stackoverflow.co",
                             "font-src 'self' data: https://fonts.gstatic.com https://pro.fontawesome.com",
-                            "connect-src 'self' https://www.clarity.ms https://vitals.vercel-insights.com https://github.com https://api.github.com https://hashflagswag.myshopify.com https://res.cloudinary.com https://widgets.guidestar.org https://www.google-analytics.com https://maps.googleapis.com https://cdn.jsdelivr.net https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co",
+                            // These headers apply to /sw.js too, and a service worker's own
+                            // fetch() is governed by connect-src, not img-src. next-pwa's
+                            // runtime caching intercepts every cross-origin image, so any
+                            // host listed in img-src also needs to be here or the image
+                            // silently fails to load for anyone with the SW registered.
+                            "connect-src 'self' https://www.clarity.ms https://vitals.vercel-insights.com https://github.com https://api.github.com https://github.githubassets.com https://www.paypalobjects.com https://hashflagswag.myshopify.com https://res.cloudinary.com https://widgets.guidestar.org https://www.google-analytics.com https://maps.googleapis.com https://cdn.jsdelivr.net https://huggingface.co https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.huggingface.co",
                             "worker-src 'self' https://cdn.jsdelivr.net",
                             "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://donorbox.org",
                             "media-src 'self' https://res.cloudinary.com",


### PR DESCRIPTION
## Summary

The GitHub Sponsors and PayPal logos on `/donate` render blank for every visitor with the service worker registered. Adding both hosts to `connect-src` fixes it.

## Root cause

These security headers apply to `/sw.js` as well as to pages, and a service worker's own `fetch()` is governed by **`connect-src`, not `img-src`**. next-pwa's default runtime caching intercepts every cross-origin image, so on the deployed site the service worker — not the browser — loads these logos. `connect-src` listed neither host, so both requests were blocked.

`https://res.cloudinary.com` happens to be in both directives (the app calls its API), which is why every other remote image on the page kept working and masked the problem.

Evidence gathered against production:

| Context | Service worker | Governed by | Result |
|---|---|---|---|
| Incognito | none | `img-src` | loads |
| Local production build | not registered | `img-src` | loads |
| `curl` | n/a | no CSP | 200 |
| Live site | active | `connect-src` | **blocked** |

Both URLs return 200 with correct content types, and both were already present in `img-src` — the markup and the CDNs were never the problem. A hard refresh makes the logos appear because it bypasses the service worker, which is why this looked intermittent.

## What changed

- `next.config.js` — added `https://github.githubassets.com` and `https://www.paypalobjects.com` to `connect-src`, with a comment recording why image hosts have to appear in this directive.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build` — config change, 300 static pages generate
- [x] Asserted against the CSP the built config actually emits: both hosts present in `connect-src`
- [ ] Verify on the deploy preview with a normal reload (not a hard refresh) that both logos render on `/donate`

## Follow-up

- Fourteen other hosts are in `img-src` but absent from `connect-src` and carry the same latent failure: `avatars.githubusercontent.com`, `cdn.shopify.com`, `*.myshopify.com`, `maps.gstatic.com`, `*.googleapis.com`, `images.huffingtonpost.com`, `images.ctfassets.net`, `www.hackerrank.com`, `*.businessinsider.com`, `i.insider.com`, `cdn.sstatic.net`, `i.stack.imgur.com`, `stackoverflow.blog`, `cdn.stackoverflow.co`. None is visibly broken today, so they're left out of this diff — but any remote image added to the site needs both directives or it silently disappears for service-worker visitors.
- Benevity and Brightfunds on `/donate` still have no logo at all. Both publish 256px icons on their own CDN; the plan is to self-host them on Cloudinary rather than add two more hosts to the CSP.