### PR TITLE
fix(a11y): Use post titles for blog image alt text

### DIFF
--- a/__tests__/components/blog-card.test.tsx
+++ b/__tests__/components/blog-card.test.tsx
@@ -1,0 +1,36 @@
+import BlogCard from "@components/blog-card/blog-03";
+import { render, screen } from "@testing-library/react";
+
+const PROPS = {
+    path: "/blog/combat-to-code",
+    title: "From Combat to Code",
+    category: { title: "Career", slug: "career", path: "/blog/category/career" },
+    postedAt: "Jan 1, 2026",
+};
+
+describe("BlogCard (blog-03)", () => {
+    it("falls back to the post title for the image alt when none is provided", () => {
+        render(<BlogCard {...PROPS} image={{ src: "/images/combat-to-code.png" }} />);
+
+        expect(screen.getByRole("img")).toHaveAttribute("alt", "From Combat to Code");
+    });
+
+    it("uses the image's own alt text when it is provided", () => {
+        render(
+            <BlogCard
+                {...PROPS}
+                image={{ src: "/images/combat-to-code.png", alt: "Marine at a laptop" }}
+            />
+        );
+
+        expect(screen.getByRole("img")).toHaveAttribute("alt", "Marine at a laptop");
+    });
+
+    it("marks the image figure as presentational", () => {
+        const { container } = render(
+            <BlogCard {...PROPS} image={{ src: "/images/combat-to-code.png" }} />
+        );
+
+        expect(container.querySelector("figure")).toHaveAttribute("role", "none");
+    });
+});

--- a/src/components/blog-card/blog-03.tsx
+++ b/src/components/blog-card/blog-03.tsx
@@ -16,11 +16,14 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-relative tw-h-[250px] tw-overflow-hidden">
                     {image?.src && (
-                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110">
+                        <figure
+                            role="none"
+                            className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110"
+                        >
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"
                                 src={image.src}
-                                alt={image?.alt || "Blog"}
+                                alt={image?.alt || title}
                                 width={image.width || 480}
                                 height={image.height || 250}
                                 loading={image.loading || "lazy"}

--- a/src/containers/blog-details/index.tsx
+++ b/src/containers/blog-details/index.tsx
@@ -12,7 +12,7 @@ function BlogDetails({ image, title, category, author, postedAt, content, tags, 
         <article className="blog-details tw-mb-10 tw-border-b tw-border-b-gray-500 tw-pb-7.5">
             <div className="entry-header tw-mb-5">
                 {image?.src && (
-                    <figure className="tw-mb-7">
+                    <figure role="none" className="tw-mb-7">
                         <img
                             className="tw-w-full tw-rounded tw-object-cover"
                             src={image.src}

--- a/src/data/blogs/beyond-the-resume.md
+++ b/src/data/blogs/beyond-the-resume.md
@@ -35,7 +35,7 @@ When Darnell Settles III, Director of Web and Digital Strategy at Methodist Le B
 Darnell reflects on the hiring process: "One aspect that stood out to me the most was the sense that candidates from Vets Who Code are known commodities. I expected our hire to hit the ground running, and I must say, my expectations were not only met but exceeded." This initial impression was crucial, highlighting the rigorous training and discipline instilled in veterans through programs like Vets Who Code, which equips them with the necessary technical skills and industry knowledge to excel in the tech industry.
 
 <p align="center">
-  <img src="v1714768081/adrian_grimm_blog_image_rfyamx.png" alt="Adrian Grimm">
+  <img src="v1714768081/adrian_grimm_blog_image_rfyamx.png" alt="Adrian Grimm, Web Developer II at Methodist Le Bonheur Healthcare, United States Marine Corps veteran and Vets Who Code alumnus">
 </p>
 
 ### **Adrian's Impact at Methodist**


### PR DESCRIPTION
## Problem

The homepage blog cards fell back to `alt="Blog"` for every post image, so the three featured posts named in #567 read as three identical "Blog" images to screen readers. The blog figures carry no caption, so the `figure` semantics only add noise. The inline image in the Methodist case study is a text banner whose alt was just "Adrian Grimm" (#755).

## Solution

- `blog-03` card now falls back to the post title for alt text, matching the other blog cards, and its figure is marked `role="none"`.
- The blog details header figure is marked `role="none"`.
- The Adrian Grimm banner alt now carries the text the image shows.

The blog header URL already goes through `getBlogHeaderUrl` (`f_auto,q_auto,w_1200,c_limit`), so #755's transformation change is not needed; the proposed square face crop would also have mangled a 10:3 banner.

Closes #567
Closes #755

## Verification

```
npx vitest run __tests__/components/blog-card.test.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test          # 72 files, 567 tests
```
