### PR TITLE
feat(donate): Add Benevity and Brightfunds logos to the giving cards

### DIFF
--- a/src/data/innerpages/donate.json
+++ b/src/data/innerpages/donate.json
@@ -46,14 +46,26 @@
                     "title": "Benevity",
                     "description": "If your employer matches donations through Benevity, you can direct your match and your workplace giving to us.",
                     "path": "https://causes.benevity.org/causes/840-862122804",
-                    "pathText": "Find VWC on Benevity"
+                    "pathText": "Find VWC on Benevity",
+                    "images": [
+                        {
+                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1788883799/donate-logos/benevity.svg",
+                            "alt": "Benevity"
+                        }
+                    ]
                 },
                 {
                     "id": 4,
                     "title": "Brightfunds",
                     "description": "Another corporate giving route. Brightfunds makes it simple for your company and its employees to donate together.",
                     "path": "https://www.brightfunds.org/organizations/vets-who-code-inc",
-                    "pathText": "Donate on Brightfunds"
+                    "pathText": "Donate on Brightfunds",
+                    "images": [
+                        {
+                            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1788883800/donate-logos/brightfunds.svg",
+                            "alt": "Brightfunds"
+                        }
+                    ]
                 }
             ]
         }


### PR DESCRIPTION
## Summary

The Benevity and Brightfunds cards on `/donate` had no logo at all, so both fell back to a text wordmark and the giving row read unevenly next to GitHub Sponsors and PayPal. Both logos are now self-hosted on Cloudinary and wired into the card data.

## What changed

- `src/data/innerpages/donate.json` — added an `images` block to the Benevity and Brightfunds items. Data-only; `src/containers/ways-to-give/index.tsx` already renders `item.images[0]` and falls back to a wordmark when it's absent.

New Cloudinary assets under `donate-logos/`:

| Asset | Source | Size |
|---|---|---|
| `benevity.svg` | Benevity brand mark | 256x256 |
| `brightfunds.svg` | BrightFunds wordmark | 1000x181 |

## Notes

**Self-hosted, not hotlinked.** `res.cloudinary.com` is already in both `img-src` and `connect-src`, so these render correctly through the service worker. Hotlinking would have reproduced the exact bug #1288 fixes for the GitHub and PayPal logos.

**Benevity's own page is a trap worth documenting.** It serves a row of `Logo-1.svg` through `Logo-8.svg` on its own CDN, and those are *client* logos — Levi's, Merck, Prudential, Visa, Starbucks, UPS. The asset used here is Benevity's brand mark from their favicon set, confirmed by alt text before download.

**Mismatched shapes are intentional.** Benevity publishes no wordmark I could find, so its card carries a square icon while Brightfunds carries a wordmark. In a 40px row with `object-contain object-left` this reads fine, since every card has its name directly below.

## Test plan

- [x] `npm test` — 480 passing
- [x] `npm run typecheck`
- [x] Verified in the browser on `/donate`: all four cards render their logo, no fallback wordmarks remain
- [ ] Confirm on the deploy preview

## Screenshots / recordings

Screenshot of the four giving cards attached.