### PR TITLE
fix(forms): Forward newsletter input changes to react-hook-form

### DIFF
--- a/__tests__/components/forms/newsletter-form.test.tsx
+++ b/__tests__/components/forms/newsletter-form.test.tsx
@@ -1,0 +1,119 @@
+import NewsletterForm from "@components/forms/newsletter-form";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockFetch = vi.fn();
+
+function jsonResponse(payload: unknown) {
+    return { json: () => Promise.resolve(payload) } as unknown as Response;
+}
+
+function renderForm() {
+    render(<NewsletterForm />);
+    return {
+        input: screen.getByLabelText("Newsletter") as HTMLInputElement,
+        submit: screen.getByRole("button", { name: "Subscribe" }),
+    };
+}
+
+describe("NewsletterForm", () => {
+    beforeEach(() => {
+        mockFetch.mockReset();
+        vi.stubGlobal("fetch", mockFetch);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("renders the email input and the Subscribe button", () => {
+        const { input, submit } = renderForm();
+
+        expect(input).toHaveAttribute("type", "email");
+        expect(input).toHaveAttribute("placeholder", "Your E-mail");
+        expect(submit).toHaveAttribute("type", "submit");
+    });
+
+    it("shows the required error and does not call fetch when submitted empty", async () => {
+        const { submit } = renderForm();
+
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Email is required")).toBeInTheDocument();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("shows the format error and does not call fetch for an invalid email", async () => {
+        const { input, submit } = renderForm();
+
+        // Passes the browser's native type="email" check (so the submit event fires)
+        // but fails validateEmail, which requires a dotted top-level domain.
+        fireEvent.change(input, { target: { value: "jody@example" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Invalid email format")).toBeInTheDocument();
+        expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("posts a valid email to /api/newsletter, then shows success and clears the input", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: true }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Thank you for subscribing!")).toBeInTheDocument();
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe("/api/newsletter");
+        expect(options.method).toBe("POST");
+        expect(JSON.parse(options.body)).toEqual({ newsletter_email: "jody@example.com" });
+        await waitFor(() => {
+            expect(input.value).toBe("");
+        });
+    });
+
+    it("shows the server error and no success message when the API rejects the email", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: false, error: "Already subscribed" }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Already subscribed")).toBeInTheDocument();
+        expect(screen.queryByText("Thank you for subscribing!")).not.toBeInTheDocument();
+    });
+
+    it("falls back to a generic error when the API fails without a message", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: false }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("OOPS Something went wrong")).toBeInTheDocument();
+    });
+
+    it("shows the thrown error message when fetch rejects", async () => {
+        mockFetch.mockRejectedValue(new Error("Network down"));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+
+        expect(await screen.findByText("Network down")).toBeInTheDocument();
+        expect(screen.queryByText("Thank you for subscribing!")).not.toBeInTheDocument();
+    });
+
+    it("clears the error message when the user types again", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ ok: false, error: "Already subscribed" }));
+        const { input, submit } = renderForm();
+
+        fireEvent.change(input, { target: { value: "jody@example.com" } });
+        fireEvent.click(submit);
+        expect(await screen.findByText("Already subscribed")).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "jody+new@example.com" } });
+
+        expect(screen.queryByText("Already subscribed")).not.toBeInTheDocument();
+    });
+});

--- a/src/components/forms/newsletter-form.tsx
+++ b/src/components/forms/newsletter-form.tsx
@@ -53,6 +53,13 @@ const NewsletterForm = forwardRef<HTMLFormElement, TProps>(({ className }, ref) 
         }
     };
 
+    const emailField = register("newsletter_email", {
+        validate: (value) => {
+            const result = validateEmail(value);
+            return result.isValid ? true : result.error || "";
+        },
+    });
+
     return (
         <form
             className={clsx("tw-relative tw-flex tw-max-w-[570px] tw-flex-wrap", className)}
@@ -71,15 +78,11 @@ const NewsletterForm = forwardRef<HTMLFormElement, TProps>(({ className }, ref) 
                     feedbackText={errors?.newsletter_email?.message}
                     state={hasKey(errors, "newsletter_email") ? "error" : "success"}
                     showState={!!hasKey(errors, "newsletter_email")}
-                    {...register("newsletter_email", {
-                        validate: (value) => {
-                            const result = validateEmail(value);
-                            return result.isValid ? true : result.error || "";
-                        },
-                    })}
-                    onChange={() => {
+                    {...emailField}
+                    onChange={(e) => {
                         setErrorMessage("");
                         setMessage("");
+                        emailField.onChange(e);
                     }}
                 />
             </div>


### PR DESCRIPTION
## Problem

Writing the newsletter form tests (#826) showed the form cannot submit on `master`. The component spreads `register("newsletter_email")` and then passes its own `onChange` after it, which replaces react-hook-form's registered handler, so the typed address never reaches form state and every submission fails validation with "Email is required".

## Solution

- `newsletter-form.tsx` hoists the registered field, spreads it, and has its `onChange` clear the feedback messages and then forward the event to react-hook-form.
- `__tests__/components/forms/newsletter-form.test.tsx` covers rendering, empty and invalid email validation without a request, the `/api/newsletter` POST body, the success message and cleared input, server error text, the fallback error, a thrown network error, and clearing the message on the next keystroke. Six of the eight tests fail against the unmodified component.

Closes #826

## Verification

```
npx vitest run __tests__/components/forms/newsletter-form.test.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test          # 72 files, 567 tests
```
