### PR TITLE
fix(a11y): Gold section-title accents on navy and hide watermark

### DIFF
--- a/src/components/section-title/index.tsx
+++ b/src/components/section-title/index.tsx
@@ -75,7 +75,8 @@ const SectionTitle = forwardRef<HTMLDivElement, TProps>(
                     content={title}
                     as="h2"
                     className={clsx(
-                        "title tw-m-0 child:tw-font-normal child:tw-text-primary [font-family:var(--font-headline)] tw-font-extrabold",
+                        "title tw-m-0 child:tw-font-normal tw-font-extrabold [font-family:var(--font-headline)]",
+                        color === "C" ? "child:tw-text-gold" : "child:tw-text-primary",
                         color === "A" && "tw-text-secondary",
                         color === "C" && "tw-text-white",
                         titleSize === "large" &&

--- a/src/containers/gradation/index.tsx
+++ b/src/containers/gradation/index.tsx
@@ -41,7 +41,10 @@ const GradationArea = ({ data: { section_title, items } }: TProps) => {
                         viewport={{ once: true, amount: 0.4 }}
                         variants={scrollUpVariants}
                     >
-                        <mark className="tw-absolute tw-right-0 tw-top-1/2 -tw-z-1 -tw-translate-y-1/2 tw-bg-transparent tw-p-5 tw-text-[120px] tw-font-black tw-leading-[0.8] tw-text-gray-100">
+                        <mark
+                            aria-hidden="true"
+                            className="tw-absolute tw-right-0 tw-top-1/2 -tw-z-1 -tw-translate-y-1/2 tw-bg-transparent tw-p-5 tw-text-[120px] tw-font-black tw-leading-[0.8] tw-text-gray-100"
+                        >
                             {items?.length.toString() || "0"}
                         </mark>
                         Steps


### PR DESCRIPTION
## Summary

Two small contrast/semantics fixes that the production-build scan turned up, both still live on `master`.

## What changed

- **`section-title`** — the accent word in a dark section title ("Upcoming **Events**", "Featured in **Media**") was brand red on navy at **2.84:1**, below the **3:1** that large text requires. The `color="C"` variant now uses gold; light sections keep red, which passes there at 4.91:1.
- **`gradation`** — the 120px numeral behind the section is pure decoration, but screen readers announced it as content. Marked `aria-hidden`.

## Verification

Measured in a production build (`npm run build` + `npm run start`), not the dev server — this work already showed that dev and production CSS differ:

| Element | Before | After |
|---|---|---|
| Home "Upcoming **Events**" accent | 2.84:1 | **9.10:1** gold `#FDB330` on navy `#091f40` |
| Home "Featured in **Media**" accent | 2.84:1 | **9.10:1** |
| `/mentor` watermark numeral | announced as content | `aria-hidden="true"` |

- [x] `npm run typecheck`: passes
- [x] `npm test`: 73 files, 582 tests pass
- [x] `npx biome check` on both files: clean (it also cleared a pre-existing class-sort warning on the edited line)

## Scope note

`color="C"` is also used by the curriculum graph, accelerator, newsletter and hero code snippet. Those titles either have no accent span or sit on navy/imagery, so gold is correct or a no-op there; only the two home sections change visibly.