### PR TITLE
fix(apply): Show errors outside the success card and fix hints

### DIFF
--- a/__tests__/components/forms/apply-form.test.tsx
+++ b/__tests__/components/forms/apply-form.test.tsx
@@ -1,5 +1,6 @@
 import ApplyForm from "@components/forms/apply-form";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { githubRegex, linkedinRegex } from "@utils/formValidations";
 import axios from "axios";
 
 vi.mock("axios");
@@ -76,8 +77,9 @@ const STEP_FIELDS: Array<Array<[keyof Values, RegExp]>> = [
 ];
 
 const LINKEDIN_ERROR =
-    "Please enter a valid LinkedIn profile URL (e.g., linkedin.com/in/your-name)";
-const GITHUB_ERROR = "Please enter a valid GitHub profile URL (e.g., github.com/your-username)";
+    "Please enter a valid LinkedIn profile URL (e.g., https://linkedin.com/in/your-name)";
+const GITHUB_ERROR =
+    "Please enter a valid GitHub profile URL (e.g., https://github.com/your-username)";
 const SUCCESS_MESSAGE = "Thank you for your application! We'll review it and get back to you soon.";
 const FAILURE_MESSAGE = "Failed to submit the form. Please try again later.";
 
@@ -228,7 +230,20 @@ describe("ApplyForm", () => {
         expect(screen.queryByText(GITHUB_ERROR)).not.toBeInTheDocument();
     });
 
