### PR TITLE
fix(team): Take the founder designation from team data

### DIFF
--- a/__tests__/pages/press-kit.test.tsx
+++ b/__tests__/pages/press-kit.test.tsx
@@ -51,6 +51,13 @@ describe("Press kit page", () => {
         expect(screen.getByAltText(/Jerome Hardaway/)).toBeInTheDocument();
     });
 
+    it("shows the founder designation from the team data", () => {
+        render(<PressKitPage />);
+        const designation = screen.getByText(founder.designation);
+        expect(designation).toBeInTheDocument();
+        expect(designation).toHaveTextContent(/Founder/);
+    });
+
     it("labels every swatch with its hex value", () => {
         render(<PressKitPage />);
         for (const hex of ["#091f40", "#c5203e", "#EEEDE9", "#1A1823", "#FDB330"]) {

--- a/src/data/team-members.json
+++ b/src/data/team-members.json
@@ -10,7 +10,7 @@
             "width": 350,
             "height": 430
         },
-        "designation": "Executive Director",
+        "designation": "Founder & Executive Director",
         "bio": "Jerome Hardaway is an Air Force veteran and the Founder and Executive Director of Vets Who Code, a nonprofit that trains U.S. military veterans and military spouses in coding to launch careers in technology. Since 2014, he has led the organization in preparing over 500 veterans for roles in the tech industry, generating more than $20 million in combined economic impact. A self-taught software engineer, he built Vets Who Code as a fully remote, open-source program focused on modern web development and AI-powered tools, blending hands-on projects with a structured, mission-driven approach to learning. Jerome is passionate about empowering veterans and military spouses to succeed in tech careers and is dedicated to fostering a supportive community for lifelong learning and growth.",
         "socials": [
             {

--- a/src/pages/press-kit.tsx
+++ b/src/pages/press-kit.tsx
@@ -249,7 +249,7 @@ const PressKitPage: PageWithLayout = () => {
                                 <span className="tw-text-red">Hardaway.</span>
                             </SharpHeadline>
                             <MonoMeta tone="accent" size="md">
-                                Founder &amp; Executive Director
+                                {founder?.designation}
                             </MonoMeta>
                             <p className="tw-mt-4 tw-font-heading tw-text-[20px] tw-font-bold tw-text-navy [line-height:1.35]">
                                 Jerome Hardaway is an Air Force veteran, a self-taught software


### PR DESCRIPTION
## Problem

`team-members.json` lists Jerome as "Executive Director", so `/team` and `/team/jerome-hardaway` said one thing while the press kit hard-coded "Founder & Executive Director" (#1297).

## Solution

The JSON now carries "Founder & Executive Director" and the press kit renders the designation from the team data instead of a literal, so the three pages cannot drift again. The press-kit test asserts the rendered designation equals the value in the data.

## Verification

```
npx vitest run __tests__/pages/press-kit.test.tsx __tests__/pages/team.tests.tsx
npm run typecheck
npm run lint      # 23 pre-existing errors on master, none new (#1221)
npm test
```
