### PR TITLE
fix(events): Show only upcoming events on the homepage

### DIFF
--- a/__tests__/lib/event.test.ts
+++ b/__tests__/lib/event.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+import { getallEvents, getEventMeta, getUpcomingEvents, isUpcomingEvent } from "@/lib/event";
+
+// Local noon, so the "start of today" boundary is unambiguous in any timezone.
+const today = new Date("2026-09-09T12:00:00");
+
+describe("isUpcomingEvent", () => {
+    it("excludes an event that already ended", () => {
+        expect(isUpcomingEvent({ start_date: "2026-09-01", end_date: "2026-09-01" }, today)).toBe(
+            false
+        );
+    });
+
+    it("includes an event starting today", () => {
+        expect(isUpcomingEvent({ start_date: "2026-09-09", end_date: "2026-09-09" }, today)).toBe(
+            true
+        );
+    });
+
+    it("includes a future event", () => {
+        expect(isUpcomingEvent({ start_date: "2026-10-15", end_date: "2026-10-15" }, today)).toBe(
+            true
+        );
+    });
+
+    it("includes a multi-day event that started yesterday and ends tomorrow", () => {
+        expect(isUpcomingEvent({ start_date: "2026-09-08", end_date: "2026-09-10" }, today)).toBe(
+            true
+        );
+    });
+
+    it("falls back to start_date when end_date is missing", () => {
+        expect(isUpcomingEvent({ start_date: "2026-09-10", end_date: "" }, today)).toBe(true);
+        expect(isUpcomingEvent({ start_date: "2026-09-08", end_date: "" }, today)).toBe(false);
+    });
+});
+
+describe("getUpcomingEvents", () => {
+    it("returns nothing when every event in src/data/events has passed", () => {
+        expect(getUpcomingEvents("all", today)).toEqual([]);
+    });
+
+    it("returns every event ascending by start_date when they are all ahead", () => {
+        const events = getUpcomingEvents(["title"], new Date("2020-01-01T12:00:00"));
+
+        expect(events).toHaveLength(getEventMeta().count);
+        expect(events.map((event) => event.start_date)).toEqual([
+            "2023-01-26",
+            "2023-02-23",
+            "2023-03-30",
+            "2023-06-29",
+        ]);
+    });
+});
+
+describe("getallEvents", () => {
+    it("returns events newest first", () => {
+        expect(getallEvents(["title"]).map((event) => event.start_date)).toEqual([
+            "2023-06-29",
+            "2023-03-30",
+            "2023-02-23",
+            "2023-01-26",
+        ]);
+    });
+});

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -1,4 +1,6 @@
+import { getStartOfDay } from "@utils/date";
 import { IEvent } from "@utils/types";
+import { parseISO } from "date-fns";
 import fs from "fs";
 import path from "path";
 import { getSlugs } from "./util";
@@ -33,11 +35,36 @@ export function getEventeBySlug(slug: string, fields: Array<keyof IEvent> | "all
     return { ...event, path: `/events/${realSlug}` };
 }
 
