### PR TITLE
fix(a11y): Hide decorative FontAwesome icons from assistive tech

### DIFF
--- a/__tests__/components/decorative-icons.test.tsx
+++ b/__tests__/components/decorative-icons.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import BlogMetaItem from "@/components/blog-meta/meta-item";
+import Social01 from "@/components/socials/social-01";
+
+const fontAwesomeIcons = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("i[class*='fa']"));
+
+describe("decorative FontAwesome icons", () => {
+    it("hides every social icon while each link keeps its accessible name", () => {
+        const { container } = render(<Social01 />);
+
+        const icons = fontAwesomeIcons(container);
+        expect(icons).toHaveLength(4);
+        for (const icon of icons) {
+            expect(icon).toHaveAttribute("aria-hidden", "true");
+        }
+
+        for (const name of ["github", "facebook", "linkedin", "youtube"]) {
+            expect(screen.getByRole("link", { name })).toHaveAttribute("aria-label", name);
+        }
+    });
+
+    it("hides the blog meta icon whether or not the item links somewhere", () => {
+        const { container } = render(
+            <>
+                <BlogMetaItem icon="far fa-calendar" text="Sep 9, 2026" />
+                <BlogMetaItem icon="far fa-user" text="Jerome" path="/team/jerome" />
+            </>
+        );
+
+        const icons = fontAwesomeIcons(container);
+        expect(icons).toHaveLength(2);
+        for (const icon of icons) {
+            expect(icon).toHaveAttribute("aria-hidden", "true");
+        }
+
+        expect(screen.getByText("Sep 9, 2026")).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: "Jerome" })).toHaveAttribute(
+            "href",
+            "/team/jerome"
+        );
+    });
+});

--- a/src/components/blog-card/blog-01.tsx
+++ b/src/components/blog-card/blog-01.tsx
@@ -71,7 +71,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
                             color: "#495057",
                         }}
                     >
-                        <i className="far fa-calendar tw-mr-2.5" />
+                        <i className="far fa-calendar tw-mr-2.5" aria-hidden="true" />
                         {postedAt}
                     </li>
                 </ul>

--- a/src/components/blog-card/blog-02.tsx
+++ b/src/components/blog-card/blog-02.tsx
@@ -48,7 +48,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
                 </h3>
                 <ul>
                     <li className="tw-mb-0 tw-mt-3.8 tw-text-md tw-text-white">
-                        <i className="far fa-calendar tw-mr-2.5" />
+                        <i className="far fa-calendar tw-mr-2.5" aria-hidden="true" />
                         {postedAt}
                     </li>
                 </ul>

--- a/src/components/blog-card/blog-03.tsx
+++ b/src/components/blog-card/blog-03.tsx
@@ -75,7 +75,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
                                 color: "#495057",
                             }}
                         >
-                            <i className="far fa-calendar tw-mr-2.5" />
+                            <i className="far fa-calendar tw-mr-2.5" aria-hidden="true" />
                             {postedAt}
                         </li>
                     </ul>

--- a/src/components/blog-card/blog-04.tsx
+++ b/src/components/blog-card/blog-04.tsx
@@ -51,7 +51,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
 
                     <ul className="tw-flex tw-text-md tw-text-gray-300">
                         <li className="tw-mb-0 tw-mt-3.8">
-                            <i className="far fa-calendar tw-mr-2.5" />
+                            <i className="far fa-calendar tw-mr-2.5" aria-hidden="true" />
                             {postedAt}
                         </li>
                     </ul>

--- a/src/components/blog-meta/meta-item.tsx
+++ b/src/components/blog-meta/meta-item.tsx
@@ -13,12 +13,12 @@ const BlogMetaItem = ({ className, text, icon, path }: TProps) => {
         <div className={clsx("blog-meta-itemn tw-mb-[5px]", className)}>
             {path ? (
                 <Anchor path={path}>
-                    <i className={clsx("tw-pr-1.5", icon)} />
+                    <i className={clsx("tw-pr-1.5", icon)} aria-hidden="true" />
                     {text}
                 </Anchor>
             ) : (
                 <>
-                    <i className={clsx("tw-pr-1.5", icon)} />
+                    <i className={clsx("tw-pr-1.5", icon)} aria-hidden="true" />
                     {text}
                 </>
             )}

--- a/src/components/event-card/event-01.tsx
+++ b/src/components/event-card/event-01.tsx
@@ -65,7 +65,7 @@ const Event01 = forwardRef<HTMLDivElement, TProps>(
                         <Anchor path={path}>{title}</Anchor>
                     </h3>
                     <p className="tw-mb-0 tw-mt-6.1 tw-text-[17px]">
-                        <i className="far fa-map-marker-alt tw-mr-2.5" />
+                        <i className="far fa-map-marker-alt tw-mr-2.5" aria-hidden="true" />
                         {location.city}, {location.country}
                     </p>
                 </div>

--- a/src/components/event-card/event-02.tsx
+++ b/src/components/event-card/event-02.tsx
@@ -23,7 +23,7 @@ const Event02 = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-grow tw-pb-3.8 tw-pr-0 sm:tw-pb-0 sm:tw-pr-7.5">
                     <div className="tw-mb-[7px] tw-text-base tw-text-gray-300">
-                        <i className="far fa-map-marker-alt tw-mr-[5px]" />
+                        <i className="far fa-map-marker-alt tw-mr-[5px]" aria-hidden="true" />
                         {location.city}, {location.country}
                     </div>
                     <h3 className="tw-mb-0 tw-text-xl tw-leading-normal">{title}</h3>

--- a/src/components/icon-box/icon-box-01.tsx
+++ b/src/components/icon-box/icon-box-01.tsx
@@ -23,7 +23,10 @@ const IconBox = forwardRef<HTMLDivElement, IconBoxProps>(
                     <p className="tw-mt-3 tw-px-2.5 tw-leading-normal">{description}</p>
                     <span className="tw-mt-5 tw-inline-flex tw-items-center tw-p-1.3 tw-text-md tw-font-bold tw-leading-none tw-text-secondary-light group-hover:tw-text-primary">
                         {pathText}{" "}
-                        <i className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]" />
+                        <i
+                            className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]"
+                            aria-hidden="true"
+                        />
                     </span>
                 </div>
                 <Anchor className="link-overlay" path={path}>

--- a/src/components/image-box/image-box-01.tsx
+++ b/src/components/image-box/image-box-01.tsx
@@ -20,7 +20,11 @@ const ImageBox = forwardRef<HTMLDivElement, ImageBoxProps>(
                 <h3 className="tw-m-0 tw-leading-normal tw-text-secondary">{title}</h3>
                 <p className="tw-mb-[34px] tw-mt-2.5 tw-leading-relaxed">{description}</p>
                 <span className="tw-inline-flex tw-items-center tw-py-[5px] tw-text-md tw-font-bold tw-leading-none tw-text-secondary-light tw-transition-colors tw-duration-300 group-hover:tw-text-primary">
-                    {pathText} <i className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]" />
+                    {pathText}{" "}
+                    <i
+                        className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]"
+                        aria-hidden="true"
+                    />
                 </span>
                 <Anchor className="link-overlay" path={path}>
                     {title}

