### PR TITLE
feat(programs): Rebuild the programs page as a three-program hub

### DIFF
--- a/__tests__/pages/programs.tests.tsx
+++ b/__tests__/pages/programs.tests.tsx
@@ -1,0 +1,66 @@
+import { render, screen, within } from "@testing-library/react";
+import Programs, { getStaticProps } from "@/pages/programs";
+
+vi.mock("@components/seo/page-seo", () => ({
+    default: () => <div data-testid="seo" />,
+}));
+
+vi.mock("@layout/layout-01", () => ({
+    default: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="layout">{children}</div>
+    ),
+}));
+
+vi.mock("next/image", () => ({
+    default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+const renderPage = () => render(<Programs data={{ factoryStatus: "Booking Q4 2026 · Q1 2027" }} />);
+
+describe("Programs hub page", () => {
+    it("links each program card to its detail page", () => {
+        renderPage();
+        const expected = [
+            ["View the Accelerator", "/programs/accelerator"],
+            ["View Mentorship", "/programs/mentorship"],
+            ["View the Factory", "/programs/software-factory"],
+        ];
+        for (const [label, href] of expected) {
+            expect(screen.getByText(label).closest("a")).toHaveAttribute("href", href);
+        }
+    });
+
+    it("routes each of the four audiences to its own destination", () => {
+        renderPage();
+        const expected = [
+            ["Apply now →", "/apply"],
+            ["Talk to us →", "/jobs"],
+            ["Volunteer →", "/mentor"],
+            ["Ways to give →", "/donate"],
+        ];
+        for (const [label, href] of expected) {
+            expect(screen.getByText(label).closest("a")).toHaveAttribute("href", href);
+        }
+    });
+
+    it("renders the comparison as a real table with row and column headers", () => {
+        renderPage();
+        const table = screen.getByRole("table");
+        expect(within(table).getAllByRole("columnheader")).toHaveLength(5);
+        expect(within(table).getAllByRole("rowheader")).toHaveLength(3);
+    });
+
+    it("title-cases the Software Factory status read from HERO_META", async () => {
+        // HERO_META stores it upper-cased. A naive toLowerCase yields "q4"/"q1",
+        // so this guards the per-word casing rather than the rendered string alone.
+        const result = (await getStaticProps({} as never)) as {
+            props: { data: { factoryStatus: string } };
+        };
+        expect(result.props.data.factoryStatus).toBe("Booking Q4 2026 · Q1 2027");
+    });
+
+    it("has exactly one h1", () => {
+        renderPage();
+        expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    });
+});

--- a/src/containers/software-factory/cta/index.tsx
+++ b/src/containers/software-factory/cta/index.tsx
@@ -124,7 +124,7 @@ const CtaSection = () => {
                             up. If we&rsquo;re not, we&rsquo;ll tell you who is.
                         </p>
                         <ul className={styles.bullets}>
-                            <li>· Currently booking Q3 2026</li>
+                            <li>· Currently booking Q4 2026 and Q1 2027</li>
                             <li>· 2 squads available</li>
                             <li>· Average response time: 1 business day</li>
                         </ul>

--- a/src/data/software-factory.ts
+++ b/src/data/software-factory.ts
@@ -271,6 +271,6 @@ export const HERO_META: Array<[string, string]> = [
     ["UNIT", "VWC SOFTWARE FACTORY"],
     ["ESTABLISHED", "2014 · FACTORY 2022"],
     ["CO", "JEROME HARDAWAY · USAF"],
-    ["STATUS", "BOOKING Q3 2026"],
+    ["STATUS", "BOOKING Q4 2026 · Q1 2027"],
     ["POSTURE", "1 FIRE TEAM · 2 ENGINEERS AVAILABLE"],
 ];

--- a/src/pages/programs.tsx
+++ b/src/pages/programs.tsx
@@ -1,22 +1,15 @@
-import ProgramCard from "@components/program-card";
 import SEO from "@components/seo/page-seo";
 import { MonoMeta, SectionEyebrow, SharpHeadline } from "@components/ui/design-system";
-import HeroArea from "@containers/hero/layout-07";
+import { HERO_META } from "@data/software-factory";
 import Layout from "@layout/layout-01";
-import { GetStaticProps, NextPage } from "next";
-
-import { getAllMediaPosts } from "../lib/mdx-pages";
-
-type Program = {
-    slug: string;
-    title: string;
-    description: string;
-};
+import Anchor from "@ui/anchor";
+import Button from "@ui/button";
+import type { GetStaticProps, NextPage } from "next";
+import Image from "next/image";
 
 type TProps = {
-    allPrograms: Program[];
-    page: {
-        title: string;
+    data: {
+        factoryStatus: string;
     };
 };
 
@@ -24,78 +17,506 @@ type PageWithLayout = NextPage<TProps> & {
     Layout: typeof Layout;
 };
 
-const heroData = {
-    items: [
-        {
-            id: 1,
-            images: [
-                {
-                    src: "https://res.cloudinary.com/vetswhocode/image/upload/v1746590043/9_ahefah.png",
-                },
-            ],
-            headings: [
-                { id: 1, content: "Our Programs" },
-                { id: 2, content: "What we do to be the tech arm of veteran support" },
-            ],
-            texts: [],
-        },
-    ],
+// 2% fractal noise, the same grain the navy sections use elsewhere. Inline data URI
+// so it costs no request.
+const GRAIN =
+    "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")";
+
+const grainLayer = { backgroundImage: GRAIN, opacity: 0.02 } as const;
+
+const HERO_FACTS: Array<[string, string, boolean?]> = [
+    ["Founded", "2014"],
+    ["Cost to Troops", "$0 · Always"],
+    ["Format", "Remote-first"],
+    ["Status", "Accepting Applications", true],
+];
+
+const COMPARISON = [
+    {
+        program: "Accelerator",
+        who: "Veterans and spouses changing careers into software engineering",
+        length: "17 weeks",
+        cost: "$0",
+        outcome: "Software engineer with a verified body of work",
+    },
+    {
+        program: "Mentorship",
+        who: "Anyone already building who needs a second set of eyes",
+        length: "6 months",
+        cost: "$0",
+        outcome: "A working plan and someone who holds you to it",
+    },
+    {
+        program: "Software Factory",
+        who: "Organizations that need software built, and troops who want paid reps",
+        length: "Per engagement",
+        cost: "$10–50k",
+        outcome: "Deployed software, documentation, 30-day warranty",
+    },
+];
+
+type ProgramCard = {
+    number: string;
+    kicker: string;
+    title: string;
+    description: string;
+    specs: Array<[string, string]>;
+    cta: string;
+    path: string;
+    image: string;
+    alt: string;
 };
 
-const ProgramsPage: PageWithLayout = ({ allPrograms, page }) => {
+const buildPrograms = (factoryStatus: string): ProgramCard[] => [
+    {
+        number: "Program 01",
+        kicker: "Cohort Training",
+        title: "Software Engineering Accelerator",
+        description:
+            "Seventeen weeks of remote-first engineering training, free to veterans and military spouses. The platform teaches what does not change so human time goes to pairing, code review, and shipping real work.",
+        specs: [
+            ["Length", "17 weeks"],
+            ["Commitment", "20–30 hrs / week"],
+            ["Cost", "$0"],
+            ["Outcome", "Software engineer"],
+        ],
+        cta: "View the Accelerator",
+        path: "/programs/accelerator",
+        image: "https://res.cloudinary.com/vetswhocode/image/upload/v1746583122/8_azjgpx.png",
+        alt: "Cohort engineers at work",
+    },
+    {
+        number: "Program 02",
+        kicker: "One to One",
+        title: "Mentorship",
+        description:
+            "One engineer in your corner for six months. A standing appointment with someone who has already done the thing you are trying to do — not a networking app, not a coffee chat.",
+        specs: [
+            ["Term", "6 months, renewable"],
+            ["Cadence", "Every other week"],
+            ["Cost", "$0"],
+            ["Outcome", "A plan, and accountability"],
+        ],
+        cta: "View Mentorship",
+        path: "/programs/mentorship",
+        image: "https://res.cloudinary.com/vetswhocode/image/upload/v1746583127/10_khmgby.png",
+        alt: "A mentor pairing session",
+    },
+    {
+        number: "Program 03",
+        kicker: "Paid Client Engineering",
+        title: "Software Factory",
+        description:
+            "Not training. A working engineering shop that takes paid client work, led by VWC engineers with cohort engineers contributing. You get production software; the veterans who build it get paid and get the reps.",
+        specs: [
+            ["Engagement", "Fixed bid"],
+            ["Range", "$10–50k"],
+            // Read from HERO_META so it cannot go stale independently of the factory page.
+            ["Status", factoryStatus],
+            ["Outcome", "Deployed software"],
+        ],
+        cta: "View the Factory",
+        path: "/programs/software-factory",
+        image: "https://res.cloudinary.com/vetswhocode/image/upload/v1746583121/6_qi229q.png",
+        alt: "Software Factory engineers shipping client work",
+    },
+];
+
+const STATS = [
+    ["97%", "Job Placement", "Graduates working in software engineering roles."],
+    ["$20M+", "Alumni Earnings", "Collective earnings unlocked for graduates and their families."],
+    [
+        "300+",
+        "Troops Trained",
+        "Veterans, service members, and military spouses through the program.",
+    ],
+    ["$0", "Tuition, 501(c)(3)", "EIN 86-2122804. No income share, no loan, no catch."],
+];
+
+const TESTIMONIALS = [
+    {
+        quote: "Vets Who Code modernized our web infrastructure when we needed it most. They implemented safe CI/CD pipelines, migrated our hosting, and mentored our team on sustainable engineering practices. They didn't just fix critical technical debt—they gave our leadership concrete systems and set our internal developers up for long-term self-sufficiency.",
+        name: "Jessica Williams",
+        title: "Director of Digital Marketing, Youth Villages",
+    },
+    {
+        quote: "Without a doubt, I would hire from Vets Who Code again. The experience has been overwhelmingly positive, and I believe in veterans' immense value to our team and our healthcare mission.",
+        name: "Darnell Settles III",
+        title: "Director of Web and Digital Strategy, Methodist Le Bonheur Healthcare",
+    },
+];
+
+// Wordmarks, not logos: the partner marks on the homepage are square glyphs covering
+// only 3 of these 7, and they're technology partners — a different list entirely.
+const EMPLOYERS = [
+    "Microsoft",
+    "Accenture",
+    "Amazon",
+    "Google",
+    "GitHub",
+    "Booz Allen",
+    "Deloitte",
+];
+
+const ROUTES = [
+    {
+        kicker: "01 / Veterans & Spouses",
+        title: "You want the training.",
+        body: "Applications for the accelerator open by cohort. Mentorship is open year-round.",
+        link: "Apply now",
+        path: "/apply",
+    },
+    {
+        kicker: "02 / Companies",
+        title: "You need engineers, or software.",
+        body: "Hire from the graduate pool, or contract the Software Factory to build and hand back.",
+        link: "Talk to us",
+        path: "/jobs",
+    },
+    {
+        kicker: "03 / Mentors & Instructors",
+        title: "You have reps to give.",
+        body: "Working engineers pair with troops, review code, and lead sessions. Two hours a month is enough to matter.",
+        link: "Volunteer",
+        path: "/mentor",
+    },
+    {
+        kicker: "04 / Donors & Funders",
+        title: "You fund the $0.",
+        body: "Tuition is free because donors and partners cover it. 501(c)(3), EIN 86-2122804. What we teach is public and auditable.",
+        link: "Ways to give",
+        path: "/donate",
+    },
+];
+
+const CARD_HOVER =
+    "tw-border tw-border-t-2 tw-border-gray-100 tw-border-t-transparent tw-transition-[transform,box-shadow,border-color] tw-duration-300 tw-ease-[cubic-bezier(0.3,0.2,0.3,0.3)] hover:tw--translate-y-0.5 hover:tw-border-t-red hover:tw-shadow-[0_10px_30px_rgba(0,0,0,0.18)]";
+
+const ProgramsPage: PageWithLayout = ({ data }) => {
+    const programs = buildPrograms(data.factoryStatus);
+
     return (
         <>
-            <SEO title={`${page.title} | Vets Who Code`} />
-            <HeroArea data={heroData} />
-            <main>
-                {/* Programs index header — SF/CG aesthetic */}
-                <section className="tw-bg-cream tw-py-20 md:tw-py-[120px]">
-                    <div className="tw-container">
-                        <div className="tw-flex tw-flex-col tw-gap-6 md:tw-flex-row md:tw-items-end md:tw-justify-between">
-                            <div className="tw-flex tw-flex-col tw-gap-4">
-                                <SectionEyebrow
-                                    label="Programs Index"
-                                    subLabel={`${allPrograms.length} Active`}
-                                />
-                                <SharpHeadline as="h2" size="h2" tone="navy">
-                                    What we run.
-                                    <br />
-                                    <span className="tw-text-red">How troops engage.</span>
-                                </SharpHeadline>
-                            </div>
-                            <MonoMeta tone="muted" size="sm" className="md:tw-text-right">
-                                Sourced · VWC · Validated · Cohort Outcomes
-                            </MonoMeta>
-                        </div>
+            <SEO
+                title="Programs | Vets Who Code"
+                description="Three ways in, one standard: the Software Engineering Accelerator, Mentorship, and the Software Factory. Free to veterans and military spouses."
+            />
 
-                        <p className="tw-mt-10 tw-max-w-[720px] tw-font-body tw-text-charcoal tw-leading-[1.5] [font-size:clamp(18px,1.4vw,22px)]">
-                            Every program is mapped to verified labor-market demand. Pick the
-                            engagement that fits your stage: pre-troop assessment, full 17-week
-                            Hashflag Stack, or a Forward Deployed engagement through the Software
-                            Factory.
-                        </p>
-
-                        <div className="tw-mt-14 tw-grid tw-gap-8 sm:tw-grid-cols-2 lg:tw-grid-cols-3">
-                            {allPrograms.map((program) => (
-                                <ProgramCard key={program.slug} program={program} />
-                            ))}
-                        </div>
+            {/* 1 — Hero */}
+            <section className="tw-relative tw-isolate tw-bg-navy">
+                <div className="tw-absolute tw-inset-0 -tw-z-10 tw-bg-[linear-gradient(135deg,#091f40_0%,#061A40_100%)]" />
+                <div className="tw-absolute tw-inset-0 -tw-z-10" style={grainLayer} />
+                <div className="tw-container tw-px-6 tw-pb-24 tw-pt-[120px]">
+                    <SectionEyebrow label="Programs Index" subLabel="3 Active" tone="dark" />
+                    <h1 className="tw-mt-7 tw-max-w-[900px] tw-font-heading tw-font-black tw-uppercase tw-leading-[1.02] tw-tracking-[-0.02em] tw-text-white [font-size:clamp(38px,6.4vw,76px)]">
+                        Three ways in.
+                        <br />
+                        {/* Gold, not red: red on navy is 2.85:1 and fails the 3:1 large-text floor. */}
+                        <span className="tw-text-gold">One standard.</span>
+                    </h1>
+                    <p className="tw-mt-8 tw-max-w-[640px] tw-font-body tw-leading-[1.6] tw-text-white/90 [font-size:clamp(17px,1.4vw,20px)]">
+                        Every program is free to veterans and military spouses, remote-first, and
+                        built around shipping real work. Pick the one that fits where you are.
+                    </p>
+                    <div className="tw-mt-10 tw-flex tw-flex-wrap tw-gap-3.5">
+                        <Button path="/apply" color="primary" size="md">
+                            Apply to a Program
+                        </Button>
+                        <Button path="/contact-us" color="light" size="md">
+                            Hire or Sponsor
+                        </Button>
                     </div>
-                </section>
-            </main>
+
+                    <div className="tw-mt-16 tw-grid tw-grid-cols-[repeat(auto-fit,minmax(180px,1fr))] tw-gap-px tw-border tw-border-[rgba(185,214,242,0.08)] tw-bg-[rgba(185,214,242,0.08)]">
+                        {HERO_FACTS.map(([key, value, accent]) => (
+                            <div
+                                key={key}
+                                className="tw-bg-[rgba(6,26,64,0.55)] tw-px-[22px] tw-py-5"
+                            >
+                                <div className="tw-mb-2 tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-[0.1em] tw-text-[rgba(185,214,242,0.7)]">
+                                    {key}
+                                </div>
+                                <div
+                                    className={`tw-font-heading tw-text-[15px] tw-font-bold ${accent ? "tw-text-gold" : "tw-text-white"}`}
+                                >
+                                    {value}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* 2 — At a glance */}
+            <section className="tw-border-b tw-border-gray-100 tw-bg-gray-50 tw-py-[72px]">
+                <div className="tw-container tw-px-6">
+                    <SectionEyebrow
+                        label="At a Glance"
+                        subLabel="Compare Before You Commit"
+                        className="tw-mb-7"
+                    />
+                    <div className="tw-overflow-x-auto">
+                        <table className="tw-w-full tw-min-w-[780px] tw-border tw-border-gray-100 tw-bg-white tw-text-left">
+                            <thead>
+                                <tr className="tw-bg-navy">
+                                    {["Program", "Who It's For", "Length", "Cost", "Outcome"].map(
+                                        (h) => (
+                                            <th
+                                                key={h}
+                                                scope="col"
+                                                className="tw-px-[18px] tw-py-3.5 tw-font-mono tw-text-[10px] tw-font-normal tw-uppercase tw-tracking-[0.1em] tw-text-navy-sky"
+                                            >
+                                                {h}
+                                            </th>
+                                        )
+                                    )}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {COMPARISON.map((row, i) => (
+                                    <tr
+                                        key={row.program}
+                                        className={`tw-border-t tw-border-gray-100 ${i === 1 ? "tw-bg-gray-50" : ""}`}
+                                    >
+                                        <th
+                                            scope="row"
+                                            className="tw-px-[18px] tw-py-5 tw-font-heading tw-text-[14px] tw-font-bold tw-uppercase tw-tracking-[-0.01em] tw-text-navy"
+                                        >
+                                            {row.program}
+                                        </th>
+                                        <td className="tw-px-[18px] tw-py-5 tw-font-body tw-text-[15px] tw-text-gray-300">
+                                            {row.who}
+                                        </td>
+                                        <td className="tw-px-[18px] tw-py-5 tw-font-mono tw-text-[12px] tw-text-ink">
+                                            {row.length}
+                                        </td>
+                                        <td className="tw-px-[18px] tw-py-5 tw-font-mono tw-text-[12px] tw-text-ink">
+                                            {row.cost}
+                                        </td>
+                                        <td className="tw-px-[18px] tw-py-5 tw-font-body tw-text-[15px] tw-text-gray-300">
+                                            {row.outcome}
+                                        </td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </section>
+
+            {/* 3 — Programs */}
+            <section className="tw-bg-cream tw-py-[110px]">
+                <div className="tw-container tw-px-6">
+                    <SectionEyebrow label="What We Run" subLabel="3 Active" />
+                    <SharpHeadline as="h2" size="h2" className="tw-mt-4 tw-max-w-[820px]">
+                        Three programs. Pick the one that fits where you are.
+                    </SharpHeadline>
+
+                    <div className="tw-mt-14 tw-grid tw-grid-cols-[repeat(auto-fit,minmax(300px,1fr))] tw-gap-[30px]">
+                        {programs.map((program) => (
+                            <article
+                                key={program.path}
+                                className={`tw-flex tw-flex-col tw-bg-white ${CARD_HOVER}`}
+                            >
+                                <div className="tw-relative tw-h-[200px] tw-w-full tw-shrink-0">
+                                    <Image
+                                        src={program.image}
+                                        alt={program.alt}
+                                        fill={true}
+                                        sizes="(max-width: 768px) 100vw, 33vw"
+                                        className="tw-object-cover"
+                                    />
+                                </div>
+                                <div className="tw-flex tw-flex-1 tw-flex-col tw-gap-[18px] tw-p-[30px]">
+                                    <div className="tw-flex tw-items-center tw-gap-3">
+                                        <span
+                                            aria-hidden="true"
+                                            className="tw-inline-block tw-h-[2px] tw-w-4 tw-shrink-0 tw-bg-red"
+                                        />
+                                        <MonoMeta size="xs" className="tw-text-gray-400">
+                                            {program.number}
+                                        </MonoMeta>
+                                        <MonoMeta size="xs" className="tw-text-gray-300">
+                                            / {program.kicker}
+                                        </MonoMeta>
+                                    </div>
+                                    <h3 className="tw-m-0 tw-font-heading tw-font-extrabold tw-uppercase tw-leading-[1.1] tw-text-navy [font-size:clamp(22px,2vw,28px)]">
+                                        {program.title}
+                                    </h3>
+                                    <p className="tw-m-0 tw-flex-1 tw-font-body tw-text-[15px] tw-text-gray-300">
+                                        {program.description}
+                                    </p>
+                                    <dl className="tw-m-0 tw-grid tw-gap-2 tw-border-t tw-border-gray-100 tw-pt-[18px]">
+                                        {program.specs.map(([key, value]) => (
+                                            <div
+                                                key={key}
+                                                className="tw-flex tw-items-baseline tw-justify-between tw-gap-4"
+                                            >
+                                                <dt className="tw-font-mono tw-text-[10px] tw-uppercase tw-tracking-[0.1em] tw-text-gray-400">
+                                                    {key}
+                                                </dt>
+                                                <dd className="tw-m-0 tw-text-right tw-font-heading tw-text-[13px] tw-font-bold tw-text-navy">
+                                                    {value}
+                                                </dd>
+                                            </div>
+                                        ))}
+                                    </dl>
+                                    <Button
+                                        path={program.path}
+                                        color="primary"
+                                        size="sm"
+                                        className="tw-self-start"
+                                    >
+                                        {program.cta}
+                                    </Button>
+                                </div>
+                            </article>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* 4 — The record */}
+            <section className="tw-relative tw-isolate tw-bg-navy tw-py-24">
+                <div className="tw-absolute tw-inset-0 tw-z-0" style={grainLayer} />
+                <div className="tw-container tw-relative tw-z-[1] tw-px-6">
+                    <SectionEyebrow
+                        label="The Record"
+                        subLabel="Since 2014"
+                        tone="dark"
+                        className="tw-mb-11"
+                    />
+                    <div className="tw-grid tw-grid-cols-[repeat(auto-fit,minmax(210px,1fr))] tw-gap-x-[30px] tw-gap-y-10">
+                        {STATS.map(([value, label, gloss]) => (
+                            <div key={label}>
+                                <div className="tw-font-heading tw-font-black tw-leading-none tw-tracking-[-0.02em] tw-text-white [font-size:clamp(40px,4.6vw,60px)]">
+                                    {value}
+                                </div>
+                                <div className="tw-mb-2 tw-mt-3 tw-font-heading tw-text-[13px] tw-font-bold tw-uppercase tw-tracking-[0.08em] tw-text-gold">
+                                    {label}
+                                </div>
+                                <p className="tw-m-0 tw-font-body tw-text-[15px] tw-text-[rgba(185,214,242,0.7)]">
+                                    {gloss}
+                                </p>
+                            </div>
+                        ))}
+                    </div>
+
+                    <div className="tw-relative tw-mb-14 tw-mt-[72px] tw-h-px tw-bg-[rgba(185,214,242,0.08)]">
+                        <span className="tw-absolute tw-left-0 tw-top-0 tw-h-px tw-w-12 tw-bg-red" />
+                    </div>
+
+                    <div className="tw-grid tw-grid-cols-[repeat(auto-fit,minmax(300px,1fr))] tw-gap-[30px]">
+                        {TESTIMONIALS.map((t) => (
+                            <blockquote
+                                key={t.name}
+                                className="tw-m-0 tw-border-l-2 tw-border-red tw-pl-[26px]"
+                            >
+                                <p className="tw-m-0 tw-font-body tw-leading-[1.55] tw-text-white [font-size:clamp(17px,1.4vw,21px)]">
+                                    {t.quote}
+                                </p>
+                                <footer className="tw-mt-5 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.1em] tw-text-[rgba(185,214,242,0.7)]">
+                                    {t.name}
+                                    <br />
+                                    <span className="tw-normal-case tw-tracking-[0.04em]">
+                                        {t.title}
+                                    </span>
+                                </footer>
+                            </blockquote>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* 5 — Employers */}
+            <section className="tw-border-b tw-border-[rgba(9,31,64,0.08)] tw-bg-cream tw-py-[72px]">
+                <div className="tw-container tw-px-6">
+                    <SectionEyebrow label="Where Graduates Work" className="tw-mb-8" />
+                    <div className="tw-flex tw-flex-wrap tw-gap-px">
+                        {EMPLOYERS.map((name) => (
+                            <div
+                                key={name}
+                                className="tw-flex tw-min-h-[88px] tw-flex-1 tw-basis-[200px] tw-items-center tw-justify-center tw-border tw-border-[rgba(9,31,64,0.1)] tw-bg-cream tw-px-6 tw-py-5"
+                            >
+                                <span className="tw-whitespace-nowrap tw-font-mono tw-text-[13px] tw-font-bold tw-uppercase tw-tracking-[0.12em] tw-text-navy">
+                                    {name}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* 6 — Next step */}
+            <section className="tw-bg-white tw-py-[100px]">
+                <div className="tw-container tw-px-6">
+                    <SectionEyebrow label="Next Step" />
+                    <SharpHeadline as="h2" size="h2" className="tw-mb-12 tw-mt-4 tw-max-w-[760px]">
+                        Find the door that is yours.
+                    </SharpHeadline>
+                    <div className="tw-grid tw-grid-cols-[repeat(auto-fit,minmax(250px,1fr))] tw-gap-[30px]">
+                        {ROUTES.map((route) => (
+                            <div
+                                key={route.path}
+                                className={`tw-flex tw-flex-col tw-gap-3.5 tw-p-[30px] ${CARD_HOVER}`}
+                            >
+                                <MonoMeta size="xs" tone="accent">
+                                    {route.kicker}
+                                </MonoMeta>
+                                <h3 className="tw-m-0 tw-font-heading tw-text-[19px] tw-font-bold tw-text-navy">
+                                    {route.title}
+                                </h3>
+                                <p className="tw-m-0 tw-flex-1 tw-font-body tw-text-[15px] tw-text-gray-300">
+                                    {route.body}
+                                </p>
+                                <Anchor
+                                    path={route.path}
+                                    className="tw-font-heading tw-text-[12px] tw-font-bold tw-uppercase tw-tracking-[0.08em] tw-text-red hover:tw-underline"
+                                >
+                                    {route.link} →
+                                </Anchor>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* 7 — CTA banner */}
+            <section className="tw-bg-red tw-py-[72px]">
+                <div className="tw-container tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-8 tw-px-6">
+                    <div className="tw-max-w-[720px]">
+                        {/* Full white, not 85%: at 11px on red, 85% white measures 3.54:1. */}
+                        <div className="tw-mb-4 tw-font-mono tw-text-[11px] tw-uppercase tw-tracking-[0.12em] tw-text-white">
+                            Retool. Retrain. Relaunch.
+                        </div>
+                        <h2 className="tw-m-0 tw-font-heading tw-font-black tw-uppercase tw-text-white [font-size:clamp(26px,3.2vw,40px)]">
+                            Pick Your Program. Lets Get To Work.
+                        </h2>
+                    </div>
+                    <div className="tw-flex tw-flex-wrap tw-gap-3.5">
+                        <Button path="/apply" color="light" size="md">
+                            Start Your Journey
+                        </Button>
+                        <Button path="/contact-us" color="light" variant="outlined" size="md">
+                            Contact
+                        </Button>
+                    </div>
+                </div>
+            </section>
         </>
     );
 };
 
 ProgramsPage.Layout = Layout;
 
-export const getStaticProps: GetStaticProps = async () => {
-    const allPrograms = getAllMediaPosts<Program>(["slug", "title", "description"], "programs");
+export const getStaticProps: GetStaticProps = () => {
+    const status = HERO_META.find(([key]) => key === "STATUS")?.[1] ?? "";
     return {
         props: {
-            allPrograms,
-            page: {
-                title: "Our Programs",
+            data: {
+                // "BOOKING Q4 2026 · Q1 2027" → "Booking Q4 2026 · Q1 2027". Title-case per word so
+                // tokens like "Q3" keep their capital.
+                factoryStatus: status.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase()),
             },
             layout: {
                 headerShadow: true,

--- a/src/pages/programs.tsx
+++ b/src/pages/programs.tsx
@@ -42,7 +42,7 @@ const COMPARISON = [
     {
         program: "Mentorship",
         who: "Anyone already building who needs a second set of eyes",
-        length: "6 months",
+        length: "17 weeks + 6 mo",
         cost: "$0",
         outcome: "A working plan and someone who holds you to it",
     },
@@ -90,10 +90,10 @@ const buildPrograms = (factoryStatus: string): ProgramCard[] => [
         kicker: "One to One",
         title: "Mentorship",
         description:
-            "One engineer in your corner for six months. A standing appointment with someone who has already done the thing you are trying to do — not a networking app, not a coffee chat.",
+            "One engineer in your corner for the length of your cohort, then six months past it. A standing weekly appointment with someone who has already done the thing you are trying to do — not a networking app, not a coffee chat.",
         specs: [
-            ["Term", "6 months, renewable"],
-            ["Cadence", "Every other week"],
+            ["Term", "17 weeks, then opt-in"],
+            ["Cadence", "Weekly, 45 min"],
             ["Cost", "$0"],
             ["Outcome", "A plan, and accountability"],
         ],

--- a/src/pages/programs.tsx
+++ b/src/pages/programs.tsx
@@ -41,10 +41,10 @@ const COMPARISON = [
     },
     {
         program: "Mentorship",
-        who: "Anyone already building who needs a second set of eyes",
+        who: "Veterans inside a cohort, and graduates working through the job search",
         length: "17 weeks + 6 mo",
         cost: "$0",
-        outcome: "A working plan and someone who holds you to it",
+        outcome: "Work that survives code review, and support through the offer",
     },
     {
         program: "Software Factory",
@@ -87,15 +87,15 @@ const buildPrograms = (factoryStatus: string): ProgramCard[] => [
     },
     {
         number: "Program 02",
-        kicker: "One to One",
+        kicker: "Mentor Corps",
         title: "Mentorship",
         description:
-            "One engineer in your corner for the length of your cohort, then six months past it. A standing weekly appointment with someone who has already done the thing you are trying to do — not a networking app, not a coffee chat.",
+            "Two tracks, running the length of your cohort and six months past it. Technical mentors read your work before each gate and say whether it would survive code review at a real company. Translation mentors turn mission experience into offers. Scoped above syntax — the harness covers that.",
         specs: [
             ["Term", "17 weeks, then opt-in"],
             ["Cadence", "Weekly, 45 min"],
             ["Cost", "$0"],
-            ["Outcome", "A plan, and accountability"],
+            ["Outcome", "Through to the offer"],
         ],
         cta: "View Mentorship",
         path: "/programs/mentorship",


### PR DESCRIPTION
## Summary

`/programs` rendered only whatever MDX files sat in `src/data/programs/` — currently just `mentorship.mdx` — so it was a one-card page that never mentioned the Accelerator or the Software Factory. This rebuilds it as a hub per the design handoff, serving all four audiences: applicants, hiring companies, mentors, and funders.

Also rolls the Software Factory booking window to **Q4 2026 · Q1 2027**, and replaces the mentorship copy with verified content from the Mentor Corps framework.

## What changed

- `src/pages/programs.tsx` — full rewrite. Seven sections: navy gradient hero with fact strip, comparison table, three program summary cards, the record (stats + testimonials), employer wordmarks, four-audience routing, CTA banner.
- `src/data/software-factory.ts` + `src/containers/software-factory/cta/index.tsx` — booking window updated. It's stated in two places, so both had to move together.
- `__tests__/pages/programs.tests.tsx` — new. Covers program links, audience routing, table semantics, the status transform, and heading structure.

Built on the existing design system: `SectionEyebrow`, `SharpHeadline`, `MonoMeta`, `@ui/button`, `@ui/anchor`, `next/image`, Tailwind brand tokens. No new components or dependencies.

## Mentorship copy is verified, not drafted

The handoff author drafted mentorship specifics because `mentorship.mdx` is placeholder prose. Those drafts were wrong and are now corrected against the Mentor Corps framework:

| Field | Handoff draft | Actual |
|---|---|---|
| Term | 6 months, renewable | 17 weeks (one cohort), then explicit opt-in |
| Cadence | Every other week | Weekly, 45 min |
| Who it's for | Anyone already building | Veterans inside a cohort, and graduates in the job search |

The card now names both tracks — technical pre-gate artifact review, and translation from mission experience to offers — and states what the program deliberately excludes: syntax, which the harness covers. That exclusion is what separates it from a generic pairing service, so it earned card space.

## Decisions worth a reviewer's eye

**`size=\"lg\"` is a dead prop value on `Button`.** It's in the TypeScript union but only `xs`/`sm`/`md` map to padding classes, so `lg` renders an unsized button — no padding, no min-height. The handoff specified `lg`; this uses `md`, the largest implemented size. **Worth fixing in `Button` separately** so the next caller doesn't hit it.

**Status is read from `HERO_META`, not hardcoded**, then title-cased per word — a naive `toLowerCase` turns \"Q4\" into \"q4\". There's a test on the transform itself, not just the rendered string.

**Comparison uses a real `<table>`** with `scope=\"col\"`/`scope=\"row\"` rather than the prototype's CSS grid, which the handoff explicitly left open.

**Gold, not red, for the second headline line.** Red on navy measures 2.85:1 and fails the 3:1 large-text floor. Same reason the CTA banner eyebrow is full white rather than 85%.

**No page-level reduced-motion or focus-ring CSS.** The handoff says both are missing in production; they aren't — `src/assets/css/globals.css` lines 519 and 535 already cover them globally.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` — 0 errors, 0 warnings on the changed files
- [x] `npm test` — 485 passing
- [x] `npm run build` — `/programs` and all program detail routes generate
- [x] Walked all seven sections in the browser; verified every CTA target resolves (`/apply`, `/contact-us`, `/jobs`, `/mentor`, `/donate`, and the three `/programs/*` detail pages)
- [ ] Confirm on the deploy preview

## Follow-up

- **`/programs/mentorship` is still placeholder prose** — \"guidance, encouragement, and networking opportunities.\" The card now sets an expectation the destination page doesn't meet. Rewriting it from the Mentor Corps framework is the obvious next change, deliberately left out of this PR's scope.
- **\"Through to the offer\"** as the mentorship outcome is extrapolated from the framework's impact tracking (time-to-first-offer). It reads as a stronger promise than the framework itself makes — swap if it overstates.
- **\"300+ Troops Trained\" and \"97% Job Placement\"** are carried from the design-system guide. Confirm current numbers.
- **Program card photos are stand-ins** lifted from `src/containers/about/story.tsx` — chosen for tone, not subject-matched.
- **Employer list is wordmarks only.** The homepage partner marks are square glyphs covering 3 of these 7, and they're technology partners — a different list from where graduates work.
- **`src/components/program-card/`** is now unused by any page (only its Storybook story imports it), and **`src/pages/programs/index.mdx`** is inert because `pageExtensions` doesn't include `.mdx`. Both left in place.
- **The booking window lives in two files.** Collapsing the CTA copy onto `HERO_META` would make the next roll a one-line change.