### PR TITLE
fix(utils): Parse date-only strings as local dates in getStartOfDay

### DIFF
--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -1,5 +1,20 @@
 import { formatDate, getStartOfDay, isDatePast } from "../date";
 
+// Force a zone west of UTC so a date-only string read as UTC midnight lands on the previous day.
+const originalTz = process.env.TZ;
+
+beforeAll(() => {
+    process.env.TZ = "America/Los_Angeles";
+});
+
+afterAll(() => {
+    if (originalTz === undefined) {
+        delete process.env.TZ;
+    } else {
+        process.env.TZ = originalTz;
+    }
+});
+
 describe("date utilities", () => {
     it("should format date correctly", () => {
         const date = new Date("2024-01-26T10:30:00");
@@ -14,5 +29,13 @@ describe("date utilities", () => {
     it("should get start of day", () => {
         const d = new Date("2024-01-01T15:30:00");
         expect(getStartOfDay(d).getHours()).toBe(0);
+    });
+
+    it("should read a date-only string as local midnight", () => {
+        expect(getStartOfDay("2026-09-09").getTime()).toBe(new Date(2026, 8, 9).getTime());
+    });
+
+    it("should read a date-time string without an offset as local time", () => {
+        expect(getStartOfDay("2026-09-09T15:30:00").getTime()).toBe(new Date(2026, 8, 9).getTime());
     });
 });

--- a/src/utils/__tests__/methods.test.ts
+++ b/src/utils/__tests__/methods.test.ts
@@ -1,4 +1,5 @@
 import {
+    eventFilter,
     flatDeep,
     getFocusableElements,
     hasKey,
@@ -9,6 +10,7 @@ import {
     toCapitalize,
     unslugify,
 } from "../methods";
+import type { IEvent } from "../types";
 
 describe("methods utilities", () => {
     describe("slugify", () => {
@@ -125,6 +127,49 @@ describe("methods utilities", () => {
 
             nextFocus([el1, el2]);
             expect(el1.focus).toHaveBeenCalled();
+        });
+    });
+
+    describe("eventFilter", () => {
+        const originalTz = process.env.TZ;
+        const event = (startDate: string) => ({ start_date: startDate }) as IEvent;
+        const yesterday = event("2026-09-08");
+        const today = event("2026-09-09");
+        const tomorrow = event("2026-09-10");
+        const events = [yesterday, today, tomorrow];
+
+        beforeAll(() => {
+            // West of UTC, so "YYYY-MM-DD" read as UTC midnight would land on the previous day.
+            process.env.TZ = "America/Los_Angeles";
+            vi.useFakeTimers();
+            vi.setSystemTime(new Date(2026, 8, 9, 12, 0, 0));
+        });
+
+        afterAll(() => {
+            vi.useRealTimers();
+            if (originalTz === undefined) {
+                delete process.env.TZ;
+            } else {
+                process.env.TZ = originalTz;
+            }
+        });
+
+        it("should return today's event for the happening filter", () => {
+            const setFilteredEvents = vi.fn();
+            eventFilter("happening", events, setFilteredEvents);
+            expect(setFilteredEvents).toHaveBeenCalledWith([today]);
+        });
+
+        it("should return tomorrow's event for the upcoming filter", () => {
+            const setFilteredEvents = vi.fn();
+            eventFilter("upcoming", events, setFilteredEvents);
+            expect(setFilteredEvents).toHaveBeenCalledWith([tomorrow]);
+        });
+
+        it("should return yesterday's event for the expired filter", () => {
+            const setFilteredEvents = vi.fn();
+            eventFilter("expired", events, setFilteredEvents);
+            expect(setFilteredEvents).toHaveBeenCalledWith([yesterday]);
         });
     });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,4 +1,4 @@
-import { format, isPast } from "date-fns";
+import { format, isPast, parseISO } from "date-fns";
 
 /**
  * Format date to readable string
@@ -21,7 +21,9 @@ export function isDatePast(date: Date | string): boolean {
  * Get start of day
  */
 export function getStartOfDay(date: Date | string = new Date()): Date {
-    const dateObj = typeof date === "string" ? new Date(date) : date;
+    // parseISO reads "YYYY-MM-DD" as local midnight; `new Date` reads it as UTC midnight,
+    // which is the previous day anywhere west of UTC.
+    const dateObj = typeof date === "string" ? parseISO(date) : date;
     const newDate = new Date(dateObj);
     newDate.setHours(0, 0, 0, 0);
     return newDate;


### PR DESCRIPTION
## Problem

`getStartOfDay` in `src/utils/date.ts` parsed string input with `new Date()`. For date-only strings such as the `start_date` values in `src/data/events`, that is UTC midnight, which is the previous evening anywhere west of UTC. The `/events` filter (`eventFilter` in `src/utils/methods.ts`) therefore put an event dated today under "expired" and tomorrow's under "happening" for US visitors.

## Solution

`getStartOfDay` now parses strings with `parseISO` from date-fns, which reads date-only strings as local dates; `Date` input is unchanged. Tests force `America/Los_Angeles` so the case fails on the old code regardless of where CI runs, and cover `eventFilter`'s happening, upcoming, and expired buckets around a fixed system time.

`formatDate` and `isDatePast` still use `new Date()` for strings and are left for a follow-up.

## Verification

```
npx vitest run src/utils/__tests__/date.test.ts src/utils/__tests__/methods.test.ts
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test
```