--- a/src/components/image-box/image-box-02.tsx
+++ b/src/components/image-box/image-box-02.tsx
@@ -30,7 +30,11 @@ const ImageBox = forwardRef<HTMLDivElement, ImageBoxProps>(
                 <h3 className="tw-m-0 tw-text-xl tw-leading-normal tw-text-secondary">{title}</h3>
                 <p className="tw-mb-[34px] tw-mt-2.5 tw-leading-relaxed">{description}</p>
                 <span className="tw-inline-flex tw-items-center tw-py-[5px] tw-text-md tw-font-bold tw-leading-none tw-text-secondary-light tw-transition-colors tw-duration-300 group-hover:tw-text-primary">
-                    {pathText} <i className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]" />
+                    {pathText}{" "}
+                    <i
+                        className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]"
+                        aria-hidden="true"
+                    />
                 </span>
                 <Anchor className="link-overlay" path={path}>
                     {title}

--- a/src/components/image-box/image-box-03.tsx
+++ b/src/components/image-box/image-box-03.tsx
@@ -20,7 +20,11 @@ const ImageBox = forwardRef<HTMLDivElement, ImageBoxProps>(
                 <h3 className="tw-m-0 tw-text-xl tw-leading-normal">{title}</h3>
                 <p className="tw-mb-[34px] tw-mt-2.5 tw-leading-relaxed">{description}</p>
                 <span className="tw-flex tw-min-h-[40px] tw-items-center tw-justify-center tw-rounded tw-bg-transparent tw-px-5 tw-text-md tw-font-bold tw-leading-none tw-text-secondary-light tw-transition group-hover:tw-bg-light-100 group-hover:tw-text-primary">
-                    {pathText} <i className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]" />
+                    {pathText}{" "}
+                    <i
+                        className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]"
+                        aria-hidden="true"
+                    />
                 </span>
                 <Anchor className="link-overlay" path={path}>
                     {title}

--- a/src/components/media-card/index.tsx
+++ b/src/components/media-card/index.tsx
@@ -80,7 +80,7 @@ const MediaCard = forwardRef<HTMLDivElement, TProps>(
                                 color: "#495057",
                             }}
                         >
