### PR TITLE
test(forms): Cover the contact form validation and submission

### DIFF
--- a/__tests__/components/forms/contact-form.test.tsx
+++ b/__tests__/components/forms/contact-form.test.tsx
@@ -1,0 +1,200 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import axios, { type AxiosResponse } from "axios";
+import ContactUsForm from "@/components/forms/contact-us-form";
+
+vi.mock("axios");
+
+const mockPost = vi.mocked(axios.post);
+
+const VALID = {
+    name: "Jane Engineer",
+    email: "jane@example.com",
+    subject: "Hiring question",
+    reason: "Hiring our troops",
+    message: "We want to hire two of your software engineers.",
+};
+
+const SUCCESS = "Thank you for your message!";
+const FAILURE = "There was an error. Please try again later.";
+
+const field = (label: string) => screen.getByLabelText(label);
+
+const fillRequiredFields = () => {
+    fireEvent.change(field("Name"), { target: { value: VALID.name } });
+    fireEvent.change(field("Email"), { target: { value: VALID.email } });
+    fireEvent.change(field("Subject"), { target: { value: VALID.subject } });
+    fireEvent.change(field("Reason for reaching out"), { target: { value: VALID.reason } });
+    fireEvent.change(field("Message"), { target: { value: VALID.message } });
+};
+
+const submit = () => fireEvent.click(screen.getByRole("button", { name: "Send Message" }));
+
+const roleButton = (name: string) => screen.getByRole("button", { name });
+
+describe("ContactUsForm", () => {
+    beforeEach(() => {
+        mockPost.mockReset();
+    });
+
+    it("renders the labelled fields, role toggles and submit button", () => {
+        render(<ContactUsForm />);
+
+        expect(field("Name")).toBeInTheDocument();
+        expect(field("Email")).toBeInTheDocument();
+        expect(field("Phone")).toBeInTheDocument();
+        expect(field("Subject")).toBeInTheDocument();
+        expect(field("Reason for reaching out")).toBeInTheDocument();
+        expect(field("Message")).toBeInTheDocument();
+
+        expect(roleButton("Applicant")).toHaveAttribute("aria-pressed", "true");
+        expect(roleButton("Partner")).toHaveAttribute("aria-pressed", "false");
+        expect(roleButton("Press")).toHaveAttribute("aria-pressed", "false");
+
+        expect(screen.getByRole("button", { name: "Send Message" })).toHaveAttribute(
+            "type",
+            "submit"
+        );
+    });
+
+    it("shows required-field errors on an empty submit and does not post", async () => {
+        render(<ContactUsForm />);
+
+        submit();
+
+        expect(await screen.findByText("Name is required")).toBeInTheDocument();
+        expect(screen.getByText("Email is required")).toBeInTheDocument();
+        expect(screen.getByText("Subject is required")).toBeInTheDocument();
+        expect(screen.getByText("Reason is required")).toBeInTheDocument();
+        expect(screen.getByText("Message is required")).toBeInTheDocument();
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("rejects a malformed email address", async () => {
+        render(<ContactUsForm />);
+
+        fillRequiredFields();
+        // Native type="email" validation would block the submit for an address with no
+        // "@", so use one the browser accepts but the app validator (which wants a TLD) rejects.
+        fireEvent.change(field("Email"), { target: { value: "jane@example" } });
+        submit();
+
+        expect(await screen.findByText("Invalid email format")).toBeInTheDocument();
+        expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it("treats phone as optional but validates a typed value", async () => {
+        mockPost.mockResolvedValue({ status: 200 } as AxiosResponse);
+        render(<ContactUsForm />);
+
+        fillRequiredFields();
+        fireEvent.change(field("Phone"), { target: { value: "not a number" } });
+        submit();
+
+        expect(await screen.findByText("Invalid phone number format")).toBeInTheDocument();
+        expect(mockPost).not.toHaveBeenCalled();
+
+        fireEvent.change(field("Phone"), { target: { value: "" } });
+        submit();
+
+        await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+        expect(screen.queryByText("Invalid phone number format")).not.toBeInTheDocument();
+        expect(mockPost).toHaveBeenCalledWith(
+            "/api/contact",
+            expect.objectContaining({ phone: "" })
+        );
+    });
+
+    it("sends the selected role with the submission", async () => {
+        mockPost.mockResolvedValue({ status: 200 } as AxiosResponse);
+        render(<ContactUsForm />);
+
+        fireEvent.click(roleButton("Press"));
+        expect(roleButton("Press")).toHaveAttribute("aria-pressed", "true");
+        expect(roleButton("Applicant")).toHaveAttribute("aria-pressed", "false");
+
+        fillRequiredFields();
+        submit();
+
+        await waitFor(() =>
+            expect(mockPost).toHaveBeenCalledWith(
+                "/api/contact",
+                expect.objectContaining({ role: "Press" })
+            )
+        );
+    });
+
+    it("posts the form, thanks the sender and resets everything on success", async () => {
+        mockPost.mockResolvedValue({ status: 200 } as AxiosResponse);
+        render(<ContactUsForm />);
+
+        fireEvent.click(roleButton("Partner"));
+        fillRequiredFields();
+        fireEvent.change(field("Phone"), { target: { value: "(555) 555-5555" } });
+        submit();
+
+        expect(await screen.findByText(SUCCESS)).toBeInTheDocument();
+        expect(mockPost).toHaveBeenCalledTimes(1);
+        expect(mockPost).toHaveBeenCalledWith("/api/contact", {
+            ...VALID,
+            phone: "(555) 555-5555",
+            role: "Partner",
+            website: "",
+        });
+
+        expect(field("Name")).toHaveValue("");
+        expect(field("Email")).toHaveValue("");
+        expect(field("Phone")).toHaveValue("");
+        expect(field("Subject")).toHaveValue("");
+        expect(field("Reason for reaching out")).toHaveValue("");
+        expect(field("Message")).toHaveValue("");
+        expect(roleButton("Applicant")).toHaveAttribute("aria-pressed", "true");
+        expect(roleButton("Partner")).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("shows the error message when the request is rejected", async () => {
+        mockPost.mockRejectedValue(new Error("Network Error"));
+        render(<ContactUsForm />);
+
+        fillRequiredFields();
+        submit();
+
+        expect(await screen.findByText(FAILURE)).toBeInTheDocument();
+        expect(screen.queryByText(SUCCESS)).not.toBeInTheDocument();
+        expect(field("Name")).toHaveValue(VALID.name);
+    });
+
+    it("shows the error message when the response is not a 200", async () => {
+        mockPost.mockResolvedValue({ status: 202 } as AxiosResponse);
+        render(<ContactUsForm />);
+
+        fillRequiredFields();
+        submit();
+
+        expect(await screen.findByText(FAILURE)).toBeInTheDocument();
+        expect(screen.queryByText(SUCCESS)).not.toBeInTheDocument();
+        expect(field("Name")).toHaveValue(VALID.name);
+    });
+
+    it("disables the submit button while the request is pending", async () => {
+        let settle: (value: AxiosResponse) => void = () => {};
+        mockPost.mockReturnValue(
+            new Promise<AxiosResponse>((resolve) => {
+                settle = resolve;
+            })
+        );
+        render(<ContactUsForm />);
+
+        fillRequiredFields();
+        submit();
+
+        const button = screen.getByRole("button", { name: "Send Message" });
+        await waitFor(() => expect(button).toBeDisabled());
+
+        await act(async () => {
+            settle({ status: 200 } as AxiosResponse);
+        });
+
+        expect(await screen.findByText(SUCCESS)).toBeInTheDocument();
+        expect(button).toBeEnabled();
+    });
+});

--- a/__tests__/components/forms/newsletter-form.test.tsx
+++ b/__tests__/components/forms/newsletter-form.test.tsx
@@ -1,0 +1,119 @@
+import NewsletterForm from "@components/forms/newsletter-form";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockFetch = vi.fn();
+
+function jsonResponse(payload: unknown) {
+    return { json: () => Promise.resolve(payload) } as unknown as Response;
+}
+
+function renderForm() {
+    render(<NewsletterForm />);
+    return {
+        input: screen.getByLabelText("Newsletter") as HTMLInputElement,
+        submit: screen.getByRole("button", { name: "Subscribe" }),
+    };
+}
+
+describe("NewsletterForm", () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+        vi.stubGlobal("fetch", mockFetch);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("renders the email input and the Subscribe button", () => {
+        const { input, submit } = renderForm();
+
+        expect(input).toHaveAttribute("type", "email");
+        expect(input).toHaveAttribute("placeholder", "Your E-mail");
+        expect(submit).toHaveAttribute("type", "submit");
+    });
+
+    it("shows the required error and does not call fetch when submitted empty", async () => {
+        const { submit } = renderForm();
+
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Email is required")).toBeInTheDocument();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("shows the format error and does not call fetch for an invalid email", async () => {
+        const { input, submit } = renderForm();
+
+        // Passes the browser's native type="email" check (so the submit event fires)
+        // but fails validateEmail, which requires a dotted top-level domain.
+        fireEvent.change(input, { target: { value: "jody@example" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Invalid email format")).toBeInTheDocument();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("posts a valid email to /api/newsletter, then shows success and clears the input", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: true }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Thank you for subscribing!")).toBeInTheDocument();
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe("/api/newsletter");
+        expect(options.method).toBe("POST");
+        expect(JSON.parse(options.body)).toEqual({ newsletter_email: "jody@example.com" });
+        await waitFor(() => {
+            expect(input.value).toBe("");
+        });
+    });
+
+    it("shows the server error and no success message when the API rejects the email", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: false, error: "Already subscribed" }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Already subscribed")).toBeInTheDocument();
+        expect(screen.queryByText("Thank you for subscribing!")).not.toBeInTheDocument();
+    });
+
+    it("falls back to a generic error when the API fails without a message", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: false }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("OOPS Something went wrong")).toBeInTheDocument();
+    });
+
+    it("shows the thrown error message when fetch rejects", async () => {
+        mockFetch.mockRejectedValue(new Error("Network down"));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Network down")).toBeInTheDocument();
+        expect(screen.queryByText("Thank you for subscribing!")).not.toBeInTheDocument();
+    });
+
+    it("clears the error message when the user types again", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: false, error: "Already subscribed" }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+        expect(await screen.findByText("Already subscribed")).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "jody+new@example.com" } });
+
+        expect(screen.queryByText("Already subscribed")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/forms/newsletter-form.tsx
+++ b/src/components/forms/newsletter-form.tsx
@@ -53,6 +53,13 @@ const NewsletterForm = forwardRef<HTMLFormElement, TProps>(({ className }, ref) 
         }
     };
 
