### PR TITLE
fix(programs): Replace the mentorship placeholder and repair its styling

### DIFF
--- a/src/data/programs/mentorship.mdx
+++ b/src/data/programs/mentorship.mdx
@@ -1,36 +1,58 @@
 ---
-title: "Mentorship Program"
-description: "Connects veterans with experienced mentors in tech for guidance and support."
+title: "Mentorship"
+description: "The Mentor Corps staffs the middle of the accelerator — pre-gate artifact review, architectural judgment, and the translation from mission experience to offers."
 slug: "mentorship"
 ---
 
-# Mentorship Program
+The accelerator teaches in a gradual release model. Units are **I do**. Evidence gates are **you do**. The Mentor Corps staffs the band in between — **we do** — which is where veterans stall and where no automated system reaches.
 
-<section className="tw-mb-8">
-  <h2 className="tw-text-3xl tw-font-bold tw-mb-2">Overview</h2>
-  <p className="tw-text-lg tw-text-gray-700">Our Mentorship Program pairs veterans with seasoned tech professionals who provide guidance, encouragement, and networking opportunities. We believe in the power of community and shared experience to accelerate your growth.</p>
-</section>
+Your mentor is a working engineer: a Vets Who Code graduate currently employed in the field, or a veteran engineer from outside the accelerator. Either way, someone who has already done the thing you are trying to do.
 
-<section className="tw-mb-8">
-  <h2 className="tw-text-2xl tw-font-semibold tw-mb-2">Outcomes</h2>
-  <ul className="tw-list-disc tw-ml-6 tw-text-gray-700">
-    <li>Personalized career guidance</li>
-    <li>Expanded professional network</li>
-    <li>Accountability and support</li>
-    <li>Confidence to pursue new opportunities</li>
-  </ul>
-</section>
+## Two tracks
 
-<section className="tw-mb-8">
-  <h2 className="tw-text-2xl tw-font-semibold tw-mb-2">How It Works</h2>
-  <ol className="tw-list-decimal tw-ml-6 tw-text-gray-700">
-    <li>Apply to be matched with a mentor</li>
-    <li>Set goals and meet regularly</li>
-    <li>Receive feedback and encouragement</li>
-    <li>Grow your skills and confidence</li>
-  </ol>
-</section>
+**Track 1 — Technical.** Pre-gate artifact review, architectural tradeoffs, debugging workflow, git CLI, and the question that matters most: would this survive code review at a real company. Coverage follows the curriculum — React and TypeScript on the frontend, the data layer including pgvector, FastAPI on the backend, and AI Engineering: RAG, agents, production AI APIs.
 
-<section className="tw-mb-8 tw-text-center">
-  <a href="/apply" className="tw-inline-block tw-bg-blue-700 tw-text-white tw-font-bold tw-px-6 tw-py-3 tw-rounded-lg tw-shadow-md tw-hover:tw-bg-blue-800 tw-focus:tw-outline-none tw-focus:tw-ring-2 tw-focus:tw-ring-blue-400">Apply Now</a>
-</section>
+**Track 2 — Translation.** Turning mission experience into engineering impact statements, mock technical and behavioral screens, portfolio review, and offer negotiation. It runs light through the accelerator and becomes the main event at graduation.
+
+## What it is not
+
+Mentorship is scoped deliberately **above syntax**. You already have the harness — OpenCode and CodeGemma 2B — for syntax questions, and it answers faster than a human can. Mentor time goes to judgment: the calls a model cannot make for you.
+
+It is also not a networking app and not a coffee chat. It is a standing appointment with a specific engineer who knows what you shipped last week.
+
+## What you get
+
+- **One 45-minute sync every week**, on a schedule you and your mentor set
+- **One pre-gate artifact read per unit**, returned within 48 hours
+- **Async access** in the cohort Discord, within your mentor's stated hours
+- **Six months of Track 2 support after graduation** — mock screens, resume, interview loops, offer negotiation
+
+Free, like everything else we run.
+
+## How it runs across 17 weeks
+
+**Onboarding, weeks 1–2.** Confirm the match, review your weakest units from intake, and agree on when you escalate rather than grind. You bring learning objectives, a working GitHub, and your first gate submission.
+
+**Frontend, weeks 3–6.** The highest-touch phase. This is where attrition happens, so this is where the mentor leans in hardest — unblocking and confidence, not lectures.
+
+**Data layer, weeks 7–10.** Correctness review. Bad schema and query decisions fail quietly, and gates alone will not catch them. You explain your modeling choices out loud.
+
+**Backend, weeks 11–14.** Tradeoff conversations, API contracts, CI/CD, and what production actually looks like. You walk your mentor through the system design of your own work.
+
+**AI engineering, weeks 15–17.** RAG and agent design judgment, and the difference between production-real and demo-real. Portfolio goes final and the job search opens.
+
+**Post-graduation, six months.** Track 2 takes over while you apply, interview, and negotiate.
+
+Data structures and algorithms run as a continuous thread across all seventeen weeks, on their own recurring touch, because interviews are shaped differently than the work.
+
+## Your mentor never grades your gate
+
+This one is structural, not a courtesy. A veteran will not admit "I don't understand this unit" to the person who decides whether they pass. Grading and mentorship stay in separate hands so the weekly sync is a place you can be honest about what is not landing.
+
+Mentors review against the published rubric for each unit — not personal preference — and are briefed on the failure modes that make mentorship worse than nothing: writing the code for you, drifting into life coaching, and contradicting the curriculum.
+
+## Getting a mentor
+
+Mentorship comes with the accelerator. If you are in a cohort, you are matched during onboarding.
+
+If you are an engineer who wants to serve on the other side of this, the commitment is one cohort at four to five hours a month — see [Mentor with us](/mentor).

