### PR TITLE
fix(apply): Clear the submit error when stepping back

### DIFF
--- a/__tests__/components/forms/apply-form.test.tsx
+++ b/__tests__/components/forms/apply-form.test.tsx
@@ -309,6 +309,19 @@ describe("ApplyForm", () => {
         expect(screen.queryByText(FAILURE_MESSAGE)).not.toBeInTheDocument();
     });
 
+    it("clears the failure message when stepping back after a failed submit", async () => {
+        mockPost.mockRejectedValue(new Error("network down"));
+        render(<ApplyForm />);
+
+        await submitValidApplication();
+        expect(await screen.findByText(FAILURE_MESSAGE)).toBeInTheDocument();
+
+        clickPrevious();
+
+        expect(screen.queryByText(FAILURE_MESSAGE)).not.toBeInTheDocument();
+        expectStep(4);
+    });
+
     it("shows a pending submit state until the request resolves", async () => {
         let resolvePost = (_value: unknown) => {};
         mockPost.mockReturnValue(

--- a/src/components/forms/apply-form.tsx
+++ b/src/components/forms/apply-form.tsx
@@ -89,6 +89,7 @@ const ApplyForm = () => {
 
     const prevStep = () => {
         if (currentStep > 1) {
+            setSubmitError("");
             setCurrentStep(currentStep - 1);
         }
     };


### PR DESCRIPTION
## Problem

After a failed submit on the last apply-form step, the error stayed on screen when the user clicked Previous, so steps 1 through 4 showed "Failed to submit the form" under the Next button (noted in #1309 review).

## Solution

`prevStep` clears the submit error. One line, plus a test that fails a submit, steps back, and asserts the error is gone.

## Verification

```
npx vitest run __tests__/components/forms/apply-form.test.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test
```
