### PR TITLE
perf(images): Serve sized Cloudinary variants for heavy static images

### DIFF
--- a/__tests__/components/blog-card.test.tsx
+++ b/__tests__/components/blog-card.test.tsx
@@ -1,0 +1,36 @@
+import BlogCard from "@components/blog-card/blog-03";
+import { render, screen } from "@testing-library/react";
+
+const PROPS = {
+    path: "/blog/combat-to-code",
+    title: "From Combat to Code",
+    category: { title: "Career", slug: "career", path: "/blog/category/career" },
+    postedAt: "Jan 1, 2026",
+};
+
+describe("BlogCard (blog-03)", () => {
+    it("falls back to the post title for the image alt when none is provided", () => {
+        render(<BlogCard {...PROPS} image={{ src: "/images/combat-to-code.png" }} />);
+
+        expect(screen.getByRole("img")).toHaveAttribute("alt", "From Combat to Code");
+    });
+
+    it("uses the image's own alt text when it is provided", () => {
+        render(
+            <BlogCard
+                {...PROPS}
+                image={{ src: "/images/combat-to-code.png", alt: "Marine at a laptop" }}
+            />
+        );
+
+        expect(screen.getByRole("img")).toHaveAttribute("alt", "Marine at a laptop");
+    });
+
+    it("marks the image figure as presentational", () => {
+        const { container } = render(
+            <BlogCard {...PROPS} image={{ src: "/images/combat-to-code.png" }} />
+        );
+
+        expect(container.querySelector("figure")).toHaveAttribute("role", "none");
+    });
+});