-    it("posts the parsed application, celebrates, and stops the rain after 5s", async () => {
+    it("the profile URL hints are accepted by their own validators", async () => {
+        render(<ApplyForm />);
+        await walkToStep(5);
+
+        const linkedInHint = screen
+            .getByLabelText(/linkedin profile url/i)
+            .getAttribute("placeholder");
+        const githubHint = screen.getByLabelText(/github profile url/i).getAttribute("placeholder");
+
+        expect(linkedinRegex.test(linkedInHint ?? "")).toBe(true);
+        expect(githubRegex.test(githubHint ?? "")).toBe(true);
+    });
+
+    it("posts the parsed application, celebrates, and keeps the confirmation after the rain", async () => {
         mockPost.mockResolvedValue({ data: {} } as never);
         render(<ApplyForm />);
 
@@ -254,6 +269,8 @@ describe("ApplyForm", () => {
         });
 
         expect(screen.queryByTestId("emoji-rain")).not.toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Application Submitted!" })).toBeInTheDocument();
+        expect(screen.getByText(SUCCESS_MESSAGE)).toBeInTheDocument();
     });
 
     it("sends null for a postal code that is not numeric", async () => {
@@ -270,7 +287,7 @@ describe("ApplyForm", () => {
         });
     });
 
-    it("shows the failure message without emoji rain when the request fails", async () => {
+    it("shows the failure message in the form and keeps it usable when the request fails", async () => {
         mockPost.mockRejectedValue(new Error("network down"));
         render(<ApplyForm />);
 
@@ -279,6 +296,17 @@ describe("ApplyForm", () => {
         expect(await screen.findByText(FAILURE_MESSAGE)).toBeInTheDocument();
         expect(screen.queryByTestId("emoji-rain")).not.toBeInTheDocument();
         expect(screen.queryByText(SUCCESS_MESSAGE)).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("heading", { name: "Application Submitted!" })
+        ).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Submit Application" })).toBeInTheDocument();
+
+        // Retrying clears the error while the new request is pending.
+        mockPost.mockReturnValue(new Promise(() => {}) as never);
+        clickSubmit();
+
+        expect(await screen.findByRole("button", { name: "Submitting..." })).toBeDisabled();
+        expect(screen.queryByText(FAILURE_MESSAGE)).not.toBeInTheDocument();
     });
 
     it("shows a pending submit state until the request resolves", async () => {

--- a/src/components/forms/apply-form.tsx
+++ b/src/components/forms/apply-form.tsx
@@ -1,6 +1,7 @@
 import EmojiRain from "@components/EmojiRain";
 import Button from "@ui/button";
 import Checkbox from "@ui/form-elements/checkbox";
+import Feedback from "@ui/form-elements/feedback";
 import Input from "@ui/form-elements/input";
 import TextArea from "@ui/form-elements/textarea";
 import { githubRegex, linkedinRegex } from "@utils/formValidations";
@@ -60,6 +61,7 @@ const STEPS = [
 const ApplyForm = () => {
     const [currentStep, setCurrentStep] = useState(1);
     const [message, setMessage] = useState("");
+    const [submitError, setSubmitError] = useState("");
     const [showEmojiRain, setShowEmojiRain] = useState<boolean>(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -67,7 +69,6 @@ const ApplyForm = () => {
         register,
         handleSubmit,
         formState: { errors },
-        reset,
         watch,
         trigger,
     } = useForm<IFormValues>({
@@ -101,6 +102,7 @@ const ApplyForm = () => {
     const onSubmit: SubmitHandler<IFormValues> = async (data) => {
         try {
             setIsSubmitting(true);
+            setSubmitError("");
 
             // Transform data to match API expectations
             const parseOrNull = (value: string) => {
@@ -120,11 +122,9 @@ const ApplyForm = () => {
 
             setTimeout(() => {
                 setShowEmojiRain(false);
-                setCurrentStep(1);
-                reset();
             }, 5000);
         } catch (_error) {
-            setMessage("Failed to submit the form. Please try again later.");
+            setSubmitError("Failed to submit the form. Please try again later.");
         } finally {
             setIsSubmitting(false);
         }
@@ -547,7 +547,7 @@ const ApplyForm = () => {
                                         <div className="tw-space-y-6">
                                             <div className="tw-rounded-lg tw-bg-gray-50 tw-p-4">
                                                 <Checkbox
-                                                    label="Have you previously attended any coding bootcamps or tech education programs?"
+                                                    label="Have you previously attended any coding or tech education programs?"
                                                     id="hasAttendedPreviousCourse"
                                                     {...register("hasAttendedPreviousCourse")}
                                                 />
@@ -611,7 +611,7 @@ const ApplyForm = () => {
                                                     </label>
                                                     <TextArea
                                                         id="otherCourses"
-                                                        placeholder="e.g., Web Development Bootcamp, Data Science Course, etc."
+                                                        placeholder="e.g., Web Development Course, Data Science Course, etc."
                                                         bg="light"
                                                         feedbackText={errors?.otherCourses?.message}
                                                         state={
@@ -654,7 +654,7 @@ const ApplyForm = () => {
                                                 </label>
                                                 <Input
                                                     id="linkedInAccountName"
-                                                    placeholder="linkedin.com/in/your-name"
+                                                    placeholder="https://linkedin.com/in/your-name"
                                                     bg="light"
                                                     feedbackText={
                                                         errors?.linkedInAccountName?.message
@@ -673,7 +673,7 @@ const ApplyForm = () => {
                                                         pattern: {
                                                             value: linkedinRegex,
                                                             message:
-                                                                "Please enter a valid LinkedIn profile URL (e.g., linkedin.com/in/your-name)",
+                                                                "Please enter a valid LinkedIn profile URL (e.g., https://linkedin.com/in/your-name)",
                                                         },
                                                     })}
                                                 />
@@ -687,7 +687,7 @@ const ApplyForm = () => {
                                                 </label>
                                                 <Input
                                                     id="githubAccountName"
-                                                    placeholder="github.com/your-username"
+                                                    placeholder="https://github.com/your-username"
                                                     bg="light"
                                                     feedbackText={
                                                         errors?.githubAccountName?.message
@@ -705,7 +705,7 @@ const ApplyForm = () => {
                                                         pattern: {
                                                             value: githubRegex,
                                                             message:
-                                                                "Please enter a valid GitHub profile URL (e.g., github.com/your-username)",
+                                                                "Please enter a valid GitHub profile URL (e.g., https://github.com/your-username)",
                                                         },
                                                     })}
                                                 />
@@ -824,6 +824,7 @@ const ApplyForm = () => {
                                     </Button>
                                 )}
                             </div>
+                            {submitError && <Feedback state="error">{submitError}</Feedback>}
                         </div>
                     </form>
                 </>


### PR DESCRIPTION
## Problem

Writing the apply form tests (#1304) surfaced four defects in `src/components/forms/apply-form.tsx`:

- After a successful submit, a 5-second timer reset the form and step underneath the confirmation card but never cleared the message, so the reset had no visible effect.
- A failed submit set the same `message` state as success, so "Failed to submit the form" rendered inside the "Application Submitted!" celebration card.
- The LinkedIn and GitHub placeholders and error hints omitted the scheme, so typing exactly what the hint showed was rejected by `linkedinRegex` and `githubRegex`.
- Step 4 copy said "coding bootcamps".

## Solution

- The confirmation now persists; the timer only ends the emoji rain. #539 asked forms to confirm submissions so people stop double-submitting, and a card that stays put does that.
- Failures go to a separate error state rendered with `Feedback` next to the submit button, cleared on the next attempt, and the form stays usable.
- Hints now read `https://linkedin.com/in/your-name` and `https://github.com/your-username`, and a test asserts the hints pass their own validators.
- Step 4 asks about "coding or tech education programs".

Tests updated for the intended behavior: the confirmation persists after the timer, the failure path keeps the form and never shows the celebration heading.

Refs #824

## Verification

```
npx vitest run __tests__/components/forms/apply-form.test.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test
```
