### PR TITLE
fix(a11y): Give scrollable regions keyboard access

### DIFF
--- a/src/components/ui/hero-code-snippet/index.tsx
+++ b/src/components/ui/hero-code-snippet/index.tsx
@@ -246,6 +246,8 @@ const HeroCodeSnippet = () => {
                         >
                             <pre
                                 className="tw-overflow-x-auto tw-px-6 tw-py-7 md:tw-px-9 md:tw-py-9"
+                                // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 — a scrollable region must be reachable by keyboard (axe scrollable-region-focusable)
+                                tabIndex={0}
                                 style={{ ...codeBody, color: IDENT }}
                             >
                                 <code>

--- a/src/containers/career-guide-detail/systems-table.tsx
+++ b/src/containers/career-guide-detail/systems-table.tsx
@@ -33,7 +33,13 @@ const SystemsTable = ({ systems }: Props) => {
                     lede="Military systems you operated and their civilian equivalents for your resume."
                 />
 
-                <div className="tw-overflow-x-auto tw-border-t tw-border-cream/10">
+                <div
+                    className="tw-overflow-x-auto tw-border-t tw-border-cream/10"
+                    role="region"
+                    aria-label="Military systems"
+                    // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 — a scrollable region must be reachable by keyboard (axe scrollable-region-focusable)
+                    tabIndex={0}
+                >
                     <table className="tw-w-full">
                         <thead>
                             <tr className="tw-bg-secondary">

--- a/src/pages/programs.tsx
+++ b/src/pages/programs.tsx
@@ -255,7 +255,13 @@ const ProgramsPage: PageWithLayout = ({ data }) => {
                         subLabel="Compare Before You Commit"
                         className="tw-mb-7"
                     />
-                    <div className="tw-overflow-x-auto">
+                    <div
+                        className="tw-overflow-x-auto"
+                        role="region"
+                        aria-label="Program comparison"
+                        // biome-ignore lint/a11y/noNoninteractiveTabindex: WCAG 2.1.1 — a scrollable region must be reachable by keyboard (axe scrollable-region-focusable)
+                        tabIndex={0}
+                    >
                         <table className="tw-w-full tw-min-w-[780px] tw-border tw-border-gray-100 tw-bg-white tw-text-left">
                             <thead>
                                 <tr className="tw-bg-navy">


### PR DESCRIPTION
## Summary

A mobile-viewport axe pass (390×844) over 22 public pages turned up three horizontally scrollable regions that keyboard users can't reach — they can't read anything past the fold without a mouse or touch. That's **WCAG 2.1.1 Keyboard** (axe `scrollable-region-focusable`), and it only appears at mobile widths, which is why desktop scans never caught it.

## What changed

| Page | Region |
|---|---|
| `/` | the hero terminal's `<pre>` code block |
| `/programs` | the program comparison table wrapper |
| `/career-guides/[mos]` | the military systems table wrapper |

Each container is now focusable. The two table wrappers also get `role="region"` and a label, so the focus stop announces what it is instead of being an unexplained tab stop.

`tabIndex` on a `<div>`/`<pre>` trips Biome's `noNoninteractiveTabindex`, which doesn't model scroll containers — the rule's own docs point at interactive roles, and a scrollable region has none. Each one carries a scoped suppression naming the criterion rather than a blanket disable.

## Verification

Same audit, before and after, against a production build at 390×844:

| Page | Before | After |
|---|---|---|
| `/` | 1 × `scrollable-region-focusable` | 0 |
| `/programs` | 1 × `scrollable-region-focusable` | 0 |
| `/career-guides/25b` | 1 × `scrollable-region-focusable` | 0 |

- [x] `npm run typecheck`: passes
- [x] `npm test`: 73 files, 582 tests pass
- [x] `npm run build`: succeeds
- [x] `npx biome check` on all three files: clean

The other 19 pages in that mobile pass were already clean, so this closes out the mobile findings.