--- a/src/components/blog-card/blog-03.tsx
+++ b/src/components/blog-card/blog-03.tsx
@@ -16,11 +16,14 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-relative tw-h-[250px] tw-overflow-hidden">
                     {image?.src && (
-                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110">
+                        <figure
+                            role="none"
+                            className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110"
+                        >
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"
                                 src={image.src}
-                                alt={image?.alt || "Blog"}
+                                alt={image?.alt || title}
                                 width={image.width || 480}
                                 height={image.height || 250}
                                 loading={image.loading || "lazy"}

--- a/src/components/ui/offcanvas/index.tsx
+++ b/src/components/ui/offcanvas/index.tsx
@@ -67,7 +67,7 @@ const Offcanvas = memo(({ className, onClose, isOpen, children }: TProps) => {
                     >
                         <motion.div
                             className={clsx(
-                                "tw-relative tw-z-30 tw-ml-auto tw-h-full tw-w-[300px] tw-bg-secondary tw-bg-[url('https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto/v1698904153/mobile-image_ssvugk.png')] tw-bg-cover tw-bg-top tw-bg-no-repeat sm:tw-w-[360px]",
+                                "tw-relative tw-z-30 tw-ml-auto tw-h-full tw-w-[300px] tw-bg-secondary tw-bg-[url('https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,dpr_auto,c_limit,w_360/v1698904153/mobile-image_ssvugk.png')] tw-bg-cover tw-bg-top tw-bg-no-repeat sm:tw-w-[360px]",
                                 "before:tw-absolute before:tw-inset-0 before:-tw-z-1 before:tw-bg-secondary/90 before:tw-content-['']",
                                 className
                             )}

--- a/src/components/ui/spinner/index.tsx
+++ b/src/components/ui/spinner/index.tsx
@@ -2,7 +2,7 @@ const Spinner = () => {
     return (
         <div className="tw-mx-auto tw-my-10 tw-h-10 tw-w-10 tw-animate-[rotatePlane_1.2s_infinite_ease-in-out] tw-bg-primary">
             <img
-                src="https://res.cloudinary.com/vetswhocode/image/upload/v1627489505/vwc_kym0qt.gif"
+                src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,dpr_auto,c_limit,w_40/v1627489505/vwc_kym0qt.gif"
                 alt="Loading"
                 className="tw-h-full tw-w-full"
             />

--- a/src/containers/blog-details/index.tsx
+++ b/src/containers/blog-details/index.tsx
@@ -12,7 +12,7 @@ function BlogDetails({ image, title, category, author, postedAt, content, tags, 
         <article className="blog-details tw-mb-10 tw-border-b tw-border-b-gray-500 tw-pb-7.5">
             <div className="entry-header tw-mb-5">
                 {image?.src && (
-                    <figure className="tw-mb-7">
+                    <figure role="none" className="tw-mb-7">
                         <img
                             className="tw-w-full tw-rounded tw-object-cover"
                             src={image.src}

--- a/src/containers/newsletter/layout-02/index.tsx
+++ b/src/containers/newsletter/layout-02/index.tsx
@@ -16,7 +16,7 @@ const NewsletterArea = ({ data: { section_title }, space, bg, titleSize }: TProp
         <Section className="tw-relative" space={space} bg={bg} id="newsletter">
             <div className="tw-absolute tw-inset-0 -tw-z-1 child:tw-h-full child:tw-w-full child:tw-object-cover">
                 <img
-                    src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto/v1678670156/website-images/vetswhocode-newsletter-bg.jpg"
+                    src="https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,dpr_auto,c_fill,w_1920,h_1080/v1678670156/website-images/vetswhocode-newsletter-bg.jpg"
                     alt="newsletter BG"
                 />
             </div>

--- a/src/data/blogs/beyond-the-resume.md
+++ b/src/data/blogs/beyond-the-resume.md
@@ -35,7 +35,7 @@ When Darnell Settles III, Director of Web and Digital Strategy at Methodist Le B
 Darnell reflects on the hiring process: "One aspect that stood out to me the most was the sense that candidates from Vets Who Code are known commodities. I expected our hire to hit the ground running, and I must say, my expectations were not only met but exceeded." This initial impression was crucial, highlighting the rigorous training and discipline instilled in veterans through programs like Vets Who Code, which equips them with the necessary technical skills and industry knowledge to excel in the tech industry.
 
 <p align="center">
-  <img src="v1714768081/adrian_grimm_blog_image_rfyamx.png" alt="Adrian Grimm">
+  <img src="v1714768081/adrian_grimm_blog_image_rfyamx.png" alt="Adrian Grimm, Web Developer II at Methodist Le Bonheur Healthcare, United States Marine Corps veteran and Vets Who Code alumnus">
 </p>
 
 ### **Adrian's Impact at Methodist**

--- a/src/data/software-factory.ts
+++ b/src/data/software-factory.ts
@@ -208,7 +208,7 @@ export const TEAM: TeamMember[] = [
         branch: "USAF Security Forces · 2004–2009",
         specialty: "Google Developer Expert · GitHub Star · White House honoree",
         body: "Jerome is a working software engineer first and a founder second — the rare nonprofit leader who still ships code on Monday and teaches it on Tuesday. An Air Force Security Forces veteran with 15+ years of production AI experience at Microsoft, Vista Equity Partners, and now Accenture Federal Services, he runs Vets Who Code the way he runs engineering teams: in the work, not above it. He's a Google Developer Expert, GitHub Star, and White House honoree, with courses on LinkedIn Learning and Frontend Masters. Since founding VWC in 2014, he's trained over 300 veterans and military spouses, unlocking $20M+ in graduate earnings — and personally mentored many of them.",
-        image: "https://res.cloudinary.com/vetswhocode/image/upload/v1683429329/jerome-headshot-bw-3900.jpg",
+        image: "https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,c_fill,g_face,w_1200,h_1474/v1683429329/jerome-headshot-bw-3900.jpg",
     },
     {
         name: "Ayumi Fukuda Bennett",

--- a/src/data/team-members.json
+++ b/src/data/team-members.json
@@ -6,7 +6,7 @@
         "path": "/team/jerome-hardaway",
         "url": "",
         "image": {
-            "src": "https://res.cloudinary.com/vetswhocode/image/upload/v1683429329/jerome-headshot-bw-3900.jpg",
+            "src": "https://res.cloudinary.com/vetswhocode/image/upload/f_auto,q_auto:good,c_fill,g_face,w_1200,h_1474/v1683429329/jerome-headshot-bw-3900.jpg",
             "width": 350,
             "height": 430
         },


### PR DESCRIPTION
## Problem

Four static images were served at their source size (#750, #751, #753, #754). The founder headshot alone was a 1.9 MB JPEG on the team page.

## Solution

Swap each URL for a Cloudinary variant sized to its render box:

| Image | Before | After |
| --- | --- | --- |
| Offcanvas sidebar background (`c_limit,w_360`) | 134 KB | 24 KB |
| Loading spinner GIF (`c_limit,w_40`) | 473 KB | 20 KB |
| Newsletter background (`c_fill,w_1920,h_1080`) | 73 KB | 22 KB |
| Founder headshot (`c_fill,g_face,w_1200,h_1474`) | 1,878 KB | 137 KB |

The headshot crop differs from the 470×470 square in #754 because the "ProfileBio" component that issue referenced no longer exists. Its real render sites are the team page cards (about 570 CSS px wide), the team member page, and the software-factory team section via `next/image`, so the crop is sized for those boxes at 2x and `next/image` downsamples from it. `dpr_auto` is omitted from the headshot URL because the site sends no DPR client hint, so Cloudinary always resolves it to 1x.

#748 (header logo) is closed separately: the proposed transformation returns a byte-identical 2 KB file.

Closes #750
Closes #751
Closes #753
Closes #754

## Verification

```
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test          # 72 files, 567 tests
curl -sI <each new URL>   # HTTP 200, sizes above measured with a browser Accept header
```