+    const emailField = register("newsletter_email", {
+        validate: (value) => {
+            const result = validateEmail(value);
+            return result.isValid ? true : result.error || "";
+        },
+    });
+
     return (
         <form
             className={clsx("tw-relative tw-flex tw-max-w-[570px] tw-flex-wrap", className)}
@@ -71,15 +78,11 @@ const NewsletterForm = forwardRef<HTMLFormElement, TProps>(({ className }, ref) 
                     feedbackText={errors?.newsletter_email?.message}
                     state={hasKey(errors, "newsletter_email") ? "error" : "success"}
                     showState={!!hasKey(errors, "newsletter_email")}
-                    {...register("newsletter_email", {
-                        validate: (value) => {
-                            const result = validateEmail(value);
-                            return result.isValid ? true : result.error || "";
-                        },
-                    })}
-                    onChange={() => {
+                    {...emailField}
+                    onChange={(e) => {
                         setErrorMessage("");
                         setMessage("");
+                        emailField.onChange(e);
                     }}
                 />
             </div>


### PR DESCRIPTION
## Problem

The contact form on `/contact-us` had no component tests (#825).

## Solution

Adds `__tests__/components/forms/contact-form.test.tsx` for `contact-us-form.tsx` (the live form; `contact-form.tsx` is the legacy `/contact-me` duplicate and is not covered on purpose). It covers rendering and labels, required-field and email validation, optional phone handling, the role toggle, the `/api/contact` payload including role and the untouched honeypot, the success message and reset, the rejection and non-200 error paths, and the disabled submit button while pending (relies on the Button fix earlier in this stack).

Closes #825

## Verification

```
npx vitest run __tests__/components/forms/contact-form.test.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test          # 72 files, 567 tests
```