--- a/src/pages/programs/[slug].tsx
+++ b/src/pages/programs/[slug].tsx
@@ -31,7 +31,7 @@ const ProgramPage: NextPage<ProgramPageProps> & { Layout: typeof Layout } = ({
                 <h1 className="tw-mb-6 tw-text-3xl tw-font-bold md:tw-text-4xl">
                     {frontmatter.title}
                 </h1>
-                <div className="prose md:prose-lg max-w-none">
+                <div className="tw-prose md:tw-prose-lg tw-max-w-none prose-headings:tw-text-navy prose-a:tw-text-red prose-strong:tw-text-navy">
                     <MDXRemote {...mdxSource} />
                 </div>
             </div>


### PR DESCRIPTION
## Summary

`/programs/mentorship` had two independent problems: it rendered with no typography styling at all, and its content was placeholder copy that the rebuilt programs page now contradicts. Both fixed.

## The styling bug

`src/pages/programs/[slug].tsx` wrapped the MDX in `className="prose md:prose-lg max-w-none"` — **unprefixed**. `tailwind.config.js` sets `prefix: "tw-"`, so all three classes were dead and the MDX rendered as unstyled HTML. Every other prose surface in the repo already uses the prefixed form:

- `src/pages/team/[slug].tsx` — `tw-prose tw-max-w-none`
- `src/pages/lessons/lesson/[id].tsx` — `tw-prose tw-max-w-none`
- `src/components/markdown-renderer/index.tsx` — `tw-prose tw-max-w-none`

Now `tw-prose md:tw-prose-lg tw-max-w-none` with brand modifiers for headings, links, and strong. This is why the old placeholder hand-rolled a `className` onto every single element — it was compensating for typography that never applied.

## The content

Replaced with the Mentor Corps framework, written mentee-facing since this page is where the programs card's "View Mentorship" CTA lands:

- Mentorship as the **we do** band of the gradual release model — units are *I do*, evidence gates are *you do*
- Both tracks: technical pre-gate review across the real stack (React/TypeScript, pgvector, FastAPI, RAG and agents), and translation from mission experience to offers
- What it deliberately excludes — syntax, because the harness answers faster than a human can
- The concrete offer: weekly 45-minute sync, one pre-gate artifact read per unit at 48-hour turnaround, async Discord, six months of Track 2 after graduation
- The 17-week arc, phase by phase
- **A mentor never grades the gate** — structural, so the weekly sync stays a place you can admit what isn't landing

Also drops the duplicate `h1`. The old file opened with `# Mentorship Program` while `[slug].tsx` already renders an `h1` from frontmatter, so the page shipped two.

## Notes for review

The framework's commitment table (4–5 hrs/month, the 2+ years bar) is the **mentor's** commitment, not the mentee's. This page is mentee-facing, so those numbers appear only in the closing pointer to `/mentor` rather than being presented as what a veteran signs up for.

Frontmatter `title` changed from "Mentorship Program" to "Mentorship" to match the programs card. `description` rewritten — it feeds SEO.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` — clean on the changed file
- [x] `npm test` — 480 passing
- [x] `npm run build`
- [x] Verified in the browser: prose styles apply, exactly one `h1`, 6 section headings, the `/mentor` link renders in brand red
- [ ] Confirm on the deploy preview

## Related

Pairs with #1290, which rebuilt `/programs` and whose mentorship card links here. That PR flagged this page as the obvious next change; this is it. The two touch different files and can merge in either order.

## Follow-up

No GFM tables in the MDX pipeline — `serialize()` in `[slug].tsx` passes no `mdxOptions`, so `remark-gfm` isn't wired up and markdown tables would render as literal text. The 17-week roadmap is written as prose paragraphs for that reason. Worth adding the plugin if future program pages want tables.