-                            <i className="far fa-calendar tw-mr-1.5" />
+                            <i className="far fa-calendar tw-mr-1.5" aria-hidden="true" />
                             {new Date(date).toLocaleDateString("en-US", {
                                 year: "numeric",
                                 month: "long",
@@ -102,7 +102,8 @@ const MediaCard = forwardRef<HTMLDivElement, TProps>(
                             transition: "color 0.3s ease",
                         }}
                     >
-                        View Media <i className="fas fa-external-link-alt tw-ml-1" />
+                        View Media{" "}
+                        <i className="fas fa-external-link-alt tw-ml-1" aria-hidden="true" />
                     </Anchor>
                 </div>
             </div>

--- a/src/components/menu/main-menu/index.tsx
+++ b/src/components/menu/main-menu/index.tsx
@@ -58,7 +58,10 @@ const MainMenu = ({ className, hoverStyle, menu, color, align }: TProps) => {
                             >
                                 {label}
                                 {hasSubmenu && (
-                                    <i className="fa fa-chevron-down tw-ml-2 tw-text-xs" />
+                                    <i
+                                        className="fa fa-chevron-down tw-ml-2 tw-text-xs"
+                                        aria-hidden="true"
+                                    />
                                 )}
                             </NavLink>
                             {submenu && (

--- a/src/components/menu/mobile-menu/expand-button.tsx
+++ b/src/components/menu/mobile-menu/expand-button.tsx
@@ -3,9 +3,10 @@ const ExpandButton = ({ onClick }: { onClick: () => void }) => {
         <button
             onClick={onClick}
             type="button"
+            aria-label="Toggle submenu"
             className="tw-absolute tw-right-0 tw-top-[11px] tw-z-10 tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-full tw-text-white tw-transition-colors hover:tw-bg-white/20"
         >
-            <i className="fa fa-chevron-down tw-text-xs" />
+            <i className="fa fa-chevron-down tw-text-xs" aria-hidden="true" />
         </button>
     );
 };

--- a/src/components/social-share/layout-01/index.tsx
+++ b/src/components/social-share/layout-01/index.tsx
@@ -21,7 +21,7 @@ const SocialShare = () => {
     return (
         <div className="tw-group tw-relative tw-inline-flex tw-cursor-pointer tw-items-center tw-text-body tw-transition-colors hover:tw-text-primary">
             <h6 className="tw-mb-0 tw-mr-3.8 tw-text-md tw-text-current">Share this course</h6>
-            <i className="far fa-share-alt" />
+            <i className="far fa-share-alt" aria-hidden="true" />
 
             <div
                 className={clsx(
@@ -37,21 +37,21 @@ const SocialShare = () => {
                     href={`https://www.facebook.com/sharer/sharer.php?u=${href}`}
                     onClick={clickHandler}
                 >
-                    <i className="fab fa-facebook-f" />
+                    <i className="fab fa-facebook-f" aria-hidden="true" />
                 </SocialLink>
                 <SocialLink
                     label="Twitter"
                     href={`https://twitter.com/intent/tweet?url=${href}`}
                     onClick={clickHandler}
                 >
-                    <i className="fab fa-twitter" />
+                    <i className="fab fa-twitter" aria-hidden="true" />
                 </SocialLink>
                 <SocialLink
                     label="Linkedin"
                     href={`https://www.linkedin.com/shareArticle?url=${href}`}
                     onClick={clickHandler}
                 >
-                    <i className="fab fa-linkedin" />
+                    <i className="fab fa-linkedin" aria-hidden="true" />
                 </SocialLink>
             </div>
         </div>

--- a/src/components/social-share/layout-02.tsx
+++ b/src/components/social-share/layout-02.tsx
@@ -35,7 +35,7 @@ const SocialShare = ({ className }: TProps) => {
                 onClick={clickHandler}
                 className="tw-mr-2.5"
             >
-                <i className="fab fa-facebook-f" />
+                <i className="fab fa-facebook-f" aria-hidden="true" />
             </SocialLink>
             <SocialLink
                 label="Twitter"
@@ -43,7 +43,7 @@ const SocialShare = ({ className }: TProps) => {
                 onClick={clickHandler}
                 className="tw-mr-2.5"
             >
-                <i className="fab fa-twitter" />
+                <i className="fab fa-twitter" aria-hidden="true" />
             </SocialLink>
             <SocialLink
                 label="Linkedin"
@@ -51,7 +51,7 @@ const SocialShare = ({ className }: TProps) => {
                 onClick={clickHandler}
                 className="tw-mr-2.5"
             >
-                <i className="fab fa-linkedin" />
+                <i className="fab fa-linkedin" aria-hidden="true" />
             </SocialLink>
         </Social>
     );

--- a/src/components/social-share/layout-03.tsx
+++ b/src/components/social-share/layout-03.tsx
@@ -32,7 +32,10 @@ const SocialShare = ({ label, className }: TProps) => {
         >
             <p className="tw-mb-0 tw-mr-3.8 tw-hidden tw-font-medium sm:tw-block">{label}</p>
 
-            <i className="fas fa-share-alt tw-h-14 tw-w-14 tw-rounded-full tw-border-2 tw-border-gray-300 tw-text-center tw-text-lg tw-leading-[52px] tw-text-primary tw-transition-colors tw-duration-300 group-hover:tw-border-primary group-hover:tw-bg-primary group-hover:tw-text-white" />
+            <i
+                className="fas fa-share-alt tw-h-14 tw-w-14 tw-rounded-full tw-border-2 tw-border-gray-300 tw-text-center tw-text-lg tw-leading-[52px] tw-text-primary tw-transition-colors tw-duration-300 group-hover:tw-border-primary group-hover:tw-bg-primary group-hover:tw-text-white"
+                aria-hidden="true"
+            />
             <Social color="light" tooltip={true} flyout={true}>
                 <SocialLink
                     label="Facebook"
@@ -40,7 +43,7 @@ const SocialShare = ({ label, className }: TProps) => {
                     onClick={clickHandler}
                     className="tw-px-3 tw-py-2.5"
                 >
-                    <i className="fab fa-facebook-f" />
+                    <i className="fab fa-facebook-f" aria-hidden="true" />
                 </SocialLink>
                 <SocialLink
                     label="Twitter"
@@ -48,7 +51,7 @@ const SocialShare = ({ label, className }: TProps) => {
                     onClick={clickHandler}
                     className="tw-px-3 tw-py-2.5"
                 >
-                    <i className="fab fa-twitter" />
+                    <i className="fab fa-twitter" aria-hidden="true" />
                 </SocialLink>
                 <SocialLink
                     label="Linkedin"
@@ -56,7 +59,7 @@ const SocialShare = ({ label, className }: TProps) => {
                     onClick={clickHandler}
                     className="tw-px-3 tw-py-2.5"
                 >
-                    <i className="fab fa-linkedin" />
+                    <i className="fab fa-linkedin" aria-hidden="true" />
                 </SocialLink>
             </Social>
         </div>

--- a/src/components/socials/social-01.tsx
+++ b/src/components/socials/social-01.tsx
@@ -4,28 +4,28 @@ import clsx from "clsx";
 const Social01 = ({ className }: { className?: string }) => (
     <Social color="dark" size="lg" className={clsx(className)}>
         <SocialLink href="https://github.com/Vets-Who-Code" label="github" className="tw-px-2.5">
-            <i className="fab fa-github" />
+            <i className="fab fa-github" aria-hidden="true" />
         </SocialLink>
         <SocialLink
             href="https://www.facebook.com/TheOfficialVetsWhoCode/"
             label="facebook"
             className="tw-px-2.5"
         >
-            <i className="fab fa-facebook-f" />
+            <i className="fab fa-facebook-f" aria-hidden="true" />
         </SocialLink>
         <SocialLink
             href="https://www.linkedin.com/company/vets-who-code"
             label="linkedin"
             className="tw-px-2.5"
         >
-            <i className="fab fa-linkedin" />
+            <i className="fab fa-linkedin" aria-hidden="true" />
         </SocialLink>
         <SocialLink
             href="https://www.youtube.com/@vetswhocode"
             label="youtube"
             className="tw-px-2.5"
         >
-            <i className="fab fa-youtube" />
+            <i className="fab fa-youtube" aria-hidden="true" />
         </SocialLink>
     </Social>
 );

--- a/src/components/team-card/index.tsx
+++ b/src/components/team-card/index.tsx
@@ -50,7 +50,7 @@ const TeamCard = forwardRef<HTMLDivElement, TProps>(
                                     label={social.label}
                                     className="tw-px-3.5"
                                 >
-                                    <i className={social.icon} />
+                                    <i className={social.icon} aria-hidden="true" />
                                 </SocialLink>
                             ))}
                         </Social>

--- a/src/components/ui/accordion/item.tsx
+++ b/src/components/ui/accordion/item.tsx
@@ -29,9 +29,15 @@ const AccordionItem = ({ id, title, description, onClick, isOpen }: TProps) => {
                 </button>
                 <span className="tw-absolute tw-right-4 tw-top-1/2 -tw-translate-y-1/2">
                     {isOpen ? (
-                        <i className="fa fa-minus-circle tw-text-xl tw-text-white" />
+                        <i
+                            className="fa fa-minus-circle tw-text-xl tw-text-white"
+                            aria-hidden="true"
+                        />
                     ) : (
-                        <i className="fa fa-plus-circle tw-text-xl tw-text-secondary-light" />
+                        <i
+                            className="fa fa-plus-circle tw-text-xl tw-text-secondary-light"
+                            aria-hidden="true"
+                        />
                     )}
                 </span>
             </h3>

--- a/src/components/ui/list-with-check/index.tsx
+++ b/src/components/ui/list-with-check/index.tsx
@@ -10,7 +10,10 @@ const ListWithCheck = forwardRef<HTMLUListElement, TProps>(({ className, list },
         <ul className={className} ref={ref}>
             {list.map((item) => (
                 <li className="tw-mt-2.5 tw-flex tw-items-center first:tw-mt-0" key={item}>
-                    <i className="fas fa-check tw-mr-[19px] tw-text-base tw-text-primary" />
+                    <i
+                        className="fas fa-check tw-mr-[19px] tw-text-base tw-text-primary"
+                        aria-hidden="true"
+                    />
                     {item}
                 </li>
             ))}

--- a/src/components/ui/motto-text/index.tsx
+++ b/src/components/ui/motto-text/index.tsx
@@ -35,7 +35,7 @@ const MottoText = forwardRef<HTMLParagraphElement, TProps>(
                     "hover:before:tw-scale-x-0 hover:before:tw-delay-75 hover:after:tw-scale-x-100 hover:after:tw-delay-300"
                 )}
             >
-                {pathText} <i className="far fa-long-arrow-right" />
+                {pathText} <i className="far fa-long-arrow-right" aria-hidden="true" />
             </Anchor>
         </p>
     )

--- a/src/components/ui/nice-select/index.tsx
+++ b/src/components/ui/nice-select/index.tsx
@@ -62,13 +62,13 @@ const NiceSelect = ({ className, options, setValue, prefix, defaultValue }: TPro
                 className="tw-flex tw-min-h-[52px] tw-w-full tw-items-center tw-py-[3px] tw-pl-5 tw-pr-10"
             >
                 <span className="label tw-flex tw-items-center tw-text-body">
-                    <i className="fa fa-align-left tw-mr-3.8" /> {prefix}
+                    <i className="fa fa-align-left tw-mr-3.8" aria-hidden="true" /> {prefix}
                     <span className="tw-ml-[3px] tw-font-medium tw-text-heading">
                         {selected?.label}
                     </span>
                 </span>
                 <span className="arrow tw-absolute tw-right-0 tw-top-0 tw-flex tw-h-full tw-w-10 tw-items-center tw-justify-center tw-bg-transparent tw-text-lg">
-                    <i className="far fa-angle-down" />
+                    <i className="far fa-angle-down" aria-hidden="true" />
                 </span>
             </button>
             <ul
@@ -91,7 +91,10 @@ const NiceSelect = ({ className, options, setValue, prefix, defaultValue }: TPro
                         onKeyPress={(e) => e}
                     >
                         {item.value === selected?.value && (
-                            <i className="fa fa-check tw-mr-2.5 tw-text-primary tw-transition-colors group-hover:tw-text-white" />
+                            <i
+                                className="fa fa-check tw-mr-2.5 tw-text-primary tw-transition-colors group-hover:tw-text-white"
+                                aria-hidden="true"
+                            />
                         )}
                         {item.label}
                     </li>

--- a/src/components/ui/swiper/index.tsx
+++ b/src/components/ui/swiper/index.tsx
@@ -121,11 +121,19 @@ const SwiperSlider = forwardRef<HTMLDivElement, TProps>(
 
                 {sliderOptions?.navigation && (
                     <>
-                        <button type="button" className={`swiper-btn swiper-btn-prev ${prevClass}`}>
-                            <i className={cn(prevIcon, "icon")} />
+                        <button
+                            type="button"
+                            aria-label="Previous slide"
+                            className={`swiper-btn swiper-btn-prev ${prevClass}`}
+                        >
+                            <i className={cn(prevIcon, "icon")} aria-hidden="true" />
                         </button>
-                        <button type="button" className={`swiper-btn swiper-btn-next ${nextClass}`}>
-                            <i className={cn(nextIcon, "icon")} />
+                        <button
+                            type="button"
+                            aria-label="Next slide"
+                            className={`swiper-btn swiper-btn-next ${nextClass}`}
+                        >
+                            <i className={cn(nextIcon, "icon")} aria-hidden="true" />
                         </button>
                     </>
                 )}

--- a/src/components/widgets/course-info/item.tsx
+++ b/src/components/widgets/course-info/item.tsx
@@ -10,7 +10,11 @@ const CourseInfo = ({ icon, label, value }: TProps) => {
     return (
         <div className="tw-flex tw-items-center tw-justify-between tw-border-t tw-border-t-gray-500 tw-py-3.8 first:tw-border-0">
             <h6 className="tw-mb-0">
-                <i className={clsx(icon, "tw-min-w-[28px] tw-text-center tw-text-body")} /> {label}
+                <i
+                    className={clsx(icon, "tw-min-w-[28px] tw-text-center tw-text-body")}
+                    aria-hidden="true"
+                />{" "}
+                {label}
             </h6>
             <span className="tw-text-right">{value}</span>
         </div>

--- a/src/components/widgets/info-price.tsx
+++ b/src/components/widgets/info-price.tsx
@@ -8,7 +8,10 @@ const PriceInfo = ({ title, currency, price }: TProps) => {
     return (
         <div className="course-price tw-mb-[7px] tw-flex tw-items-center tw-justify-between">
             <h3 className="tw-mb-0 tw-text-h6">
-                <i className="far fa-money-bill-wave tw-min-w-[28px] tw-text-center tw-text-body" />{" "}
+                <i
+                    className="far fa-money-bill-wave tw-min-w-[28px] tw-text-center tw-text-body"
+                    aria-hidden="true"
+                />{" "}
                 {title}
             </h3>
             <span className="tw-text-right">

--- a/src/components/widgets/recent-posts-widget.tsx
+++ b/src/components/widgets/recent-posts-widget.tsx
@@ -16,8 +16,14 @@ const RecentPostsWidget = ({ recentPosts }: TProps) => {
                     path={path}
                     className="tw-group tw-relative tw-block tw-border-b tw-border-b-gray-500 tw-pb-3.8 tw-pl-7.5 tw-pt-4 tw-text-lg tw-font-bold tw-leading-[1.78] tw-text-body last:tw-border-0"
                 >
-                    <i className="fa fa-long-arrow-alt-right tw-absolute tw-left-0 tw-top-6 tw-text-base tw-transition-all tw-duration-300 group-hover:tw-invisible group-hover:tw-translate-x-full group-hover:tw-opacity-0" />
-                    <i className="fa fa-long-arrow-alt-right tw-invisible tw-absolute tw-left-0 tw-top-6 -tw-translate-x-full tw-text-base tw-text-primary tw-opacity-0 tw-transition-all tw-duration-300 group-hover:tw-visible group-hover:tw-translate-x-0 group-hover:tw-opacity-100" />
+                    <i
+                        className="fa fa-long-arrow-alt-right tw-absolute tw-left-0 tw-top-6 tw-text-base tw-transition-all tw-duration-300 group-hover:tw-invisible group-hover:tw-translate-x-full group-hover:tw-opacity-0"
+                        aria-hidden="true"
+                    />
+                    <i
+                        className="fa fa-long-arrow-alt-right tw-invisible tw-absolute tw-left-0 tw-top-6 -tw-translate-x-full tw-text-base tw-text-primary tw-opacity-0 tw-transition-all tw-duration-300 group-hover:tw-visible group-hover:tw-translate-x-0 group-hover:tw-opacity-100"
+                        aria-hidden="true"
+                    />
                     <span>{title}</span>
                 </Anchor>
             ))}

--- a/src/components/widgets/search-widget.tsx
+++ b/src/components/widgets/search-widget.tsx
@@ -44,7 +44,7 @@ const SearchWidget = ({ className }: TProps) => {
                     type="submit"
                     className="tw-absolute tw-right-0 tw-top-0 tw-flex tw-h-14 tw-w-14 tw-items-center tw-justify-center tw-rounded-br tw-rounded-tr tw-text-primary tw-transition-colors hover:tw-bg-primary hover:tw-text-white"
                 >
-                    <i className="fas fa-search" />
+                    <i className="fas fa-search" aria-hidden="true" />
                 </button>
             </form>
         </div>

--- a/src/components/widgets/text-widget.tsx
+++ b/src/components/widgets/text-widget.tsx
@@ -32,16 +32,16 @@ const TextWidget = ({ className, mode }: TProps) => {
                     href="https://www.facebook.com/TheOfficialVetsWhoCode/"
                     label="Facebook"
                 >
-                    <i className="fab fa-facebook-square" />
+                    <i className="fab fa-facebook-square" aria-hidden="true" />
                 </SocialLink>
                 <SocialLink href="https://github.com/Vets-Who-Code" label="Github">
-                    <i className="fab fa-github" />
+                    <i className="fab fa-github" aria-hidden="true" />
                 </SocialLink>
                 <SocialLink href="https://www.linkedin.com/company/vets-who-code" label="linkedin">
-                    <i className="fab fa-linkedin" />
+                    <i className="fab fa-linkedin" aria-hidden="true" />
                 </SocialLink>
                 <SocialLink href="https://www.youtube.com/@vetswhocode" label="youtube">
-                    <i className="fab fa-youtube" />
+                    <i className="fab fa-youtube" aria-hidden="true" />
                 </SocialLink>
             </Social>
         </div>

--- a/src/containers/about/layout-01/index.tsx
+++ b/src/containers/about/layout-01/index.tsx
@@ -80,7 +80,10 @@ const QuoteArea = ({
                                             className="tw-text-md tw-font-bold tw-text-secondary-light"
                                         >
                                             {anchors[0].content}{" "}
-                                            <i className="far fa-long-arrow-right" />
+                                            <i
+                                                className="far fa-long-arrow-right"
+                                                aria-hidden="true"
+                                            />
                                         </Anchor>
                                     )}
                                 </div>

--- a/src/containers/blog-details/blog-author.tsx
+++ b/src/containers/blog-details/blog-author.tsx
@@ -23,7 +23,7 @@ const BlogAuthor = ({ name, image, bio, socials }: IInstructor) => {
                                 label={label}
                                 className="tw-px-2.5 tw-py-1.5"
                             >
-                                <i className={icon} />
+                                <i className={icon} aria-hidden="true" />
                             </SocialLink>
                         ))}
                     </Social>

--- a/src/containers/blog-details/index.tsx
+++ b/src/containers/blog-details/index.tsx
@@ -39,7 +39,7 @@ function BlogDetails({ image, title, category, author, postedAt, content, tags, 
                 {audioUrl && (
                     <div className="tw-mt-7 tw-rounded-lg tw-bg-gradient-to-r tw-from-navy-midnight tw-to-navy-deep tw-p-5 tw-shadow-lg">
                         <div className="tw-mb-3 tw-flex tw-items-center tw-gap-2 tw-text-sm tw-font-medium tw-text-white">
-                            <i className="fas fa-headphones tw-text-navy-sky" />
+                            <i className="fas fa-headphones tw-text-navy-sky" aria-hidden="true" />
                             <span>Listen to this article</span>
                         </div>
                         <audio controls={true} className="tw-w-full" preload="metadata">

--- a/src/containers/blog-full/layout-05/index.tsx
+++ b/src/containers/blog-full/layout-05/index.tsx
@@ -45,7 +45,8 @@ const BlogArea = ({ data: { blogs } }: TProps) => {
                                     className="tw-min-w-[250px] tw-border-gray-500"
                                     onClick={handlerLoadMore}
                                 >
-                                    Load More <i className="fal fa-redo tw-ml-4" />
+                                    Load More{" "}
+                                    <i className="fal fa-redo tw-ml-4" aria-hidden="true" />
                                 </Button>
                             ) : (
                                 <p>No course to show</p>

--- a/src/containers/blog/layout-02/index.tsx
+++ b/src/containers/blog/layout-02/index.tsx
@@ -45,8 +45,14 @@ const BlogArea = ({
                             path={path}
                             className="tw-group tw-relative tw-mt-5 tw-block tw-pl-7.5 tw-font-bold tw-leading-[1.78] tw-text-secondary first:tw-mt-0"
                         >
-                            <i className="fa fa-long-arrow-alt-right tw-absolute tw-left-0 tw-top-[5px] tw-text-base tw-transition-all tw-duration-300 group-hover:tw-invisible group-hover:tw-translate-x-full group-hover:tw-opacity-0" />
-                            <i className="fa fa-long-arrow-alt-right tw-invisible tw-absolute tw-left-0 tw-top-[5px] -tw-translate-x-full tw-text-base tw-text-primary tw-opacity-0 tw-transition-all tw-duration-300 group-hover:tw-visible group-hover:tw-translate-x-0 group-hover:tw-opacity-100" />
+                            <i
+                                className="fa fa-long-arrow-alt-right tw-absolute tw-left-0 tw-top-[5px] tw-text-base tw-transition-all tw-duration-300 group-hover:tw-invisible group-hover:tw-translate-x-full group-hover:tw-opacity-0"
+                                aria-hidden="true"
+                            />
+                            <i
+                                className="fa fa-long-arrow-alt-right tw-invisible tw-absolute tw-left-0 tw-top-[5px] -tw-translate-x-full tw-text-base tw-text-primary tw-opacity-0 tw-transition-all tw-duration-300 group-hover:tw-visible group-hover:tw-translate-x-0 group-hover:tw-opacity-100"
+                                aria-hidden="true"
+                            />
                             <span>{title}</span>
                         </Anchor>
                     ))}

--- a/src/containers/event-details/summary.tsx
+++ b/src/containers/event-details/summary.tsx
@@ -17,14 +17,20 @@ function Summary({ start_date, end_date, start_time, end_time, venue, title, bod
                 </h2>
                 <div className="tw-mb-10 tw-flex tw-flex-wrap tw-items-center tw-justify-center lg:tw-mb-15">
                     <div className="tw-mx-3 tw-mb-[5px]">
-                        <i className="fal fa-calendar tw-mr-[5px] tw-text-primary" />
+                        <i
+                            className="fal fa-calendar tw-mr-[5px] tw-text-primary"
+                            aria-hidden="true"
+                        />
                         <span>
                             {formatDate(start_date)} - {formatDate(end_date)}
                         </span>
                     </div>
 
                     <div className="tw-mx-3 tw-mb-[5px]">
-                        <i className="fal fa-clock tw-mr-[5px] tw-text-primary" />
+                        <i
+                            className="fal fa-clock tw-mr-[5px] tw-text-primary"
+                            aria-hidden="true"
+                        />
                         <span>
                             {formatDate(`${start_date} ${start_time}`, "h:mm a")} -{" "}
                             {formatDate(`${end_date} ${end_time}`, "h:mm a")}
@@ -32,7 +38,10 @@ function Summary({ start_date, end_date, start_time, end_time, venue, title, bod
                     </div>
 
                     <div className="tw-mx-3 tw-mb-[5px]">
-                        <i className="fal fa-video tw-mr-[5px] tw-text-primary" />
+                        <i
+                            className="fal fa-video tw-mr-[5px] tw-text-primary"
+                            aria-hidden="true"
+                        />
                         <span>{venue}</span>
                     </div>
                 </div>

--- a/src/containers/faq/layout-03/index.tsx
+++ b/src/containers/faq/layout-03/index.tsx
@@ -71,11 +71,17 @@ const FaqArea = ({ data: { images, items } }: TProps) => {
                                 variants={scrollUpVariants}
                             >
                                 <h4 className="tw-relative tw-pl-8 tw-text-lg tw-font-semibold md:tw-max-w-[310px]">
-                                    <i className="far fa-long-arrow-right tw-absolute tw-left-0 tw-top-2 tw-text-primary" />
+                                    <i
+                                        className="far fa-long-arrow-right tw-absolute tw-left-0 tw-top-2 tw-text-primary"
+                                        aria-hidden="true"
+                                    />
                                     {item.title}
                                 </h4>
                                 <div className="tw-relative tw-mt-5 tw-pl-8 md:tw-mt-0">
-                                    <i className="far fa-check tw-absolute tw-left-0 tw-top-2 tw-text-primary" />
+                                    <i
+                                        className="far fa-check tw-absolute tw-left-0 tw-top-2 tw-text-primary"
+                                        aria-hidden="true"
+                                    />
                                     {item.texts?.map((text) => (
                                         <p key={text.id}>{text.content}</p>
                                     ))}

--- a/src/containers/hero/layout-01/index.tsx
+++ b/src/containers/hero/layout-01/index.tsx
@@ -65,7 +65,7 @@ const HeroArea = ({ data: { headings, texts, buttons, images, popularCourse } }:
                         ))}
                         {buttons?.map(({ id, content, icon, ...rest }) => (
                             <Button key={id} className="tw-mt-3" {...rest}>
-                                <i className={clsx(icon, "tw-mr-3")} />
+                                <i className={clsx(icon, "tw-mr-3")} aria-hidden="true" />
                                 {content}
                             </Button>
                         ))}

--- a/src/containers/hero/layout-02/index.tsx
+++ b/src/containers/hero/layout-02/index.tsx
@@ -44,7 +44,7 @@ const HeroArea = ({ data: { headings, texts, buttons, motto, images } }: TProps)
 
                     {buttons?.map(({ id, content, icon, ...rest }) => (
                         <Button key={id} className="tw-mt-5" {...rest}>
-                            <i className={clsx(icon, "tw-mr-4")} />
+                            <i className={clsx(icon, "tw-mr-4")} aria-hidden="true" />
                             {content}
                         </Button>
                     ))}

--- a/src/containers/hero/layout-03/index.tsx
+++ b/src/containers/hero/layout-03/index.tsx
@@ -48,7 +48,7 @@ const HeroArea = ({ data: { headings, buttons, images } }: TProps) => {
                 {buttons?.map(({ id, content, icon, ...rest }) => (
                     <Button key={id} className="tw-mt-7" {...rest}>
                         {content}
-                        <i className={clsx(icon, "tw-ml-4")} />
+                        <i className={clsx(icon, "tw-ml-4")} aria-hidden="true" />
                     </Button>
                 ))}
             </motion.div>

--- a/src/containers/hero/layout-04/index.tsx
+++ b/src/containers/hero/layout-04/index.tsx
@@ -148,7 +148,10 @@ const HeroArea = ({ data: { images, headings, texts, buttons, video } }: TProps)
                                     variant="outlined"
                                     onClick={() => setOpen(true)}
                                 >
-                                    <i className={clsx(buttons[1]?.icon, "tw-mr-4")} />
+                                    <i
+                                        className={clsx(buttons[1]?.icon, "tw-mr-4")}
+                                        aria-hidden="true"
+                                    />
                                     {buttons[1].content}
                                 </Button>
                             )}

--- a/src/containers/hero/layout-05/index.tsx
+++ b/src/containers/hero/layout-05/index.tsx
@@ -40,7 +40,7 @@ const HeroArea = ({ data: { headings, texts, buttons, images } }: TProps) => {
                     ))}
                     {buttons?.map(({ id, content, icon, ...rest }) => (
                         <Button key={id} className="tw-mt-5" {...rest}>
-                            {icon && <i className={clsx(icon, "tw-mr-3")} />}
+                            {icon && <i className={clsx(icon, "tw-mr-3")} aria-hidden="true" />}
                             {content}
                         </Button>
                     ))}

--- a/src/containers/hero/layout-06/index.tsx
+++ b/src/containers/hero/layout-06/index.tsx
@@ -46,7 +46,7 @@ const HeroArea = ({ data: { headings, texts, buttons, images, video } }: TProps)
                     {buttons?.map(({ id, content, icon, ...rest }) => (
                         <Button key={id} {...rest}>
                             {content}
-                            {icon && <i className={clsx(icon, "tw-ml-4")} />}
+                            {icon && <i className={clsx(icon, "tw-ml-4")} aria-hidden="true" />}
                         </Button>
                     ))}
                 </motion.div>

--- a/src/containers/ways-to-give/index.tsx
+++ b/src/containers/ways-to-give/index.tsx
@@ -72,7 +72,10 @@ const WaysToGive = ({ data: { section_title, items }, space, bg }: TProps) => {
 
                                 <span className="tw-inline-flex tw-items-center tw-text-md tw-font-bold tw-leading-none tw-text-secondary-light tw-transition-colors tw-duration-300 group-hover:tw-text-primary">
                                     {item.pathText}
-                                    <i className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]" />
+                                    <i
+                                        className="far fa-long-arrow-right tw-ml-3.5 tw-text-[16px]"
+                                        aria-hidden="true"
+                                    />
                                 </span>
 
                                 {/* Anchor defaults to target=_blank rel=noopener for external paths */}

--- a/src/layouts/headers/header.tsx
+++ b/src/layouts/headers/header.tsx
@@ -56,7 +56,10 @@ const Header = ({ shadow, fluid }: TProps) => {
                                     New Cohort Starts:
                                 </p>
                                 <div className="tw-flex tw-items-center sm:tw-mr-[45px] md:tw-mr-5 lg:tw-mr-[45px]">
-                                    <i className="far fa-clock tw-mr-[5px] tw-text-lg tw-text-secondary" />
+                                    <i
+                                        className="far fa-clock tw-mr-[5px] tw-text-lg tw-text-secondary"
+                                        aria-hidden="true"
+                                    />
                                     <CountdownTimer targetDate={cohortStartDate || ""} />
                                 </div>
                             </>

--- a/src/layouts/sidebar/item.tsx
+++ b/src/layouts/sidebar/item.tsx
@@ -26,6 +26,7 @@ const Item = ({ title, type, duration, video, access, path }: IProps) => {
                         type === "lesson" && "fa-file-alt",
                         type === "quiz" && "fa-clock"
                     )}
+                    aria-hidden="true"
                 />
                 <span>{title}</span>
             </div>
@@ -51,7 +52,7 @@ const Item = ({ title, type, duration, video, access, path }: IProps) => {
                 )}
                 {access === "paid" && video && (
                     <span className="tw-ml-2.5 tw-px-3.8 tw-font-medium">
-                        <i className="far fa-video" />
+                        <i className="far fa-video" role="img" aria-label="Video" />
                     </span>
                 )}
             </div>

--- a/src/layouts/sidebar/search-form.tsx
+++ b/src/layouts/sidebar/search-form.tsx
@@ -31,7 +31,7 @@ const SearchForm02 = ({ className }: TProps) => {
                 aria-label="Search"
                 className="tw-absolute tw-right-2.5 tw-top-0 tw-mx-2.5 tw-h-full tw-w-4 tw-text-white"
             >
-                <i className="far fa-search" />
+                <i className="far fa-search" aria-hidden="true" />
             </button>
         </form>
     );

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -27,10 +27,10 @@ const Error404Page = () => {
                         </p>
                         <div className="tw-mt-8">
                             <Button className="tw-m-2.5" onClick={() => router.back()}>
-                                <i className="far fa-history tw-mr-3" /> Go back
+                                <i className="far fa-history tw-mr-3" aria-hidden="true" /> Go back
                             </Button>
                             <Button className="tw-m-2.5" path="/">
-                                <i className="far fa-home tw-mr-3" /> Homepage
+                                <i className="far fa-home tw-mr-3" aria-hidden="true" /> Homepage
                             </Button>
                         </div>
                     </div>

--- a/src/pages/portfolio-checklist.tsx
+++ b/src/pages/portfolio-checklist.tsx
@@ -556,7 +556,7 @@ const PortfolioChecklist: PageProps = () => {
                             title="Print or save as PDF"
                             aria-label="Print checklist or save as PDF"
                         >
-                            <i className="fas fa-print tw-mr-1.5" />
+                            <i className="fas fa-print tw-mr-1.5" aria-hidden="true" />
                             Print / PDF
                         </button>
                         <button
@@ -566,7 +566,7 @@ const PortfolioChecklist: PageProps = () => {
                             title="Reset all checkboxes"
                             aria-label="Reset all checkboxes to unchecked"
                         >
-                            <i className="fas fa-undo tw-mr-1.5" />
+                            <i className="fas fa-undo tw-mr-1.5" aria-hidden="true" />
                             Reset
                         </button>
                     </div>
@@ -674,6 +674,7 @@ const PortfolioChecklist: PageProps = () => {
                                                 ? "fas fa-check-circle tw-text-navy-ocean"
                                                 : "far fa-circle tw-text-gray-100"
                                         )}
+                                        aria-hidden="true"
                                     />
                                     <span className="tw-truncate">
                                         {section.number}. {section.title}
@@ -687,7 +688,10 @@ const PortfolioChecklist: PageProps = () => {
                             href="#quality-bar"
                             className="tw-flex tw-items-center tw-gap-2 tw-rounded-md tw-px-2 tw-py-1 tw-text-sm tw-text-gray-300 tw-transition-colors hover:tw-bg-gray-50"
                         >
-                            <i className="far fa-star tw-text-xs tw-text-primary" />
+                            <i
+                                className="far fa-star tw-text-xs tw-text-primary"
+                                aria-hidden="true"
+                            />
                             <span className="tw-truncate">Quality Bar</span>
                         </a>
                     </li>

--- a/src/pages/team/[slug].tsx
+++ b/src/pages/team/[slug].tsx
@@ -60,7 +60,11 @@ const MemberProfile: PageProps = ({ data: { member } }) => {
                                             title={social.label}
                                             className="tw-text-primary tw-transition-colors hover:tw-text-secondary"
                                         >
-                                            <i className={`${social.icon} tw-text-3xl`} />
+                                            <i
+                                                className={`${social.icon} tw-text-3xl`}
+                                                aria-hidden="true"
+                                            />
+                                            <span className="tw-sr-only">{social.label}</span>
                                         </a>
                                     ))}
                                 </div>


### PR DESCRIPTION
## Problem

FontAwesome icons are empty `<i>` elements whose glyph comes from CSS, and screen readers can announce them. Only 5 of 223 icons carried `aria-hidden` (#566).

## Solution

Adds `aria-hidden="true"` to 78 decorative FontAwesome icons across 49 files on the public marketing surface: blog, event, media, and team cards, social links and share bars, widgets, sidebar, header, hero layouts, FAQ, 404, and the portfolio checklist. Icon-only controls keep an accessible name: the mobile submenu toggle and the swiper arrows gained `aria-label`s, and the team-member social links gained screen-reader-only text (Biome's `useAnchorContent` flags anchors whose only child is hidden). One icon carries meaning with no adjacent text, the paid-lesson video marker in the sidebar, and gets `role="img"` with a label instead.

Troop and LMS pages (jobs, profile, translator, admin, assessment) are intentionally out of scope for this pass.

A small test renders the social links and blog meta items and asserts every icon is hidden while links keep their labels.

Closes #566

## Verification

```
npx vitest run __tests__/components/decorative-icons.test.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test          # 72 files, 567 tests
```
