### PR TITLE
fix(home): Gate the donate modal on engagement instead of a timer

### DIFF
--- a/__tests__/components/engagement-modal.tests.tsx
+++ b/__tests__/components/engagement-modal.tests.tsx
@@ -1,0 +1,101 @@
+import { EngagementModal } from "@components/ui/engagement-modal/EngagementModal";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SafeLocalStorage } from "@utils/safe-storage";
+
+vi.mock("motion/react", () => ({
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    motion: {
+        div: ({ children, ...rest }: React.ComponentProps<"div">) => (
+            <div {...rest}>{children}</div>
+        ),
+    },
+}));
+
+const PROPS = {
+    headline: "Your Next Mission Starts Here.",
+    body: "Support Vets Who Code.",
+    cta1: { label: "Donate Now", href: "/donate" },
+    cta2: { label: "Join the Mission", href: "#newsletter" },
+};
+
+/** Put the document at a given fraction of scroll depth and fire the listener. */
+const scrollTo = (fraction: number) => {
+    Object.defineProperty(document.documentElement, "scrollHeight", {
+        value: 2000,
+        configurable: true,
+    });
+    Object.defineProperty(window, "innerHeight", { value: 1000, configurable: true });
+    Object.defineProperty(window, "scrollY", {
+        value: fraction * (2000 - 1000),
+        configurable: true,
+    });
+    fireEvent.scroll(window);
+};
+
+const modal = () => screen.queryByRole("dialog");
+
+describe("EngagementModal", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        window.matchMedia = vi.fn().mockReturnValue({
+            matches: true,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        }) as unknown as typeof window.matchMedia;
+    });
+
+    it("never interrupts a first-time visitor, even at full scroll depth", () => {
+        render(<EngagementModal {...PROPS} />);
+        scrollTo(1);
+        expect(modal()).not.toBeInTheDocument();
+    });
+
+    it("stays hidden for a returning visitor who has not read far enough", () => {
+        SafeLocalStorage.setItem("vwc_visit_count", 3);
+        render(<EngagementModal {...PROPS} />);
+        scrollTo(0.5);
+        expect(modal()).not.toBeInTheDocument();
+    });
+
+    it("shows for a returning visitor past the scroll threshold", async () => {
+        SafeLocalStorage.setItem("vwc_visit_count", 3);
+        render(<EngagementModal {...PROPS} />);
+        scrollTo(0.75);
+        await waitFor(() => expect(modal()).toBeInTheDocument());
+    });
+
+    it("shows on exit intent for a returning visitor on a fine pointer", async () => {
+        SafeLocalStorage.setItem("vwc_visit_count", 3);
+        render(<EngagementModal {...PROPS} />);
+        fireEvent.mouseOut(document, { clientY: 0, relatedTarget: null });
+        await waitFor(() => expect(modal()).toBeInTheDocument());
+    });
+
+    it("never fires exit intent on a touch device", () => {
+        SafeLocalStorage.setItem("vwc_visit_count", 3);
+        (window.matchMedia as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+            matches: false,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        });
+        render(<EngagementModal {...PROPS} />);
+        fireEvent.mouseOut(document, { clientY: 0, relatedTarget: null });
+        expect(modal()).not.toBeInTheDocument();
+    });
+
+    it("stays dismissed across later visits", () => {
+        SafeLocalStorage.setItem("vwc_visit_count", 3);
+        SafeLocalStorage.setItem("vwc_engagement_modal_dismissed", true);
+        render(<EngagementModal {...PROPS} />);
+        scrollTo(1);
+        expect(modal()).not.toBeInTheDocument();
+    });
+
+    it("counts a visit once per session, not once per page view", () => {
+        const { unmount } = render(<EngagementModal {...PROPS} />);
+        unmount();
+        render(<EngagementModal {...PROPS} />);
+        expect(SafeLocalStorage.getItem<number>("vwc_visit_count", 0)).toBe(1);
+    });
+});

