### PR TITLE
fix(styles): Replace the invalid tw-group-hover variant spelling

### DIFF
--- a/src/components/blog-card/blog-01.tsx
+++ b/src/components/blog-card/blog-01.tsx
@@ -19,7 +19,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
             {image?.src && (
                 <figure className="tw-relative tw-overflow-hidden">
                     <img
-                        className="tw-h-60 tw-w-full tw-object-cover tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110 sm:tw-h-80 xl:tw-h-[200px]"
+                        className="tw-h-60 tw-w-full tw-object-cover tw-transition-transform tw-duration-1500 group-hover:tw-scale-110 sm:tw-h-80 xl:tw-h-[200px]"
                         src={image.src}
                         alt={image?.alt || title}
                         width={image?.width || 270}

--- a/src/components/blog-card/blog-02.tsx
+++ b/src/components/blog-card/blog-02.tsx
@@ -19,7 +19,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
             {image?.src ? (
                 <figure className="tw-relative tw-col-span-full tw-row-span-full tw-overflow-hidden after:tw-absolute after:tw-inset-0 after:tw-bg-darkGradient after:tw-content-['']">
                     <img
-                        className="tw-h-[680px] tw-w-full tw-object-cover tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110"
+                        className="tw-h-[680px] tw-w-full tw-object-cover tw-transition-transform tw-duration-1500 group-hover:tw-scale-110"
                         src={image.src}
                         alt={image?.alt || title}
                         width={image?.width || 500}

--- a/src/components/blog-card/blog-03.tsx
+++ b/src/components/blog-card/blog-03.tsx
@@ -18,7 +18,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
                     {image?.src && (
                         <figure
                             role="none"
-                            className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110"
+                            className="tw-h-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110"
                         >
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"

--- a/src/components/blog-card/blog-04.tsx
+++ b/src/components/blog-card/blog-04.tsx
@@ -20,7 +20,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-relative tw-h-[240px] tw-overflow-hidden tw-rounded-t sm:tw-h-64 md:tw-h-[225px] lg:tw-h-[185px] xl:tw-h-[250px]">
                     {image?.src && (
-                        <div className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110">
+                        <div className="tw-h-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110">
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"
                                 src={image.src}

--- a/src/components/blog-card/blog-05.tsx
+++ b/src/components/blog-card/blog-05.tsx
@@ -27,7 +27,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-group tw-relative tw-max-h-[300px] tw-overflow-hidden tw-rounded md:tw-max-h-[400px]">
                     {image?.src && (
-                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110">
+                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110">
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"
                                 src={image.src}

--- a/src/components/blog-card/blog-06.tsx
+++ b/src/components/blog-card/blog-06.tsx
@@ -24,7 +24,7 @@ const BlogCard = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-group tw-relative tw-max-h-[340px] tw-min-h-[320px] tw-overflow-hidden tw-rounded md:tw-w-[calc(50%_-_45px)]">
                     {image?.src && (
-                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110">
+                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110">
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"
                                 src={image.src}

--- a/src/components/course-card/course-01.tsx
+++ b/src/components/course-card/course-01.tsx
@@ -14,7 +14,7 @@ const CourseCard = forwardRef<HTMLDivElement, TProps>(
         return (
             <div
                 className={clsx(
-                    "group tw-h-full tw-overflow-hidden tw-rounded-2xl tw-border tw-border-gray-200/50 tw-bg-white tw-transition-all tw-duration-500 hover:-tw-translate-y-2 hover:tw-bg-white hover:tw-shadow-2xl hover:tw-shadow-primary/10",
+                    "tw-group tw-h-full tw-overflow-hidden tw-rounded-2xl tw-border tw-border-gray-200/50 tw-bg-white tw-transition-all tw-duration-500 hover:-tw-translate-y-2 hover:tw-bg-white hover:tw-shadow-2xl hover:tw-shadow-primary/10",
                     className
                 )}
                 ref={ref}
@@ -27,7 +27,7 @@ const CourseCard = forwardRef<HTMLDivElement, TProps>(
                             width={thumbnail?.width || 370}
                             height={thumbnail?.height || 229}
                             loading={thumbnail?.loading || "lazy"}
-                            className="tw-group-hover:tw-scale-110 tw-w-full tw-transition-transform tw-duration-1000 tw-ease-out"
+                            className="group-hover:tw-scale-110 tw-w-full tw-transition-transform tw-duration-1000 tw-ease-out"
                         />
                     )}
 

--- a/src/components/course-card/course-04.tsx
+++ b/src/components/course-card/course-04.tsx
@@ -22,7 +22,7 @@ const CourseCard02 = forwardRef<HTMLDivElement, TProps>(
                 <figure className="tw-relative tw-overflow-hidden">
                     {thumbnail?.src && (
                         <img
-                            className="tw-w-full tw-rounded-t tw-transition-transform tw-duration-1000 tw-ease-out tw-group-hover:tw-scale-110"
+                            className="tw-w-full tw-rounded-t tw-transition-transform tw-duration-1000 tw-ease-out group-hover:tw-scale-110"
                             src={thumbnail.src}
                             alt={thumbnail?.alt || "Course"}
                             width={thumbnail?.width || 370}

--- a/src/components/event-card/event-01.tsx
+++ b/src/components/event-card/event-01.tsx
@@ -21,7 +21,7 @@ const Event01 = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-relative tw-h-[230px] tw-overflow-hidden max-w-full">
                     {thumbnail?.src && (
-                        <figure className="tw-group-hover:tw-scale-110 tw-h-full tw-transition-transform tw-duration-1500">
+                        <figure className="group-hover:tw-scale-110 tw-h-full tw-transition-transform tw-duration-1500">
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"
                                 src={thumbnail.src}

--- a/src/components/media-card/index.tsx
+++ b/src/components/media-card/index.tsx
@@ -19,7 +19,7 @@ const MediaCard = forwardRef<HTMLDivElement, TProps>(
             {image?.src && (
                 <figure className="tw-relative tw-overflow-hidden">
                     <img
-                        className="tw-h-52 tw-w-full tw-object-cover tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-105"
+                        className="tw-h-52 tw-w-full tw-object-cover tw-transition-transform tw-duration-1500 group-hover:tw-scale-105"
                         src={image.src}
                         alt={image?.alt || title}
                         width={image?.width || 300}

--- a/src/components/team-card/index.tsx
+++ b/src/components/team-card/index.tsx
@@ -17,7 +17,7 @@ const TeamCard = forwardRef<HTMLDivElement, TProps>(
                     {image?.src ? (
                         <div className="tw-relative">
                             <img
-                                className="tw-h-[430px] tw-w-[350px] tw-object-cover tw-grayscale tw-transition-all tw-duration-1000 tw-ease-out tw-group-hover:tw-scale-110 tw-group-hover:tw-grayscale-0"
+                                className="tw-h-[430px] tw-w-[350px] tw-object-cover tw-grayscale tw-transition-all tw-duration-1000 tw-ease-out group-hover:tw-scale-110 group-hover:tw-grayscale-0"
                                 src={image.src}
                                 alt={image?.alt || name}
                                 width={image?.width || 350}

--- a/src/components/ui/video-with-poster/video-01.tsx
+++ b/src/components/ui/video-with-poster/video-01.tsx
@@ -18,7 +18,7 @@ const Video01 = ({ poster, video, className }: TProps) => {
         >
             {poster?.src && (
                 <img
-                    className="tw-w-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110"
+                    className="tw-w-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110"
                     src={poster.src}
                     alt={poster?.alt || "video poster"}
                     width={poster?.width || 970}

--- a/src/components/ui/video-with-poster/video-02.tsx
+++ b/src/components/ui/video-with-poster/video-02.tsx
@@ -20,7 +20,7 @@ const Video02 = forwardRef<HTMLDivElement, TProps>(({ poster, video, className }
         >
             {poster?.src && (
                 <img
-                    className="tw-w-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110"
+                    className="tw-w-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110"
                     src={poster.src}
                     alt={poster?.alt || "video poster"}
                     width={poster?.width || 1170}

--- a/src/components/url-preview-card/index.tsx
+++ b/src/components/url-preview-card/index.tsx
@@ -145,7 +145,7 @@ export default function URLPreviewCard({ url, className = "" }: URLPreviewCardPr
                     src={displayImage}
                     alt={metadata.title || "Preview image"}
                     fill={true}
-                    className="tw-object-cover tw-group-hover:tw-scale-105 tw-transition-transform tw-duration-300"
+                    className="tw-object-cover group-hover:tw-scale-105 tw-transition-transform tw-duration-300"
                     unoptimized={true}
                 />
             </div>

--- a/src/components/zoom-card/index.tsx
+++ b/src/components/zoom-card/index.tsx
@@ -25,7 +25,7 @@ const ZoomCard = forwardRef<HTMLDivElement, TProps>(
             >
                 <div className="tw-relative tw-h-[230px] tw-overflow-hidden tw-rounded-t max-w-full">
                     {thumbnail?.src && (
-                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 tw-group-hover:tw-scale-110">
+                        <figure className="tw-h-full tw-transition-transform tw-duration-1500 group-hover:tw-scale-110">
                             <img
                                 className="tw-h-full tw-w-full tw-object-cover"
                                 src={thumbnail.src}


### PR DESCRIPTION
## Problem

`tailwind.config.js` sets `prefix: "tw-"`, which applies to utilities, not variants. Fifteen components spelled the hover-zoom as `tw-group-hover:tw-scale-110`, which Tailwind never generates, so those card image zooms were dead CSS. The working form, `group-hover:tw-*`, is already used 37 times elsewhere and in the config safelist.

## Solution

Rename the variant token in the 15 files (blog, course, event, media, team, zoom and URL-preview cards, and the two video-with-poster components). Only the variant spelling changes. `course-01` also named its wrapper `group` instead of `tw-group`, which is equally inert under the prefix, so that one word is corrected too. `grep -rn "tw-group-hover:" src` now returns nothing.

## Verification

```
npx vitest run __tests__/components/blog-card.test.tsx __tests__/components/decorative-icons.test.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test
npm run build
```
