### PR TITLE
fix(utils): Read date-only strings as local dates when formatting

### DIFF
--- a/src/utils/__tests__/date.test.ts
+++ b/src/utils/__tests__/date.test.ts
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { formatDate, getStartOfDay, isDatePast } from "../date";
 
 // Force a zone west of UTC so a date-only string read as UTC midnight lands on the previous day.
@@ -21,9 +22,36 @@ describe("date utilities", () => {
         expect(formatDate(date)).toBe("Jan 26, 2024");
     });
 
+    it("should format a date-only string as that local day", () => {
+        expect(formatDate("2023-01-26")).toBe("Jan 26, 2023");
+    });
+
+    it("should format a space-separated date-time string as local time", () => {
+        expect(formatDate("2023-01-26 19:00:00", "h:mm a")).toBe("7:00 PM");
+    });
+
+    it("should format a full ISO string with an offset the same as before", () => {
+        const iso = "2024-12-01T20:30:00.000Z";
+        expect(formatDate(iso, "MMMM d, yyyy")).toBe(format(new Date(iso), "MMMM d, yyyy"));
+    });
+
+    it("should still format a non-ISO string", () => {
+        expect(formatDate("Jan 26, 2024")).toBe("Jan 26, 2024");
+    });
+
     it("should detect past date", () => {
         const past = new Date(Date.now() - 1000);
         expect(isDatePast(past)).toBe(true);
+    });
+
+    it("should treat a past date-only string as past", () => {
+        expect(isDatePast("2023-01-26")).toBe(true);
+    });
+
+    it("should not treat tomorrow's date-only string as past", () => {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+        expect(isDatePast(format(tomorrow, "yyyy-MM-dd"))).toBe(false);
     });
 
     it("should get start of day", () => {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,30 +1,33 @@
-import { format, isPast, parseISO } from "date-fns";
+import { format, isPast, isValid, parseISO } from "date-fns";
+
+// parseISO reads "YYYY-MM-DD" as local midnight; `new Date` reads it as UTC midnight,
+// which is the previous day anywhere west of UTC. Non-ISO strings fall back to `new Date`.
+function toDate(input: Date | string): Date {
+    if (typeof input !== "string") return input;
+    const parsed = parseISO(input);
+    return isValid(parsed) ? parsed : new Date(input);
+}
 
 /**
  * Format date to readable string
  * @example formatDate(new Date()) // "Jan 26, 2024"
  */
 export function formatDate(date: Date | string, pattern = "MMM dd, yyyy"): string {
-    const dateObj = typeof date === "string" ? new Date(date) : date;
-    return format(dateObj, pattern);
+    return format(toDate(date), pattern);
 }
 
 /**
  * Check if date is in the past
  */
 export function isDatePast(date: Date | string): boolean {
-    const dateObj = typeof date === "string" ? new Date(date) : date;
-    return isPast(dateObj);
+    return isPast(toDate(date));
 }
 
 /**
  * Get start of day
  */
 export function getStartOfDay(date: Date | string = new Date()): Date {
-    // parseISO reads "YYYY-MM-DD" as local midnight; `new Date` reads it as UTC midnight,
-    // which is the previous day anywhere west of UTC.
-    const dateObj = typeof date === "string" ? parseISO(date) : date;
-    const newDate = new Date(dateObj);
+    const newDate = new Date(toDate(date));
     newDate.setHours(0, 0, 0, 0);
     return newDate;
 }


### PR DESCRIPTION
## Problem

`formatDate` and `isDatePast` in `src/utils/date.ts` still parsed strings with `new Date`. For date-only strings, which is the shape of every event `start_date` and media `date`, that is UTC midnight, so a US visitor's browser renders the previous day and can disagree with the server-rendered HTML. #1308 fixed the same problem for `getStartOfDay` only.

## Solution

One small helper parses strings with `parseISO` and falls back to `new Date` when `parseISO` cannot read the input, so lenient legacy strings keep working. All three utilities use it. Tests run under a forced `America/Los_Angeles` zone and cover date-only, space-separated date-time (used by the event details summary), ISO with `Z`, and a lenient fallback.

## Verification

```
npx vitest run src/utils/__tests__/date.test.ts src/utils/__tests__/methods.test.ts __tests__/lib/event.test.ts
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test
```