--- a/src/components/ui/engagement-modal/EngagementModal.tsx
+++ b/src/components/ui/engagement-modal/EngagementModal.tsx
@@ -1,4 +1,4 @@
-import { SafeSessionStorage } from "@utils/safe-storage";
+import { SafeLocalStorage, SafeSessionStorage } from "@utils/safe-storage";
 import { AnimatePresence, motion } from "motion/react";
 import Link from "next/link";
 import React, { useEffect, useRef, useState } from "react";
@@ -18,7 +18,16 @@ interface CustomWindow extends Window {
 
 declare let window: CustomWindow;
 
-const MODAL_FLAG = "vwc_engagement_modal_shown";
+// Dismissal is permanent (localStorage), not per-session. The previous flag lived in
+// sessionStorage, so a visitor who closed the modal saw it again on their next visit.
+const DISMISSED_KEY = "vwc_engagement_modal_dismissed";
+const VISIT_COUNT_KEY = "vwc_visit_count";
+const VISIT_COUNTED_KEY = "vwc_visit_counted";
+
+/** Cold traffic converts badly on a financial ask. Wait for the second visit. */
+const MIN_VISITS = 2;
+/** Fraction of the page a visitor must reach before the ask is earned. */
+const SCROLL_THRESHOLD = 0.7;
 
 export const EngagementModal: React.FC<EngagementModalProps> = ({
     headline,
@@ -49,24 +58,52 @@ export const EngagementModal: React.FC<EngagementModalProps> = ({
             return () => clearTimeout(timer);
         }
 
-        // Use SafeSessionStorage to check if modal was shown
-        const modalShown = SafeSessionStorage.getItem<boolean>(MODAL_FLAG, false);
-        if (modalShown) return;
+        if (SafeLocalStorage.getItem<boolean>(DISMISSED_KEY, false)) return;
 
-        const timer = setTimeout(() => {
+        // Count each browsing session once, so "visits" means visits and not page views.
+        let visits = SafeLocalStorage.getItem<number>(VISIT_COUNT_KEY, 0);
+        if (!SafeSessionStorage.getItem<boolean>(VISIT_COUNTED_KEY, false)) {
+            visits += 1;
+            SafeLocalStorage.setItem(VISIT_COUNT_KEY, visits);
+            SafeSessionStorage.setItem(VISIT_COUNTED_KEY, true);
+        }
+
+        // First-time visitors are still deciding what this place is. Never interrupt them.
+        if (visits < MIN_VISITS) return;
+
+        const reveal = () => {
             setOpen(true);
-            // Mark modal as shown with SafeSessionStorage
-            SafeSessionStorage.setItem(MODAL_FLAG, true);
-        }, 3000);
+            SafeLocalStorage.setItem(DISMISSED_KEY, true);
+        };
 
-        return () => clearTimeout(timer);
+        // Earned by reading: 70% of the page.
+        const onScroll = () => {
+            const scrollable = document.documentElement.scrollHeight - window.innerHeight;
+            if (scrollable <= 0) return;
+            if (window.scrollY / scrollable >= SCROLL_THRESHOLD) reveal();
+        };
+
+        // Exit intent: cursor leaving through the top of the viewport. Pointer-based,
+        // so it never fires on touch devices, where a takeover hurts most.
+        const onMouseOut = (e: MouseEvent) => {
+            if (e.clientY <= 0 && !e.relatedTarget) reveal();
+        };
+
+        window.addEventListener("scroll", onScroll, { passive: true });
+        const finePointer = window.matchMedia("(pointer: fine)").matches;
+        if (finePointer) document.addEventListener("mouseout", onMouseOut);
+
+        return () => {
+            window.removeEventListener("scroll", onScroll);
+            if (finePointer) document.removeEventListener("mouseout", onMouseOut);
+        };
     }, [forceShow]);
 
     // Accessibility: close on ESC
     useEffect(() => {
         if (!open) return;
         const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key === "Escape") setOpen(false);
+            if (e.key === "Escape") dismiss();
         };
         window.addEventListener("keydown", onKeyDown);
         return () => window.removeEventListener("keydown", onKeyDown);
@@ -82,8 +119,13 @@ export const EngagementModal: React.FC<EngagementModalProps> = ({
     }, [open]);
 
     // Dismiss on click outside
+    const dismiss = () => {
+        setOpen(false);
+        SafeLocalStorage.setItem(DISMISSED_KEY, true);
+    };
+
     const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
-        if (e.target === e.currentTarget) setOpen(false);
+        if (e.target === e.currentTarget) dismiss();
     };
 
     return (
@@ -124,7 +166,7 @@ export const EngagementModal: React.FC<EngagementModalProps> = ({
                                 type="button"
                                 aria-label="Close"
                                 className="tw-absolute tw-right-6 tw-top-6 tw-text-4xl tw-text-secondary hover:tw-text-primary focus:tw-outline-none"
-                                onClick={() => setOpen(false)}
+                                onClick={dismiss}
                             >
                                 &times;
                             </button>
@@ -163,7 +205,7 @@ export const EngagementModal: React.FC<EngagementModalProps> = ({
                                         passHref={true}
                                         onClick={(e) => {
                                             e.preventDefault();
-                                            setOpen(false);
+                                            dismiss();
                                             const targetId = cta2.href.substring(1);
                                             const targetElement = document.getElementById(targetId);
                                             if (targetElement) {


### PR DESCRIPTION
## Summary

The homepage donate modal opened on a **3-second timer** after landing — to everyone, first visit included. That matches the reported analytics: page views **-74%**, bounce **67%**, donations flat despite traffic **+85%**. A financial ask delivered before any value reads as a toll gate.

It now waits for evidence of interest before asking.

## What was actually happening

`src/components/ui/engagement-modal/EngagementModal.tsx`:

```ts
const timer = setTimeout(() => { setOpen(true); ... }, 3000);
```

No scroll condition, no visit check, no device check. And the "already shown" flag lived in **sessionStorage**, so closing it lasted one session — the same visitor met the same modal on their next visit.

## What changed

| | Before | After |
|---|---|---|
| Trigger | 3s timer | 70% scroll depth, or exit intent |
| Audience | Everyone, first visit included | Second visit onward |
| Exit intent | — | Desktop only, gated on `(pointer: fine)` |
| Dismissal | sessionStorage — returned next session | localStorage — permanent |

The visit counter increments **once per browsing session**, not per page view, so refreshing or clicking through three pages doesn't promote a first-time visitor to "returning."

Exit intent fires on `mouseout` with `clientY <= 0` and no `relatedTarget` — cursor leaving through the top of the viewport. It's registered only behind `matchMedia("(pointer: fine)")`, so it never fires on touch, where a takeover costs the most and where there is no exit-intent gesture to detect anyway.

## What I did not build, and why

The recommendation to "replace modal takeovers with an unobtrusive banner or sticky navbar button" is **already satisfied**: `src/layouts/headers/header.tsx:64` renders a persistent gold Donate button on every page of the site. Adding a second persistent ask would compete with it rather than help, so this PR only fixes the interruption.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 502 passing, 7 new cases on this component
- [x] `npm run build`

New tests cover the behaviour that actually matters: a first-time visitor at 100% scroll depth still sees nothing; a returning visitor at 50% sees nothing; a returning visitor at 75% sees it; exit intent works on a fine pointer and never on touch; dismissal survives later visits; and a visit counts once per session rather than once per page view.

## Notes

**This will reduce modal impressions sharply**, which is the point — but it means donation attribution from the modal will drop before the funnel effect shows up. Worth watching bounce rate and page views per session as the primary signals, not modal conversions.

The two thresholds are one-line constants at the top of the component (`MIN_VISITS = 2`, `SCROLL_THRESHOLD = 0.7`) if you want to tune them after seeing data.

## Follow-up

Two pre-existing items in this file, left alone since they're unrelated to the trigger fix:

- A `useEffect` whose only job is to `delete window.openEngagementModal` — nothing ever sets that property.
- A `{false && process.env.NODE_ENV === "development" && ...}` block for a test button, unreachable by construction, with a comment saying to remove it before production.

The modal is also `min-h-[520px]` on mobile inside a `max-h-[95vh]` shell, which is most of a phone screen when it does appear. Now that it only reaches engaged returning visitors that matters less, but it's the obvious next tightening if mobile bounce stays high.