+// Event dates are "YYYY-MM-DD" strings. `new Date` reads those as UTC midnight, which is
+// the previous day west of UTC; parseISO reads them as local dates like the rest of the day math.
+const dayStart = (date: string) => getStartOfDay(parseISO(date)).getTime();
+
+const byStartDate = (a: IEvent, b: IEvent) => dayStart(a.start_date) - dayStart(b.start_date);
+
+export function isUpcomingEvent(
+    event: Pick<IEvent, "start_date" | "end_date">,
+    now: Date = new Date()
+): boolean {
+    return dayStart(event.end_date || event.start_date) >= getStartOfDay(now).getTime();
+}
+
+// Always read the date fields so filtering and sorting work whatever the caller asked for.
+function readEvents(fields: Array<keyof IEvent> | "all") {
+    const readFields: Array<keyof IEvent> | "all" =
+        fields === "all" ? "all" : [...fields, "start_date", "end_date"];
+    return getSlugs(directory).map((slug) => getEventeBySlug(slug, readFields));
+}
+
 export function getallEvents(fields: Array<keyof IEvent> | "all", skip = 0, limit?: number) {
-    const slugs = getSlugs(directory);
-    let events = slugs.map((slug) => getEventeBySlug(slug, fields));
+    let events = readEvents(fields).sort((a, b) => byStartDate(b, a));
     if (limit) events = events.slice(skip, limit);
     return events;
+}
+
+export function getUpcomingEvents(fields: Array<keyof IEvent> | "all", now: Date = new Date()) {
+    return readEvents(fields)
+        .filter((event) => isUpcomingEvent(event, now))
+        .sort(byStartDate);
 }
 
 export function getEventMeta() {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -23,7 +23,7 @@ import { IBlog, IEvent, IMedia } from "@utils/types";
 import type { NextPage } from "next";
 import { GetStaticProps } from "next";
 import { getAllBlogs } from "../lib/blog";
-import { getallEvents } from "../lib/event";
+import { getUpcomingEvents } from "../lib/event";
 import { getAllMediaPosts } from "../lib/mdx-pages";
 import { getPageData } from "../lib/page";
 
@@ -114,13 +114,15 @@ const Home: PageProps = ({ data }) => {
             {/* Testimonials — light */}
             <TestimonialArea data={content?.["testimonial-area"]} titleSize="large" />
 
-            {/* Events — navy */}
-            <div className="dark-section tw-bg-navy">
-                <EventArea
-                    data={{ ...content?.["event-area"], events: data.events }}
-                    titleSize="large"
-                />
-            </div>
+            {/* Events — navy, only while there is something upcoming */}
+            {data.events.length > 0 && (
+                <div className="dark-section tw-bg-navy">
+                    <EventArea
+                        data={{ ...content?.["event-area"], events: data.events }}
+                        titleSize="large"
+                    />
+                </div>
+            )}
 
             {/* Mission pull-quote + alumni proof — light */}
             <div className="tw-py-20 md:tw-py-[120px]">
@@ -171,7 +173,7 @@ Home.Layout = Layout;
 
 export const getStaticProps: GetStaticProps = () => {
     const page = getPageData("home", "index");
-    const events = getallEvents(["title", "thumbnail", "start_date", "location"], 0, 6);
+    const events = getUpcomingEvents(["title", "thumbnail", "start_date", "location"]).slice(0, 6);
     const allMedia = getAllMediaPosts<IMedia>(
         ["slug", "title", "mediaType", "url", "publication", "date", "image", "description"],
         "media"


### PR DESCRIPTION
## Problem

The homepage "Upcoming Events" slider showed the four events in `src/data/events`, all from 2023, because `getallEvents` did no date filtering (#553).

## Solution

- `src/lib/event.ts` gains a pure `isUpcomingEvent` helper and `getUpcomingEvents`, which keeps events whose end date (falling back to start date) is today or later, sorted soonest first. `getallEvents` now returns newest first so `/events` reads as an archive; its skip and limit semantics are unchanged.
- The homepage uses `getUpcomingEvents` and renders the navy events block only when there is at least one upcoming event, so a stale 2023 slider no longer appears and no empty dark band is left behind. It returns automatically once a current event JSON is added.
- Date-only strings are parsed with `parseISO` so "today" is evaluated in local time; `new Date("YYYY-MM-DD")` parses as UTC midnight and would have excluded a same-day event west of UTC. The existing `eventFilter` in `src/utils/methods.ts` still has that off-by-one and is untouched here.
- Event JSON, the section copy, and the `/events` filter are unchanged. "Upcoming" is evaluated at build time, the same as the rest of the static homepage.

Closes #553

## Verification

```
npx vitest run __tests__/lib/event.test.ts
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test          # 72 files, 567 tests
npm run build
```
